### PR TITLE
Add functions with arguments

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -22,6 +22,30 @@
 - `else` will invert the comparison block
 - `end` will end the comparison block
 
+### Functions
+Use the `fn` keyword to define functions:
+```
+fn function
+  echo "Hello, Ion!"
+end
+```
+And use the function name to call it:
+```
+ion:# function
+Hello, Ion!
+```
+You can also create function with arguments:
+```
+fn print_two_strings first second
+  echo $first $second
+end
+```
+To call the function you can use the function name followed by the arguments:
+```
+ion:# print_two_strings "Foo" "Bar"
+Foo Bar
+```
+
 ### Piping
 - `echo foo | cat | xargs touch` will pipe the output from one process to another.
 

--- a/src/flow_control.rs
+++ b/src/flow_control.rs
@@ -9,7 +9,7 @@ pub fn is_flow_control_command(command: &str) -> bool {
 #[derive(Clone)]
 pub enum Statement {
     For(String, Vec<String>),
-    Function(String),
+    Function(String, Vec<String>),
     If,
     Default
 }
@@ -141,7 +141,8 @@ impl FlowControl {
         let mut args = args.into_iter();
         if let Some(name) = args.nth(1) {
             self.collecting_block = true;
-            self.current_statement = Statement::Function(name.as_ref().to_string());
+            let values: Vec<String> = args.map(|value| value.as_ref().to_string()).collect();
+            self.current_statement = Statement::Function(name.as_ref().to_string(), values);
         } else {
             println!("Functions must have the function name as the first argument");
             return FAILURE;

--- a/src/function.rs
+++ b/src/function.rs
@@ -4,4 +4,5 @@ use super::peg::Pipeline;
 pub struct Function {
     pub name: String,
     pub pipelines: Vec<Pipeline>,
+    pub args: Vec<String>
 }

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -66,6 +66,14 @@ impl Variables {
         }
     }
 
+    pub fn get_var(&self, name: &str) -> Option<&String> {
+        self.variables.get(name)
+    }
+
+    pub fn unset_var(&mut self, name: &str) -> Option<String> {
+        self.variables.remove(name)
+    }
+
     pub fn expand_pipeline(&self, pipeline: &Pipeline) -> Pipeline {
         // TODO don't copy everything
         // TODO ugh, I made it worse


### PR DESCRIPTION
Syntax:
This creates a function called `print_two_strings` which takes two arguments:
```
fn print_two_strings first second
  echo $first $second
end
```
And this will call the function:
```
ion:# print_two_strings "Foo" "Bar"
Foo Bar
```