### PR TITLE
Ion Variables Patch

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -1,26 +1,54 @@
 use std::collections::VecDeque;
+use std::fs::OpenOptions;
+use std::io::{Write};
+use variables::Variables;
 use super::status::SUCCESS;
 
 pub struct History {
     history:             VecDeque<String>,
-    max_size:            usize,
     pub previous_status: i32,
 }
 
 impl History {
     pub fn new() -> History {
         History {
-            history:         VecDeque::new(),
-            max_size:        1000, // TODO don't hardcode this size, make it configurable
+            history:         VecDeque::with_capacity(1000),
             previous_status: SUCCESS,
         }
     }
 
-    pub fn add(&mut self, command: String) {
-        self.history.truncate(self.max_size - 1); // Make room for new item
+    /// Add a command to the history buffer and remove the oldest commands when the max history
+    /// size has been met.
+    pub fn add(&mut self, command: String, variables: &Variables) {
+        // Write this command to the history file if writing to the file is enabled.
+        // TODO: Prevent evaluated files from writing to the log.
+        if variables.expand_string("$HISTORY_FILE_ENABLED") == "1" {
+            let history_file = variables.expand_string("$HISTORY_FILE");
+            History::write_to_disk(history_file, &command);
+        }
+
+        self.history.truncate(History::get_size(variables) - 1); // Make room for new item
         self.history.push_front(command);
     }
 
+    /// If writing to the disk is enabled, this function will be used for logging history to the
+    /// designated history file. If the history file does not exist, it will be created.
+    fn write_to_disk(history_file: &str, command: &str) {
+        match OpenOptions::new().append(true).create(true).open(history_file) {
+            Ok(mut file) => {
+                if let Err(message) = file.write_all(command.as_bytes()) {
+                    println!("{}", message);
+                }
+                if let Err(message) = file.write(b"\n") {
+                    println!("{}", message);
+                }
+                // TODO: Limit the size of the history file.
+            },
+            Err(message) => println!("{}", message)
+        }
+    }
+
+    /// Print the entire history list currently buffered to stdout directly.
     pub fn history<I: IntoIterator>(&self, _: I) -> i32
         where I::Item: AsRef<str>
     {
@@ -28,5 +56,15 @@ impl History {
             println!("{}", command);
         }
         SUCCESS
+    }
+
+    /// This function will take a map of variables as input and attempt to parse the value of the
+    /// history size variable. If it succeeds, it will return the value of that variable, else it
+    /// will return a default value of 1000.
+    fn get_size(variables: &Variables) -> usize {
+        match variables.expand_string("$HISTORY_SIZE").parse::<usize>() {
+            Ok(size) => size,
+            _        => 1000,
+        }
     }
 }

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 use std::fs::OpenOptions;
-use std::io::{Write};
+use std::io::Write;
 use variables::Variables;
 use super::status::SUCCESS;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,6 @@ use self::flow_control::{FlowControl, is_flow_control_command, Statement};
 use self::status::{SUCCESS, NO_SUCH_COMMAND, TERMINATED};
 use self::function::Function;
 
-
 pub mod directory_stack;
 pub mod to_num;
 pub mod input_editor;

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ use self::flow_control::{FlowControl, is_flow_control_command, Statement};
 use self::status::{SUCCESS, NO_SUCH_COMMAND, TERMINATED};
 use self::function::Function;
 
+
 pub mod directory_stack;
 pub mod to_num;
 pub mod input_editor;
@@ -30,7 +31,6 @@ pub mod history;
 pub mod flow_control;
 pub mod status;
 pub mod function;
-
 
 /// This struct will contain all of the data structures related to this
 /// instance of the shell.
@@ -45,12 +45,69 @@ pub struct Shell {
 impl Shell {
     /// Panics if DirectoryStack construction fails
     pub fn new() -> Self {
-        Shell {
+        let mut new_shell = Shell {
             variables: Variables::new(),
             flow_control: FlowControl::new(),
             directory_stack: DirectoryStack::new().expect(""),
             history: History::new(),
             functions: HashMap::new()
+        };
+        new_shell.initialize_default_variables();
+        new_shell.evaluate_init_file();
+        return new_shell;
+    }
+
+    /// This function will initialize the default variables used by the shell. This function will
+    /// be called before evaluating the init
+    fn initialize_default_variables(&mut self) {
+        self.variables.set_var("DIRECTORY_STACK_SIZE", "1000");
+        self.variables.set_var("HISTORY_SIZE", "1000");
+        self.variables.set_var("HISTORY_FILE_ENABLED", "1");
+
+        {   // Initialize the HISTORY_FILE variable
+            let mut history_path = std::env::home_dir().unwrap();
+            history_path.push(".ion_history");
+            self.variables.set_var("HISTORY_FILE", history_path.to_str().unwrap());
+        }
+
+        {   // Initialize the CWD (Current Working Directory) variable
+            match std::env::current_dir() {
+                Ok(path) => self.variables.set_var("CWD", path.to_str().unwrap()),
+                Err(_)   => self.variables.set_var("CWD", "?")
+            }
+        }
+    }
+
+    /// This functional will update variables that need to be kept consistent with each iteration
+    /// of the prompt. In example, the CWD variable needs to be updated to reflect changes to the
+    /// the current working directory.
+    fn update_variables(&mut self) {
+        {   // Update the CWD (Current Working Directory) variable
+            match std::env::current_dir() {
+                Ok(path) => self.variables.set_var("CWD", path.to_str().unwrap()),
+                Err(_)   => self.variables.set_var("CWD", "?")
+            }
+        }
+    }
+
+    /// Evaluates the source init file in the user's home directory. If the file does not exist,
+    /// the file will be created.
+    fn evaluate_init_file(&mut self) {
+        let commands = &Command::map();
+        let mut source_file = std::env::home_dir().unwrap(); // Obtain home directory
+        source_file.push(".ionrc");                          // Location of ion init file
+
+        if let Ok(mut file) = File::open(source_file.clone()) {
+            let mut command_list = String::new();
+            if let Err(message) = file.read_to_string(&mut command_list) {
+                println!("{}: Failed to read {:?}", message, source_file.clone());
+            } else {
+                self.on_command(&command_list, commands);
+            }
+        } else {
+            if let Err(message) = File::create(source_file) {
+                println!("{}", message);
+            }
         }
     }
 
@@ -89,13 +146,11 @@ impl Shell {
     }
 
     fn print_default_prompt(&self) {
-        let cwd = env::current_dir().ok().map_or("?".to_string(),
-                                                 |ref p| p.to_str().unwrap_or("?").to_string());
-        print!("ion:{}# ", cwd);
+        print!("ion:{}# ", self.variables.expand_string("$CWD"));
     }
 
     fn on_command(&mut self, command_string: &str, commands: &HashMap<&str, Command>) {
-        self.history.add(command_string.to_string());
+        self.history.add(command_string.to_string(), &self.variables);
 
         let mut jobs = parse(command_string);
 
@@ -210,26 +265,6 @@ impl Shell {
         }
     }
 
-    /// Evaluates the source init file in the user's home directory. If the file does not exist,
-    /// the file will be created.
-    fn evaluate_init_file(&mut self, commands: &HashMap<&'static str, Command>) {
-        let mut source_file = std::env::home_dir().unwrap(); // Obtain home directory
-        source_file.push(".ionrc");                          // Location of ion init file
-
-        if let Ok(mut file) = File::open(source_file.clone()) {
-            let mut command_list = String::new();
-            if let Err(message) = file.read_to_string(&mut command_list) {
-                println!("{}: Failed to read {:?}", message, source_file.clone());
-            } else {
-                self.on_command(&command_list, commands);
-            }
-        } else {
-            if let Err(message) = File::create(source_file) {
-                println!("{}", message);
-            }
-        }
-    }
-
     /// Evaluates the given file and returns 'SUCCESS' if it succeeds.
     fn source_command(&mut self, arguments: &[String]) -> i32 {
         let commands = Command::map();
@@ -250,7 +285,7 @@ impl Shell {
                 }
             },
             None => {
-                self.evaluate_init_file(&commands);
+                self.evaluate_init_file();
                 return status::SUCCESS;
             },
         }
@@ -286,7 +321,7 @@ impl Command {
                             name: "cd",
                             help: "Change the current directory\n    cd <path>",
                             main: box |args: &[String], shell: &mut Shell| -> i32 {
-                                shell.directory_stack.cd(args)
+                                shell.directory_stack.cd(args, &shell.variables)
                             },
                         });
 
@@ -336,7 +371,7 @@ impl Command {
                             name: "pushd",
                             help: "Push a directory to the stack",
                             main: box |args: &[String], shell: &mut Shell| -> i32 {
-                                shell.directory_stack.pushd(args)
+                                shell.directory_stack.pushd(args, &shell.variables)
                             },
                         });
 
@@ -452,7 +487,6 @@ impl Command {
 fn main() {
     let commands = Command::map();
     let mut shell = Shell::new();
-    shell.evaluate_init_file(&commands);
 
     let mut dash_c = false;
     for arg in env::args().skip(1) {
@@ -473,7 +507,7 @@ fn main() {
                     Err(err) => println!("ion: failed to open {}: {}", arg, err)
                 }
             }
-            
+
             // Exit with the previous command's exit status.
             process::exit(shell.history.previous_status);
         }
@@ -485,7 +519,8 @@ fn main() {
         if !command.is_empty() {
             shell.on_command(command, &commands);
         }
-        shell.print_prompt()
+        shell.update_variables();
+        shell.print_prompt();
     }
 
     // Exit with the previous command's exit status.

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -73,12 +73,11 @@ impl Variables {
     }
 
     #[inline]
-    fn expand_string<'a>(&'a self, original: &'a str) -> &'a str {
+    pub fn expand_string<'a>(&'a self, original: &'a str) -> &'a str {
         if original.starts_with("$") {
-            if let Some(value) = self.variables.get(&original[1..]) {
-                &value
-            } else {
-                ""
+            match self.variables.get(&original[1..]) {
+                Some(value) => &value,
+                None        => ""
             }
         } else {
             original


### PR DESCRIPTION
Several changes were necessary to allow Ion to use variables for tuning the shell. The `History` structure, for example, no longer needs to have a `max_size` variable because this information is already stored as a variable in the shell. This patch adds a few system variables such as `CWD`, `HISTORY_FILE`, `HISTORY_FILE_ENABLED`, `HISTORY_SIZE`, and `DIRECTORY_STACK_SIZE`. It also adds the capability for history being logged to a history file, named `ion_history`. What's currently lacking from this implementation is limiting the size of the history log and not logging commands loaded from files in history.