### PR TITLE
Add piping from one process to another

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ion-shell"
 description = "The Ion Shell"
 repository = "https://github.com/redox-os/ion"
-version = "0.1.0"
+version = "0.1.1"
 license-file = "LICENSE"
 readme = "README.md"
 authors = [

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -22,6 +22,9 @@
 - `else` will invert the comparison block
 - `end` will end the comparison block
 
+### Piping
+- `echo foo | cat | xargs touch` will pipe the output from one process to another.
+
 ## Proposed Syntax
 
 A LR(k) grammar. This is a rough brainstorm and is somewhat out of sync with the examples:

--- a/src/flow_control.rs
+++ b/src/flow_control.rs
@@ -1,5 +1,5 @@
 use super::to_num::ToNum;
-use super::peg::Job;
+use super::peg::Pipeline;
 use super::status::{SUCCESS, FAILURE};
 
 pub fn is_flow_control_command(command: &str) -> bool {
@@ -15,7 +15,7 @@ pub enum Statement {
 }
 
 pub struct CodeBlock {
-    pub jobs: Vec<Job>,
+    pub pipelines: Vec<Pipeline>,
 }
 
 pub struct Mode {
@@ -34,7 +34,7 @@ impl FlowControl {
         FlowControl {
             modes: vec![],
             collecting_block: false,
-            current_block: CodeBlock { jobs: vec![] },
+            current_block: CodeBlock { pipelines: vec![] },
             current_statement: Statement::Default,
         }
     }

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,7 +1,7 @@
-use super::peg::Job;
+use super::peg::Pipeline;
 
 #[derive(Clone)]
 pub struct Function {
     pub name: String,
-    pub jobs: Vec<Job>,
+    pub pipelines: Vec<Pipeline>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,9 +162,9 @@ impl Shell {
                 // TODO move this logic into "end" command
                 if job.command == "end" {
                     self.flow_control.collecting_block = false;
-                    let block_jobs: Vec<Job> = self.flow_control
+                    let block_jobs: Vec<Pipeline> = self.flow_control
                                                    .current_block
-                                                   .jobs
+                                                   .pipelines
                                                    .drain(..)
                                                    .collect();
                     match self.flow_control.current_statement.clone() {
@@ -173,46 +173,49 @@ impl Shell {
                             let values = vals.clone();
                             for value in values {
                                 self.variables.set_var(&variable, &value);
-                                for job in block_jobs.iter() {
-                                    self.run_job(job, &pipeline, commands);
+                                for pipeline in block_jobs.iter() {
+                                    self.run_pipeline(&pipeline, commands);
                                 }
                             }
                         },
                         Statement::Function(ref name) => {
-                            self.functions.insert(name.clone(), Function { name: name.clone(), jobs: block_jobs.clone() });
+                            self.functions.insert(name.clone(), Function { name: name.clone(), pipelines: block_jobs.clone() });
                         },
                         _ => {}
                     }
                     self.flow_control.current_statement = Statement::Default;
                 } else {
-                    self.flow_control.current_block.jobs.push(job);
+                    self.flow_control.current_block.pipelines.push(pipeline);
                 }
             } else {
                 if self.flow_control.skipping() && !is_flow_control_command(&job.command) {
                     continue;
                 }
-                self.run_job(&job, &pipeline, commands);
+                self.run_pipeline(&pipeline, commands);
             }
         }
     }
 
-    fn run_job(&mut self, job: &Job, pipeline: &Pipeline, commands: &HashMap<&str, Command>) -> Option<i32> {
-        let mut job = self.variables.expand_job(job);
-        job.expand_globs();
+    fn run_pipeline(&mut self, pipeline: &Pipeline, commands: &HashMap<&str, Command>) -> Option<i32> {
+        let job = pipeline.jobs[0].clone();
+        let mut pipeline = self.variables.expand_pipeline(pipeline);
+        pipeline.expand_globs();
         let exit_status = if let Some(command) = commands.get(job.command.as_str()) {
             Some((*command.main)(job.args.as_slice(), self))
-        } else if self.functions.get(job.command.as_str()).is_some() { // Not really idiomatic but I don't know how to clone the value without borrowing self
+        } else if self.functions.get(job.command.as_str()).is_some() { 
+            // Not really idiomatic but I don't know how to clone the value without borrowing self
             let function = self.functions.get(job.command.as_str()).unwrap().clone();
             let mut return_value = None;
-            for function_job in function.jobs.iter() {
-                return_value = self.run_job(&function_job, pipeline, commands)
+            for function_pipeline in function.pipelines.iter() {
+                return_value = self.run_pipeline(function_pipeline, commands)
             }
             return_value
-        } else {
-            //self.run_external_commmand(job)
+        } else if pipeline.jobs.len() > 1 { // TODO Piping should not be a special case in the future
             let mut piped_commands: Vec<process::Command> = pipeline.jobs.iter().map(|job| { Shell::build_command(job) }).collect();
-            pipe(&mut piped_commands);
-            Some(0)  // TODO fix this shit
+            Some(pipe(&mut piped_commands))
+        }
+        else {
+            self.run_external_commmand(job)
         };
         if let Some(code) = exit_status {
             self.variables.set_var("?", &code.to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,10 +157,9 @@ impl Shell {
 
         // Execute commands
         for pipeline in pipelines.drain(..) {
-            let job = pipeline.jobs[0].clone();
             if self.flow_control.collecting_block {
                 // TODO move this logic into "end" command
-                if job.command == "end" {
+                if pipeline.jobs[0].command == "end" {
                     self.flow_control.collecting_block = false;
                     let block_jobs: Vec<Pipeline> = self.flow_control
                                                    .current_block
@@ -188,7 +187,7 @@ impl Shell {
                     self.flow_control.current_block.pipelines.push(pipeline);
                 }
             } else {
-                if self.flow_control.skipping() && !is_flow_control_command(&job.command) {
+                if self.flow_control.skipping() && !is_flow_control_command(&pipeline.jobs[0].command) {
                     continue;
                 }
                 self.run_pipeline(&pipeline, commands);
@@ -197,7 +196,7 @@ impl Shell {
     }
 
     fn run_pipeline(&mut self, pipeline: &Pipeline, commands: &HashMap<&str, Command>) -> Option<i32> {
-        let job = pipeline.jobs[0].clone();
+        let job = pipeline.jobs[0].clone(); // TODO stop doing this once builtins work in pipelines.
         let mut pipeline = self.variables.expand_pipeline(pipeline);
         pipeline.expand_globs();
         let exit_status = if let Some(command) = commands.get(job.command.as_str()) {

--- a/src/peg.rs
+++ b/src/peg.rs
@@ -12,6 +12,14 @@ impl Pipeline {
             jobs: jobs,
         }
     }
+
+    pub fn expand_globs(&mut self) {
+        let jobs = self.jobs.drain(..).map(|mut job| {
+            job.expand_globs();
+            job
+        }).collect();
+        self.jobs = jobs;
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -1,21 +1,54 @@
 use std::process::{Stdio, Command, Child};
-use std::os::unix::io::{FromRawFd, IntoRawFd};
+use std::os::unix::io::{FromRawFd, AsRawFd};
 
-pub fn pipe(commands: &mut [Command]) {
-    if commands.len() == 0 {
-        return;
-    }
+use super::status::{TERMINATED, NO_SUCH_COMMAND};
+
+/// This function will panic if called with an empty slice
+pub fn pipe(commands: &mut [Command]) -> i32 {
     let end = commands.len() - 1;
     for command in &mut commands[..end] {
         command.stdout(Stdio::piped());
     }
-    let mut prev: Option<Child> = None;
+    let mut children: Vec<Option<Child>> = vec![];
     for command in commands {
-        if let Some(child) = prev {
-            unsafe {
-                command.stdin(Stdio::from_raw_fd(child.stdout.unwrap().into_raw_fd()));
+        if let Some(spawned) = children.last() {
+            if let Some(ref child) = *spawned {
+                if let Some(ref stdout) = child.stdout {
+                    unsafe { command.stdin(Stdio::from_raw_fd(stdout.as_raw_fd())); }
+                }
+            } else {
+                command.stdin(Stdio::null());
             }
         }
-        prev = Some(command.spawn().expect(""));
+        children.push(command.spawn().ok());
+    }
+    wait(&mut children)
+}
+
+/// This function will panic if called with an empty vector
+fn wait(children: &mut Vec<Option<Child>>) -> i32 {
+    let end = children.len() - 1;
+    for child in children.drain(..end) {
+        if let Some(mut child) = child {
+            child.wait();
+        }
+    }
+    if let Some(mut child) = children.pop().unwrap() {
+        match child.wait() {
+            Ok(status) => {
+                if let Some(code) = status.code() {
+                    code
+                } else {
+                    println!("child ended by signal");
+                    TERMINATED
+                }
+            }
+            Err(err) => {
+                println!("Failed to wait: {}", err);
+                100 // TODO what should we return here?
+            }
+        }
+    } else {
+        NO_SUCH_COMMAND
     }
 }

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -1,0 +1,21 @@
+use std::process::{Stdio, Command, Child};
+use std::os::unix::io::{FromRawFd, IntoRawFd};
+
+pub fn pipe(commands: &mut [Command]) {
+    if commands.len() == 0 {
+        return;
+    }
+    let end = commands.len() - 1;
+    for command in &mut commands[..end] {
+        command.stdout(Stdio::piped());
+    }
+    let mut prev: Option<Child> = None;
+    for command in commands {
+        if let Some(child) = prev {
+            unsafe {
+                command.stdin(Stdio::from_raw_fd(child.stdout.unwrap().into_raw_fd()));
+            }
+        }
+        prev = Some(command.spawn().expect(""));
+    }
+}

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::io::{stdout, Write};
 
-use super::peg::Job;
+use super::peg::{Pipeline, Job};
 use super::input_editor::readln;
 use super::status::{SUCCESS, FAILURE};
 
@@ -61,6 +61,11 @@ impl Variables {
                 self.variables.insert(name.to_string(), value.to_string());
             }
         }
+    }
+
+    pub fn expand_pipeline(&self, pipeline: &Pipeline) -> Pipeline {
+        // TODO don't copy everything
+        Pipeline::new(pipeline.jobs.iter().map(|job| {self.expand_job(job)}).collect())
     }
 
     pub fn expand_job(&self, job: &Job) -> Job {


### PR DESCRIPTION
This required some minor changes to the grammar which propagated through the rest of the code base. When using a pipeline builtin functions are ignored at this time. The logic for executing commands was updated into an undesirable state because of the complications with builtins. Piping logic was added  in a new file.