### PR TITLE
Enable Truncation of History File

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
-use std::fs::OpenOptions;
-use std::io::Write;
+use std::fs::{File, OpenOptions};
+use std::io::{self, Read, Seek, SeekFrom, Write};
 use variables::Variables;
 use super::status::SUCCESS;
 
@@ -22,9 +22,9 @@ impl History {
     pub fn add(&mut self, command: String, variables: &Variables) {
         // Write this command to the history file if writing to the file is enabled.
         // TODO: Prevent evaluated files from writing to the log.
-        if variables.expand_string("$HISTORY_FILE_ENABLED") == "1" {
+        if variables.expand_string("$HISTORY_FILE_ENABLED") == "1" && command.trim() != "" {
             let history_file = variables.expand_string("$HISTORY_FILE");
-            History::write_to_disk(&history_file, &command);
+            History::write_to_disk(&history_file, History::get_file_size(variables), &command);
         }
 
         self.history.truncate(History::get_size(variables) - 1); // Make room for new item
@@ -33,18 +33,63 @@ impl History {
 
     /// If writing to the disk is enabled, this function will be used for logging history to the
     /// designated history file. If the history file does not exist, it will be created.
-    fn write_to_disk(history_file: &str, command: &str) {
-        match OpenOptions::new().append(true).create(true).open(history_file) {
+    fn write_to_disk(history_file: &str, max_size: usize, command: &str) {
+        match OpenOptions::new().read(true).write(true).create(true).open(history_file) {
             Ok(mut file) => {
+                // Determine the number of commands stored and the file length.
+                let (file_length, commands_stored) = {
+                    let mut commands_stored = 0;
+                    let mut file_length = 0;
+                    let file = File::open(history_file).unwrap();
+                    for byte in file.bytes() {
+                        if byte.unwrap_or(b' ') == b'\n' { commands_stored += 1; }
+                        file_length += 1;
+                    }
+                    (file_length, commands_stored)
+                };
+
+                // Truncate the history file if the limit has been reached
+                if commands_stored >= max_size {
+                    let seek_point = {
+                        let commands_to_delete = commands_stored - max_size + 1;
+                        let mut matched = 0;
+                        let mut bytes = 0;
+                        let file = File::open(history_file).unwrap();
+                        for byte in file.bytes() {
+                            if byte.unwrap_or(b' ') == b'\n' { matched += 1; }
+                            bytes += 1;
+                            if matched == commands_to_delete { break }
+                        }
+                        bytes as u64
+                    };
+                    
+                    if let Err(message) = file.seek(SeekFrom::Start(seek_point)) {
+                        println!("ion: unable to seek in history file: {}", message);
+                    }
+
+                    let mut buffer: Vec<u8> = Vec::with_capacity(file_length - seek_point as usize);
+                    if let Err(message) = file.read_to_end(&mut buffer) {
+                        println!("ion: unable to buffer history file: {}", message);
+                    }
+
+                    if let Err(message) = file.set_len(0) {
+                        println!("ion: unable to truncate history file: {}", message);
+                    }
+
+                    if let Err(message) = io::copy(&mut buffer.as_slice(), &mut file) {
+                        println!("ion: unable to write to history file: {}", message);
+                    }
+                }
+
+                // Write the command to the history file.
                 if let Err(message) = file.write_all(command.as_bytes()) {
-                    println!("{}", message);
+                    println!("ion: unable to write to history file: {}", message);
                 }
                 if let Err(message) = file.write(b"\n") {
-                    println!("{}", message);
+                    println!("ion: unable to write to history file: {}", message);
                 }
-                // TODO: Limit the size of the history file.
             },
-            Err(message) => println!("{}", message)
+            Err(message) => println!("ion: error opening file: {}", message)
         }
     }
 
@@ -61,10 +106,22 @@ impl History {
     /// This function will take a map of variables as input and attempt to parse the value of the
     /// history size variable. If it succeeds, it will return the value of that variable, else it
     /// will return a default value of 1000.
+    #[inline]
     fn get_size(variables: &Variables) -> usize {
         match variables.expand_string("$HISTORY_SIZE").parse::<usize>() {
             Ok(size) => size,
             _        => 1000,
+        }
+    }
+
+    /// This function will take a map of variables as input and attempt to parse the value of the
+    /// history file size variable. If it succeeds, it will return the value of that variable, else
+    /// it will return a default value of 1000.
+    #[inline]
+    fn get_file_size(variables: &Variables) -> usize {
+        match variables.expand_string("$HISTORY_FILE_SIZE").parse::<usize>() {
+            Ok(size)  => size,
+            Err(_)    => 1000,
         }
     }
 }


### PR DESCRIPTION
This will allow the history file to be truncated by a specified maximum number of commands, removing the topmost elements from the file so that a new command may be added at the bottom in their place.