### PR TITLE
Add basic support for escaping into ion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: rust
+rust:
+  - nightly
 sudo: false
 notifications:
   email: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,12 @@
 name = "ion-shell"
 description = "The Ion Shell"
 repository = "https://github.com/redox-os/ion"
-version = "0.0.3"
+version = "0.0.4"
 license-file = "LICENSE"
 readme = "README.md"
 authors = [
   "Jeremy Soller <jackpot51@gmail.com>",
   "Michael Gattozzi <mgattozzi@gmail.com>",
-  "Łukasz Niemier <lukasz@niemier.pl>"
+  "Łukasz Niemier <lukasz@niemier.pl>",
+  "Skyler Berg <skylertheberg@gmail.com>"
 ]

--- a/src/input_editor.rs
+++ b/src/input_editor.rs
@@ -1,0 +1,10 @@
+use std::string::String;
+use std::io::{stdin};
+
+pub fn readln() -> Option<String> {
+    let mut buffer = String::new();
+    match stdin().read_line(&mut buffer) {
+        Ok(_) => Some(buffer),
+        Err(_) => None
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use std::thread;
 
 use self::to_num::ToNum;
 use self::input_editor::readln;
-use self::tokenizer::tokenize;
+use self::tokenizer::{Token, tokenize};
 
 pub mod to_num;
 pub mod input_editor;
@@ -401,25 +401,28 @@ fn on_command(command_string: &str,
         return;
     }
 
-    let mut tokens: Vec<String> = tokenize(command_string);
+    let mut tokens: Vec<Token> = tokenize(command_string);
 
     // replace variables
     // TODO This copies all tokens and is inefficient
-    let mut args: Vec<_> = tokens.iter().map(|arg| {
-        if arg.starts_with('$') {
-            let mut result = String::new();
-            let name = arg[1..arg.len()].to_string();
-            for variable in variables.iter() {
-                if variable.name == name {
-                    result = variable.value.clone();
-                    break;
+    let mut args: Vec<String> = vec![];
+    for token in tokens.drain(..) {
+        if let Token::Word(arg) = token {
+            if arg.starts_with('$') {
+                let mut result = String::new();
+                let name = arg[1..arg.len()].to_string();
+                for variable in variables.iter() {
+                    if variable.name == name {
+                        result = variable.value.clone();
+                        break;
+                    }
                 }
+                args.push(result);
+            } else {
+                args.push(arg.clone());
             }
-            result
-        } else {
-            arg.clone()
         }
-    }).collect();
+    }
 
     // Execute commands
     if let Some(cmd) = args.get(0) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,24 +3,16 @@ use std::string::String;
 use std::vec::Vec;
 use std::boxed::Box;
 use std::fs::{self, File};
-use std::io::{stdout, stdin, Read, Write};
+use std::io::{stdout, Read, Write};
 use std::env;
 use std::process;
 use std::thread;
 
 use self::to_num::ToNum;
+use self::input_editor::readln;
 
 pub mod to_num;
-
-macro_rules! readln {
-    () => ({
-        let mut buffer = String::new();
-        match stdin().read_line(&mut buffer) {
-            Ok(_) => Some(buffer),
-            Err(_) => None
-        }
-    });
-}
+pub mod input_editor;
 
 /// Structure which represents a Terminal's command.
 /// This command structure contains a name, and the code which run the functionnality associated to this one, with zero, one or several argument(s).
@@ -262,7 +254,7 @@ impl Command {
                         let arg = arg_original.trim();
                         print!("{}=", arg);
                         stdout().flush();
-                        if let Some(value_original) = readln!() {
+                        if let Some(value_original) = readln() {
                             let value = value_original.trim();
                             set_var(variables, arg, value);
                         }
@@ -599,7 +591,7 @@ fn real_main() {
         print!("ion:{}# ", cwd);
         stdout().flush();
 
-        if let Some(command_original) = readln!() {
+        if let Some(command_original) = readln() {
             let command = command_original.trim();
             if command == "exit" {
                 break;

--- a/src/main.rs
+++ b/src/main.rs
@@ -553,6 +553,27 @@ pub fn set_var(variables: &mut Vec<Variable>, name: &str, value: &str) {
     }
 }
 
+fn print_prompt(modes: &Vec<Mode>) {
+        for mode in modes.iter().rev() {
+            if mode.value {
+                print!("+ ");
+            } else {
+                print!("- ");
+            }
+        }
+
+        let cwd = match env::current_dir() {
+            Ok(path) => match path.to_str() {
+                Some(path_str) => path_str.to_string(),
+                None => "?".to_string()
+            },
+            Err(_) => "?".to_string()
+        };
+
+        print!("ion:{}# ", cwd);
+        stdout().flush();
+}
+
 fn real_main() {
     let commands = Command::vec();
     let mut variables: Vec<Variable> = vec![];
@@ -572,24 +593,8 @@ fn real_main() {
     }
 
     loop {
-        for mode in modes.iter().rev() {
-            if mode.value {
-                print!("+ ");
-            } else {
-                print!("- ");
-            }
-        }
 
-        let cwd = match env::current_dir() {
-            Ok(path) => match path.to_str() {
-                Some(path_str) => path_str.to_string(),
-                None => "?".to_string()
-            },
-            Err(_) => "?".to_string()
-        };
-
-        print!("ion:{}# ", cwd);
-        stdout().flush();
+        print_prompt(&modes);
 
         if let Some(command_original) = readln() {
             let command = command_original.trim();

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,12 +1,19 @@
-pub fn tokenize(input: &str) -> Vec<String> {
-    let mut result: Vec<String> = vec![];
+#[derive(PartialEq)]
+#[derive(Debug)]
+pub enum Token {
+    Word(String),
+    End,
+}
+
+pub fn tokenize(input: &str) -> Vec<Token> {
+    let mut result: Vec<Token> = vec![];
     for raw_word in input.split(' ') {
         let word = raw_word.trim();
         if word.starts_with("#") {
             break;
         }
         if !word.is_empty() {
-            result.push(word.to_string());
+            result.push(Token::Word(word.to_string()));
         }
     }
     result
@@ -19,40 +26,37 @@ mod tests {
 
     #[test]
     fn tokenize_empty_string() {
-        let expected: Vec<String> = vec![];
-        assert_eq!(tokenize(""), expected);
+        assert!(tokenize("").is_empty());
     }
 
     #[test]
     fn tokenize_single_word() {
-        let expected: Vec<String> = vec!["word".to_string()];
-        assert_eq!(tokenize("word"), expected);
+        let expected: Vec<Token> = vec![Token::Word("word".to_string())];
+        assert_eq!(expected, tokenize("word"));
     }
 
     #[test]
     fn tokenize_whitespace() {
-        let expected: Vec<String> = vec![];
-        assert_eq!(tokenize(" \t   "), expected);
+        assert!(tokenize(" \t   ").is_empty());
     }
 
     #[test]
     fn tokenize_multiple_words() {
-        let expected: Vec<String> = vec![
-            "one".to_string(),
-            "two".to_string(),
-            "three".to_string()];
-        assert_eq!(tokenize("one two three"), expected);
+        let expected: Vec<Token> = vec![
+            Token::Word("one".to_string()),
+            Token::Word("two".to_string()),
+            Token::Word("three".to_string())];
+        assert_eq!(expected, tokenize("one two three"));
     }
 
     #[test]
     fn tokenize_comment() {
-        let expected: Vec<String> = vec![];
-        assert_eq!(tokenize("# some text"), expected);
+        assert!(tokenize("# some text").is_empty());
     }
 
     #[test]
     fn tokenize_end_of_line_comment() {
-        let expected: Vec<String> = vec!["word".to_string()];
-        assert_eq!(tokenize("word # more stuff"), expected);
+        let expected: Vec<Token> = vec![Token::Word("word".to_string())];
+        assert_eq!(expected, tokenize("word # more stuff"));
     }
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,0 +1,58 @@
+pub fn tokenize(input: &str) -> Vec<String> {
+    let mut result: Vec<String> = vec![];
+    for raw_word in input.split(' ') {
+        let word = raw_word.trim();
+        if word.starts_with("#") {
+            break;
+        }
+        if !word.is_empty() {
+            result.push(word.to_string());
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn tokenize_empty_string() {
+        let expected: Vec<String> = vec![];
+        assert_eq!(tokenize(""), expected);
+    }
+
+    #[test]
+    fn tokenize_single_word() {
+        let expected: Vec<String> = vec!["word".to_string()];
+        assert_eq!(tokenize("word"), expected);
+    }
+
+    #[test]
+    fn tokenize_whitespace() {
+        let expected: Vec<String> = vec![];
+        assert_eq!(tokenize(" \t   "), expected);
+    }
+
+    #[test]
+    fn tokenize_multiple_words() {
+        let expected: Vec<String> = vec![
+            "one".to_string(),
+            "two".to_string(),
+            "three".to_string()];
+        assert_eq!(tokenize("one two three"), expected);
+    }
+
+    #[test]
+    fn tokenize_comment() {
+        let expected: Vec<String> = vec![];
+        assert_eq!(tokenize("# some text"), expected);
+    }
+
+    #[test]
+    fn tokenize_end_of_line_comment() {
+        let expected: Vec<String> = vec!["word".to_string()];
+        assert_eq!(tokenize("word # more stuff"), expected);
+    }
+}


### PR DESCRIPTION
The only functional difference in this change should be that the shell now supports basic quoting. There was a lot of refactoring along the way. Look through the commit log for more details on what I did. Each commit should have an informative message with more details beyond the first line.