### PR TITLE
Less Obnoxious Error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -154,8 +154,8 @@ impl Shell {
             let mut command = Shell::build_command(&job);
             match command.spawn() {
                 Ok(mut child) => Some(Shell::wait_and_get_status(&mut child, &job.command)),
-                Err(err) => {
-                    println!("{}: Failed to execute: {}", job.command, err);
+                Err(_) => {
+                    println!("ion: command not found: {}", job.command);
                     Some(NO_SUCH_COMMAND)
                 }
             }


### PR DESCRIPTION
Instead of the current verbose error message when an invalid command is entered, what if we were to print a traditional error message like so:

ion:/home/mmstick/Programming/Rust/ion# HELP
ion: command not found: HELP