### PR TITLE
Lots of cleanup and refactor

### DIFF
--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -1,9 +1,8 @@
-use std::collections::BTreeMap;
 use std::io::{stdout, Write};
 use std::env;
 use std::process;
 
-use super::set_var;
+use super::{set_var, Variables};
 use super::input_editor::readln;
 
 pub fn cd(args: &[String]) {
@@ -17,7 +16,7 @@ pub fn cd(args: &[String]) {
     }
 }
 
-pub fn read(args: &[String], variables: &mut BTreeMap<String, String>) {
+pub fn read(args: &[String], variables: &mut Variables) {
     let mut out = stdout();
     for i in 1..args.len() {
         if let Some(arg_original) = args.get(i) {
@@ -34,7 +33,7 @@ pub fn read(args: &[String], variables: &mut BTreeMap<String, String>) {
     }
 }
 
-pub fn run(args: &[String], variables: &mut BTreeMap<String, String>) {
+pub fn run(args: &[String], variables: &mut Variables) {
     let path = "/apps/shell/main.bin";
 
     let mut command = process::Command::new(path);

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::io::{stdout, Write};
 use std::env;
 use std::process;
@@ -17,7 +17,7 @@ pub fn cd(args: &[String]) {
     }
 }
 
-pub fn read(args: &[String], variables: &mut HashMap<String, String>) {
+pub fn read(args: &[String], variables: &mut BTreeMap<String, String>) {
     let mut out = stdout();
     for i in 1..args.len() {
         if let Some(arg_original) = args.get(i) {
@@ -34,7 +34,7 @@ pub fn read(args: &[String], variables: &mut HashMap<String, String>) {
     }
 }
 
-pub fn run(args: &[String], variables: &mut HashMap<String, String>) {
+pub fn run(args: &[String], variables: &mut BTreeMap<String, String>) {
     let path = "/apps/shell/main.bin";
 
     let mut command = process::Command::new(path);

--- a/src/expansion.rs
+++ b/src/expansion.rs
@@ -1,7 +1,7 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use super::tokenizer::Token;
 
-pub fn expand_tokens(tokens: &mut Vec<Token>, variables: &HashMap<String, String>) -> Vec<Token> {
+pub fn expand_tokens(tokens: &mut Vec<Token>, variables: &BTreeMap<String, String>) -> Vec<Token> {
     let mut expanded_tokens: Vec<Token> = vec![];
     for token in tokens.drain(..) {
         expanded_tokens.push(match token {

--- a/src/expansion.rs
+++ b/src/expansion.rs
@@ -1,7 +1,7 @@
-use std::collections::BTreeMap;
 use super::tokenizer::Token;
+use super::Variables;
 
-pub fn expand_tokens(tokens: &mut Vec<Token>, variables: &BTreeMap<String, String>) -> Vec<Token> {
+pub fn expand_tokens(tokens: &mut Vec<Token>, variables: &Variables) -> Vec<Token> {
     let mut expanded_tokens: Vec<Token> = vec![];
     for token in tokens.drain(..) {
         expanded_tokens.push(match token {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,10 +22,12 @@ pub mod tokenizer;
 pub mod parser;
 pub mod expansion;
 
+pub type Variables = BTreeMap<String, String>;
+
 /// This struct will contain all of the data structures related to this
 /// instance of the shell.
 pub struct Shell {
-    pub variables: BTreeMap<String, String>,
+    pub variables: Variables,
     pub modes: Vec<Mode>,
     pub directory_stack: DirectoryStack,
 }
@@ -275,7 +277,7 @@ fn on_command(command_string: &str, commands: &HashMap<&str, Command>, shell: &m
 }
 
 
-pub fn set_var(variables: &mut BTreeMap<String, String>, name: &str, value: &str) {
+pub fn set_var(variables: &mut Variables, name: &str, value: &str) {
     if name.is_empty() {
         return;
     }
@@ -312,7 +314,7 @@ fn print_prompt(modes: &Vec<Mode>) {
     }
 }
 
-fn run_external_commmand(args: Vec<String>, variables: &mut BTreeMap<String, String>) {
+fn run_external_commmand(args: Vec<String>, variables: &mut Variables) {
     if let Some(path) = args.get(0) {
         let mut command = process::Command::new(path);
         for i in 1..args.len() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 #![feature(box_syntax)]
 #![feature(convert)]
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs::File;
 use std::io::{stdout, Read, Write};
 use std::env;
@@ -25,16 +25,16 @@ pub mod expansion;
 /// This struct will contain all of the data structures related to this
 /// instance of the shell.
 pub struct Shell {
-    pub variables: HashMap<String, String>,
+    pub variables: BTreeMap<String, String>,
     pub modes: Vec<Mode>,
     pub directory_stack: DirectoryStack,
 }
 
 impl Shell {
     /// Panics if DirectoryStack construction fails
-    pub fn new() -> Shell {
+    pub fn new() -> Self {
         Shell {
-            variables: HashMap::new(),
+            variables: BTreeMap::new(),
             modes: vec![],
             directory_stack: DirectoryStack::new().expect(""),
         }
@@ -173,9 +173,7 @@ pub struct Mode {
 fn on_command(command_string: &str, commands: &HashMap<&str, Command>, shell: &mut Shell) {
     // Show variables
     if command_string == "$" {
-        let mut pairs: Vec<_> = shell.variables.iter().collect();
-        pairs.sort();
-        for (key, value) in pairs {
+        for (key, value) in shell.variables.iter() {
             println!("{}={}", key, value);
         }
         return;
@@ -277,7 +275,7 @@ fn on_command(command_string: &str, commands: &HashMap<&str, Command>, shell: &m
 }
 
 
-pub fn set_var(variables: &mut HashMap<String, String>, name: &str, value: &str) {
+pub fn set_var(variables: &mut BTreeMap<String, String>, name: &str, value: &str) {
     if name.is_empty() {
         return;
     }
@@ -314,7 +312,7 @@ fn print_prompt(modes: &Vec<Mode>) {
     }
 }
 
-fn run_external_commmand(args: Vec<String>, variables: &mut HashMap<String, String>) {
+fn run_external_commmand(args: Vec<String>, variables: &mut BTreeMap<String, String>) {
     if let Some(path) = args.get(0) {
         let mut command = process::Command::new(path);
         for i in 1..args.len() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,25 +1,17 @@
 use super::tokenizer::Token;
 
-#[derive(Debug)]
-#[derive(PartialEq)]
-#[derive(Clone)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct Job {
     pub command: String,
     pub args: Vec<String>,
 }
 
-impl Job {
-    pub fn new() -> Job {
-        Job {
-            command: String::new(),
-            args: vec![],
-        }
-    }
-}
+//impl Job {
+//}
 
 pub fn parse(tokens: &mut Vec<Token>) -> Vec<Job> {
     let mut jobs: Vec<Job> = vec![];
-    let mut job = Job::new();
+    let mut job = Job::default();
     for token in tokens.drain(..) {
         match token {
             Token::Word(word) => {
@@ -31,8 +23,8 @@ pub fn parse(tokens: &mut Vec<Token>) -> Vec<Job> {
             }
             Token::End => {
                 if !job.command.is_empty() {
-                    jobs.push(job.clone());
-                    job = Job::new();
+                    jobs.push(job);
+                    job = Job::default();
                 }
             }
         }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,10 +1,10 @@
-#[derive(PartialEq)]
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Token {
     Word(String),
     End,
 }
 
+#[derive(Debug, PartialEq)]
 enum TokenizerState {
     Default,
     DoubleQuoted,


### PR DESCRIPTION
* Remove an unneeded clone
* Cleanup the way `#[derive]` is used on a few types
* Derive `Default` for `parser::Job` and use `Job::default()` instead of `Job::new()` which did the same thing
* Use BTreeMap for shell variables to have it automatically be sorted for reading
* Remove an unneeded binding in `on_command()`
* Use a type alias for `BTreeMap<String, String>` everywhere for easier maintenance 