### PR TITLE
rewrite tilde_expansion to remove regex dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,3 @@ authors = [
 [dependencies]
 peg = "*"
 glob = "*"
-regex = "0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,6 @@
 #![plugin(peg_syntax_ext)]
 
 extern crate glob;
-extern crate regex;
 
 use std::collections::HashMap;
 use std::fs::File;


### PR DESCRIPTION
**Problem**: `tilde_expansion` uses the `regex` crate, which Redox doesn't support. See #168 

**Solution**: Rewrite `tilde_expansion` to remove `regex` dependency.

**Fixes**: #168

**State**: ready

