### PR TITLE
Add partially working for loop

### DIFF
--- a/src/flow_control.rs
+++ b/src/flow_control.rs
@@ -22,8 +22,7 @@ pub struct FlowControl {
     pub modes: Vec<Mode>,
     pub collecting_block: bool,
     pub current_block: CodeBlock,
-    pub current_statement: Statement,
-    //pub prompt: &'static str,  // Custom prompt while collecting code block
+    pub current_statement: Statement, /* pub prompt: &'static str,  // Custom prompt while collecting code block */
 }
 
 impl FlowControl {
@@ -106,16 +105,14 @@ impl FlowControl {
                     println!("For loops must have 'in' as the second argument");
                     return;
                 }
-            }
-            else {
+            } else {
                 println!("For loops must have 'in' as the second argument");
                 return;
             }
             let values: Vec<String> = args.map(|value| value.as_ref().to_string()).collect();
             self.current_statement = Statement::For(variable, values);
             self.collecting_block = true;
-        }
-        else {
+        } else {
             println!("For loops must have a variable name as the first argument");
             return;
         }

--- a/src/flow_control.rs
+++ b/src/flow_control.rs
@@ -1,7 +1,16 @@
 use super::to_num::ToNum;
+use super::peg::Job;
 
 pub fn is_flow_control_command(command: &str) -> bool {
     command == "end" || command == "if" || command == "else"
+}
+
+pub enum Statement {
+    Job(Job),
+}
+
+pub struct CodeBlock {
+    pub jobs: Vec<Job>,
 }
 
 pub struct Mode {
@@ -10,11 +19,18 @@ pub struct Mode {
 
 pub struct FlowControl {
     pub modes: Vec<Mode>,
+    pub collecting_block: bool,
+    pub current_block: CodeBlock,
+    //pub prompt: &'static str,  // Custom prompt while collecting code block
 }
 
 impl FlowControl {
     pub fn new() -> FlowControl {
-        FlowControl { modes: vec![] }
+        FlowControl {
+            modes: vec![],
+            collecting_block: false,
+            current_block: CodeBlock { jobs: vec![] },
+        }
     }
 
     pub fn skipping(&self) -> bool {
@@ -26,6 +42,7 @@ impl FlowControl {
     {
         let mut args = args.into_iter(); // TODO why does the compiler want this to be mutable?
         let mut value = false;
+        // TODO cleanup as_ref calls
         if let Some(left) = args.nth(1) {
             if let Some(cmp) = args.nth(0) {
                 if let Some(right) = args.nth(0) {
@@ -74,5 +91,11 @@ impl FlowControl {
         } else {
             println!("Syntax error: fi found with no previous if");
         }
+    }
+
+    pub fn for_<I: IntoIterator>(&mut self, _: I)
+        where I::Item: AsRef<str>
+    {
+        self.collecting_block = true;
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use std::process;
 
 use self::directory_stack::DirectoryStack;
 use self::input_editor::readln;
-use self::peg::{parse,Job};
+use self::peg::{parse, Job};
 use self::variables::Variables;
 use self::history::History;
 use self::flow_control::{FlowControl, is_flow_control_command, Statement};
@@ -92,7 +92,11 @@ impl Shell {
                 // TODO move this logic into "end" command
                 if job.command == "end" {
                     self.flow_control.collecting_block = false;
-                    let block_jobs: Vec<Job> = self.flow_control.current_block.jobs.drain(..).collect();
+                    let block_jobs: Vec<Job> = self.flow_control
+                                                   .current_block
+                                                   .jobs
+                                                   .drain(..)
+                                                   .collect();
                     let mut variable = String::new();
                     let mut values: Vec<String> = vec![];
                     if let Statement::For(ref var, ref vals) = self.flow_control.current_statement {
@@ -106,13 +110,10 @@ impl Shell {
                         }
                     }
                     self.flow_control.current_statement = Statement::Default;
-                }
-                else {
+                } else {
                     self.flow_control.current_block.jobs.push(job);
                 }
-            }
-
-            else {
+            } else {
                 if self.flow_control.skipping() && !is_flow_control_command(&job.command) {
                     continue;
                 }

--- a/src/peg.rs
+++ b/src/peg.rs
@@ -15,6 +15,14 @@ impl Job {
             args: args,
         }
     }
+
+    pub fn from_vec_string(args: Vec<String>) -> Self {
+        let command = args[0].clone();
+        Job {
+            command: command,
+            args: args,
+        }
+    }
 }
 
 pub fn parse(code: &str) -> Vec<Job> {

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -57,15 +57,12 @@ impl Variables {
         }
     }
 
-    pub fn expand_variables(&self, jobs: &mut [Job]) {
+    pub fn expand_job(&self, job: &Job) -> Job {
         // TODO don't copy everything
-        for mut job in &mut jobs[..] {
-            job.command = self.expand_string(&job.command).to_string();
-            job.args = job.args
-                          .iter()
-                          .map(|original: &String| self.expand_string(&original).to_string())
-                          .collect();
-        }
+        Job::from_vec_string(job.args
+                                .iter()
+                                .map(|original: &String| self.expand_string(&original).to_string())
+                                .collect())
     }
 
     #[inline]


### PR DESCRIPTION
You can do some fun stuff with this for loop like
```
for i in 1 2 3
echo $i
end
```
However, this implementation is a little messy and does not play nice with other flow control commands. That means no nesting `if` or `for` inside a for loop. Obviously that will have to be fixed. I am merging now because I doubt I will be able to take it to the next level tonight.