### PR TITLE
Remove empty commands `if`, `fi`, and `else`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -102,15 +102,6 @@ impl Command {
                             }),
                         });
 
-        commands.insert("else".to_string(),
-                        Command {
-                            name: "else",
-                            help: "",
-                            main: Box::new(|_: &Vec<String>,
-                                            _: &mut BTreeMap<String, String>,
-                                            _: &mut Vec<Mode>| {}),
-                        });
-
         commands.insert("exec".to_string(),
                         Command {
                             name: "exec",
@@ -160,15 +151,6 @@ impl Command {
                                             _: &mut Vec<Mode>| {}),
                         });
 
-        commands.insert("fi".to_string(),
-                        Command {
-                            name: "fi",
-                            help: "",
-                            main: Box::new(|_: &Vec<String>,
-                                            _: &mut BTreeMap<String, String>,
-                                            _: &mut Vec<Mode>| {}),
-                        });
-
         commands.insert("free".to_string(),
                         Command {
                             name: "free",
@@ -187,15 +169,6 @@ impl Command {
                                     Err(err) => println!("Failed to open file: memory: {}", err),
                                 }
                             }),
-                        });
-
-        commands.insert("if".to_string(),
-                        Command {
-                            name: "if",
-                            help: "",
-                            main: Box::new(|_: &Vec<String>,
-                                            _: &mut BTreeMap<String, String>,
-                                            _: &mut Vec<Mode>| {}),
                         });
 
         commands.insert("ls".to_string(),


### PR DESCRIPTION
These commands did nothing and could never be accessed because of how
on_command is written. The only reason I could think to include them
would be to have them show up in help. However, they did not have any
help strings and I don't think the grammar for the language should be a
built into the command that lists the available builtins.