### PR TITLE
add directory stack support to tilde expansion

### DIFF
--- a/src/directory_stack.rs
+++ b/src/directory_stack.rs
@@ -25,9 +25,9 @@ impl DirectoryStack {
     /// directory stack size variable. If it succeeds, it will return the value of that variable,
     /// else it will return a default value of 1000.
     fn get_size(variables: &Variables) -> usize {
-        match variables.expand_string("$DIRECTORY_STACK_SIZE").parse::<usize>() {
+        match variables.get_var_or_empty("DIRECTORY_STACK_SIZE").parse::<usize>() {
             Ok(size) => size,
-            _        => 1000,
+            _ => 1000,
         }
     }
 
@@ -135,6 +135,14 @@ impl DirectoryStack {
     {
         self.print_dirs();
         SUCCESS
+    }
+
+    pub fn dir_from_top(&self, num: usize) -> Option<&PathBuf> {
+        self.dirs.get(num)
+    }
+
+    pub fn dir_from_bottom(&self, num: usize) -> Option<&PathBuf> {
+        self.dirs.iter().rev().nth(num)
     }
 
     fn print_dirs(&self) {

--- a/src/history.rs
+++ b/src/history.rs
@@ -24,8 +24,8 @@ impl History {
     pub fn add(&mut self, command: String, variables: &Variables) {
         // Write this command to the history file if writing to the file is enabled.
         // TODO: Prevent evaluated files from writing to the log.
-        if variables.expand_string("$HISTORY_FILE_ENABLED") == "1" && command.trim() != "" {
-            let history_file = variables.expand_string("$HISTORY_FILE");
+        if variables.get_var_or_empty("HISTORY_FILE_ENABLED") == "1" && command.trim() != "" {
+            let history_file = variables.get_var_or_empty("HISTORY_FILE");
             History::write_to_disk(&history_file, History::get_file_size(variables), &command);
         }
 
@@ -119,9 +119,9 @@ impl History {
     /// will return a default value of 1000.
     #[inline]
     fn get_size(variables: &Variables) -> usize {
-        match variables.expand_string("$HISTORY_SIZE").parse::<usize>() {
+        match variables.get_var_or_empty("HISTORY_SIZE").parse::<usize>() {
             Ok(size) => size,
-            _        => 1000,
+            _ => 1000,
         }
     }
 
@@ -130,9 +130,9 @@ impl History {
     /// it will return a default value of 1000.
     #[inline]
     fn get_file_size(variables: &Variables) -> usize {
-        match variables.expand_string("$HISTORY_FILE_SIZE").parse::<usize>() {
-            Ok(size)  => size,
-            Err(_)    => 1000,
+        match variables.get_var_or_empty("HISTORY_FILE_SIZE").parse::<usize>() {
+            Ok(size) => size,
+            Err(_) => 1000,
         }
     }
 }


### PR DESCRIPTION
**Problem**: Tilde expansion does not support accessing the directory stack.

**Changes introduced by this pull request**:

- tilde expansion supports the directory stack
- `Variables.expand_*()` methods now have a `directory_stack` parameter
- new `Variables.get_var_or_empty()` method designed to replace many uses of `Variables.expand_string()`, to increase performance and prevent needing to pass the dir stack around as much
**Drawbacks**: New parameter in the `Variables.expand_*()` methods

**Fixes**: #156

**State**: Ready