### PR TITLE
Clippy Fixes

### DIFF
--- a/src/flow_control.rs
+++ b/src/flow_control.rs
@@ -29,8 +29,8 @@ pub struct FlowControl {
     pub current_statement: Statement, /* pub prompt: &'static str,  // Custom prompt while collecting code block */
 }
 
-impl FlowControl {
-    pub fn new() -> FlowControl {
+impl Default for FlowControl {
+    fn default() -> FlowControl {
         FlowControl {
             modes: vec![],
             collecting_block: false,
@@ -38,7 +38,9 @@ impl FlowControl {
             current_statement: Statement::Default,
         }
     }
+}
 
+impl FlowControl {
     pub fn skipping(&self) -> bool {
         self.modes.iter().any(|mode| !mode.value)
     }
@@ -102,12 +104,12 @@ impl FlowControl {
     pub fn end<I: IntoIterator>(&mut self, _: I) -> i32
         where I::Item: AsRef<str>
     {
-        if !self.modes.is_empty() {
-            self.modes.remove(0);
-            SUCCESS
-        } else {
+        if self.modes.is_empty() {
             println!("Syntax error: end found outside of a block");
             FAILURE
+        } else {
+            self.modes.remove(0);
+            SUCCESS
         }
     }
 

--- a/src/history.rs
+++ b/src/history.rs
@@ -9,14 +9,16 @@ pub struct History {
     pub previous_status: i32,
 }
 
-impl History {
-    pub fn new() -> History {
+impl Default for History {
+    fn default() -> History {
         History {
             history:         VecDeque::with_capacity(1000),
             previous_status: SUCCESS,
         }
     }
+}
 
+impl History {
     /// Add a command to the history buffer and remove the oldest commands when the max history
     /// size has been met.
     pub fn add(&mut self, command: String, variables: &Variables) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,19 +43,62 @@ pub struct Shell {
     functions: HashMap<String, Function>
 }
 
-impl Shell {
+impl Default for Shell {
     /// Panics if DirectoryStack construction fails
-    pub fn new() -> Self {
+    fn default() -> Shell {
         let mut new_shell = Shell {
-            variables: Variables::new(),
-            flow_control: FlowControl::new(),
+            variables: Variables::default(),
+            flow_control: FlowControl::default(),
             directory_stack: DirectoryStack::new().expect(""),
-            history: History::new(),
+            history: History::default(),
             functions: HashMap::new()
         };
         new_shell.initialize_default_variables();
         new_shell.evaluate_init_file();
-        return new_shell;
+        new_shell
+    }
+}
+
+impl Shell {
+    fn execute(&mut self) {
+        let commands = Command::map();
+        let mut dash_c = false;
+        for arg in env::args().skip(1) {
+            if arg == "-c" {
+                dash_c = true;
+            } else {
+                if dash_c {
+                    self.on_command(&arg, &commands);
+                } else {
+                    match File::open(&arg) {
+                        Ok(mut file) => {
+                            let mut command_list = String::new();
+                            match file.read_to_string(&mut command_list) {
+                                Ok(_) => self.on_command(&command_list, &commands),
+                                Err(err) => println!("ion: failed to read {}: {}", arg, err)
+                            }
+                        },
+                        Err(err) => println!("ion: failed to open {}: {}", arg, err)
+                    }
+                }
+
+                // Exit with the previous command's exit status.
+                process::exit(self.history.previous_status);
+            }
+        }
+
+        self.print_prompt();
+        while let Some(command) = readln() {
+            let command = command.trim();
+            if !command.is_empty() {
+                self.on_command(command, &commands);
+            }
+            self.update_variables();
+            self.print_prompt();
+        }
+
+        // Exit with the previous command's exit status.
+        process::exit(self.history.previous_status);
     }
 
     /// This function will initialize the default variables used by the shell. This function will
@@ -188,7 +231,7 @@ impl Shell {
                             let values = vals.clone();
                             for value in values {
                                 self.variables.set_var(&variable, &value);
-                                for pipeline in block_jobs.iter() {
+                                for pipeline in &block_jobs {
                                     self.run_pipeline(&pipeline, commands);
                                 }
                             }
@@ -217,28 +260,26 @@ impl Shell {
         let exit_status = if let Some(command) = commands.get(pipeline.jobs[0].command.as_str()) {
             Some((*command.main)(pipeline.jobs[0].args.as_slice(), self))
         } else if let Some(function) = self.functions.get(pipeline.jobs[0].command.as_str()).cloned() {
-            if pipeline.jobs[0].args.len() - 1 != function.args.len() {
-                println!("This function takes {} arguments, but you provided {}", function.args.len(), pipeline.jobs[0].args.len()-1);
-                Some(NO_SUCH_COMMAND) // not sure if this is the right error code
-            } else {
+            if pipeline.jobs[0].args.len() - 1 == function.args.len() {
                 let mut variables_backup: HashMap<&str, Option<String>> = HashMap::new();
                 for (name, value) in function.args.iter().zip(pipeline.jobs[0].args.iter().skip(1)) {
                     variables_backup.insert(name, self.variables.get_var(name).cloned());
                     self.variables.set_var(name, value);
                 }
                 let mut return_value = None;
-                for function_pipeline in function.pipelines.iter() {
+                for function_pipeline in &function.pipelines {
                     return_value = self.run_pipeline(function_pipeline, commands)
                 }
-                for (name, value_option) in variables_backup.iter() {
+                for (name, value_option) in &variables_backup {
                     match *value_option {
                         Some(ref value) => self.variables.set_var(name, value),
-                        None => {
-                            self.variables.unset_var(name);
-                        }
+                        None => {self.variables.unset_var(name);},
                     }
                 }
                 return_value
+            } else {
+                println!("This function takes {} arguments, but you provided {}", function.args.len(), pipeline.jobs[0].args.len()-1);
+                Some(NO_SUCH_COMMAND) // not sure if this is the right error code
             }
         } else {
             Some(execute_pipeline(pipeline))
@@ -259,19 +300,19 @@ impl Shell {
                     let mut command_list = String::new();
                     if let Err(message) = file.read_to_string(&mut command_list) {
                         println!("{}: Failed to read {}", message, argument);
-                        return status::FAILURE;
+                        status::FAILURE
                     } else {
                         self.on_command(&command_list, &commands);
-                        return status::SUCCESS;
+                        status::SUCCESS
                     }
                 } else {
                     println!("Failed to open {}", argument);
-                    return status::FAILURE;
+                    status::FAILURE
                 }
             },
             None => {
                 self.evaluate_init_file();
-                return status::SUCCESS;
+                status::SUCCESS
             },
         }
     }
@@ -484,7 +525,7 @@ impl Command {
                                         println!("Command helper not found [run 'help']...");
                                     }
                                 } else {
-                                    for (command, _help) in command_helper.iter() {
+                                    for command in command_helper.keys() {
                                         println!("{}", command);
                                     }
                                 }
@@ -497,44 +538,5 @@ impl Command {
 }
 
 fn main() {
-    let commands = Command::map();
-    let mut shell = Shell::new();
-
-    let mut dash_c = false;
-    for arg in env::args().skip(1) {
-        if arg == "-c" {
-            dash_c = true;
-        } else {
-            if dash_c {
-                shell.on_command(&arg, &commands);
-            } else {
-                match File::open(&arg) {
-                    Ok(mut file) => {
-                        let mut command_list = String::new();
-                        match file.read_to_string(&mut command_list) {
-                            Ok(_) => shell.on_command(&command_list, &commands),
-                            Err(err) => println!("ion: failed to read {}: {}", arg, err)
-                        }
-                    },
-                    Err(err) => println!("ion: failed to open {}: {}", arg, err)
-                }
-            }
-
-            // Exit with the previous command's exit status.
-            process::exit(shell.history.previous_status);
-        }
-    }
-
-    shell.print_prompt();
-    while let Some(command) = readln() {
-        let command = command.trim();
-        if !command.is_empty() {
-            shell.on_command(command, &commands);
-        }
-        shell.update_variables();
-        shell.print_prompt();
-    }
-
-    // Exit with the previous command's exit status.
-    process::exit(shell.history.previous_status);
+    Shell::default().execute();
 }

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -18,9 +18,10 @@ pub fn execute_pipeline(pipeline: Pipeline) -> i32 {
     }
     if let Some(stdout) = pipeline.stdout {
         if let Some(mut command) = piped_commands.last_mut() {
-            let file = match stdout.append {
-                true => OpenOptions::new().write(true).append(true).open(&stdout.file),
-                false => File::create(&stdout.file)
+            let file = if stdout.append {
+                OpenOptions::new().write(true).append(true).open(&stdout.file)
+            } else {
+                File::create(&stdout.file)
             };
             match file {
                 Ok(f) => unsafe { command.stdout(Stdio::from_raw_fd(f.into_raw_fd())); },
@@ -63,7 +64,7 @@ fn wait(children: &mut Vec<Option<Child>>) -> i32 {
     let end = children.len() - 1;
     for child in children.drain(..end) {
         if let Some(mut child) = child {
-            child.wait();
+            let _ = child.wait();
         }
     }
     if let Some(mut child) = children.pop().unwrap() {

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -12,11 +12,13 @@ pub struct Variables {
     variables: BTreeMap<String, String>,
 }
 
-impl Variables {
-    pub fn new() -> Variables {
+impl Default for Variables {
+    fn default() -> Variables {
         Variables { variables: BTreeMap::new() }
     }
+}
 
+impl Variables {
     pub fn read<I: IntoIterator>(&mut self, args: I) -> i32
         where I::Item: AsRef<str>
     {
@@ -53,7 +55,7 @@ impl Variables {
                 return FAILURE;
             },
             _ => {
-                for (key, value) in self.variables.iter() {
+                for (key, value) in &self.variables {
                     println!("{}={}", key, value);
                 }
             }
@@ -162,7 +164,7 @@ impl Variables {
         let mut new = original.to_owned();
         new = self.tilde_expansion(new);
         let mut replacements: Vec<(usize, usize, String)> = vec![];
-        for (n, _) in original.match_indices("$") {
+        for (n, _) in original.match_indices('$') {
             if n > 0 {
                 if let Some(c) = original.chars().nth(n-1) {
                     if c == '\\' {


### PR DESCRIPTION
**Problem**: Non-Idiomatic Rust

**Solution**: Fixes applied by Clippy

**Changes introduced by this pull request**:

- Implement **Default** traits
- Do not use **.iter()** for basic looping
- Do not use **if not** conditionals
- When matching a single character, match as a character instead of a string
- Remove unnecessary **return** keywords
- Move the bulk of **main()** into **shell::execute()**