### PR TITLE
Exit With Previous Status

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -2,15 +2,17 @@ use std::collections::VecDeque;
 use super::status::SUCCESS;
 
 pub struct History {
-    history: VecDeque<String>,
-    max_size: usize,
+    history:             VecDeque<String>,
+    max_size:            usize,
+    pub previous_status: i32,
 }
 
 impl History {
     pub fn new() -> History {
         History {
-            history: VecDeque::new(),
-            max_size: 1000, // TODO don't hardcode this size, make it configurable
+            history:         VecDeque::new(),
+            max_size:        1000, // TODO don't hardcode this size, make it configurable
+            previous_status: SUCCESS,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -442,4 +442,7 @@ fn main() {
         }
         shell.print_prompt()
     }
+
+    // Exit with the previous command's exit status.
+    process::exit(shell.history.previous_status);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,6 +136,7 @@ impl Shell {
         };
         if let Some(code) = exit_status {
             self.variables.set_var("?", &code.to_string());
+            self.history.previous_status = code;
         }
     }
 
@@ -281,14 +282,13 @@ impl Command {
                         Command {
                             name: "exit",
                             help: "To exit the curent session",
-                            main: box |args: &[String], _: &mut Shell| -> i32 {
+                            main: box |args: &[String], shell: &mut Shell| -> i32 {
                                 if let Some(status) = args.get(1) {
                                     if let Ok(status) = status.parse::<i32>() {
                                         process::exit(status);
                                     }
                                 }
-                                // TODO should use exit status of previously run command, not 0
-                                process::exit(0);
+                                process::exit(shell.history.previous_status);
                             },
                         });
 


### PR DESCRIPTION
This will allow Ion to exit with the last command's exit status. The previous command's exit status is stored inside the `History` structure attached to the `Shell`.