### PR TITLE
Make builtin commands return exit statuses

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use super::status::SUCCESS;
 
 pub struct History {
     history: VecDeque<String>,
@@ -18,11 +19,12 @@ impl History {
         self.history.push_front(command);
     }
 
-    pub fn history<I: IntoIterator>(&self, _: I)
+    pub fn history<I: IntoIterator>(&self, _: I) -> i32
         where I::Item: AsRef<str>
     {
         for command in self.history.iter().rev() {
             println!("{}", command);
         }
+        SUCCESS
     }
 }

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,0 +1,4 @@
+pub const SUCCESS: i32 = 0;
+pub const FAILURE: i32 = -1;
+pub const NO_SUCH_COMMAND: i32 = 127;
+pub const TERMINATED: i32 = 143;

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -3,6 +3,7 @@ use std::io::{stdout, Write};
 
 use super::peg::Job;
 use super::input_editor::readln;
+use super::status::{SUCCESS, FAILURE};
 
 pub struct Variables {
     variables: BTreeMap<String, String>,
@@ -13,7 +14,7 @@ impl Variables {
         Variables { variables: BTreeMap::new() }
     }
 
-    pub fn read<I: IntoIterator>(&mut self, args: I)
+    pub fn read<I: IntoIterator>(&mut self, args: I) -> i32
         where I::Item: AsRef<str>
     {
         let mut out = stdout();
@@ -21,14 +22,16 @@ impl Variables {
             print!("{}=", arg.as_ref().trim());
             if let Err(message) = out.flush() {
                 println!("{}: Failed to flush stdout", message);
+                return FAILURE;
             }
             if let Some(value) = readln() {
                 self.set_var(arg.as_ref(), value.trim());
             }
         }
+        SUCCESS
     }
 
-    pub fn let_<I: IntoIterator>(&mut self, args: I)
+    pub fn let_<I: IntoIterator>(&mut self, args: I) -> i32
         where I::Item: AsRef<str>
     {
         let mut args = args.into_iter();
@@ -45,6 +48,7 @@ impl Variables {
                 }
             }
         }
+        SUCCESS
     }
 
     pub fn set_var(&mut self, name: &str, value: &str) {


### PR DESCRIPTION
There are a couple other return status related changes in this patch.
Barring the TODOs added to the code, exit statuses should behave about
how you would expect now.