### PR TITLE
Rustify Error Handling

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -69,6 +69,7 @@ impl History {
                         bytes as u64
                     };
 
+
                     if let Err(message) = file.seek(SeekFrom::Start(seek_point)) {
                         println!("ion: unable to seek in history file: {}", message);
                     }
@@ -119,10 +120,7 @@ impl History {
     /// will return a default value of 1000.
     #[inline]
     fn get_size(variables: &Variables) -> usize {
-        match variables.get_var_or_empty("HISTORY_SIZE").parse::<usize>() {
-            Ok(size) => size,
-            _ => 1000,
-        }
+        variables.get_var_or_empty("HISTORY_SIZE").parse::<usize>().unwrap_or(1000)
     }
 
     /// This function will take a map of variables as input and attempt to parse the value of the
@@ -130,9 +128,6 @@ impl History {
     /// it will return a default value of 1000.
     #[inline]
     fn get_file_size(variables: &Variables) -> usize {
-        match variables.get_var_or_empty("HISTORY_FILE_SIZE").parse::<usize>() {
-            Ok(size) => size,
-            Err(_) => 1000,
-        }
+        variables.get_var_or_empty("HISTORY_FILE_SIZE").parse::<usize>().unwrap_or(1000)
     }
 }

--- a/src/input_editor.rs
+++ b/src/input_editor.rs
@@ -2,8 +2,5 @@ use std::io::stdin;
 
 pub fn readln() -> Option<String> {
     let mut buffer = String::new();
-    match stdin().read_line(&mut buffer) {
-        Ok(_) => Some(buffer),
-        Err(_) => None,
-    }
+    stdin().read_line(&mut buffer).ok().map_or(None, |_| Some(buffer))
 }

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -91,7 +91,7 @@ impl Variables {
     }
 
     pub fn get_var_or_empty(&self, name: &str) -> String {
-        self.get_var(name).unwrap_or(String::new())
+        self.get_var(name).unwrap_or_default()
     }
 
     pub fn unset_var(&mut self, name: &str) -> Option<String> {
@@ -146,7 +146,7 @@ impl Variables {
         // TODO don't copy everything
         Job::new(job.args
                      .iter()
-                     .map(|original: &String| self.expand_string(&original, dir_stack))
+                     .map(|original: &String| self.expand_string(original, dir_stack))
                      .collect(),
                  job.background)
     }
@@ -167,7 +167,7 @@ impl Variables {
 
     pub fn tilde_expansion(&self, word: String, dir_stack: &DirectoryStack) -> String {
         // If the word doesn't start with ~, just return it to avoid allocating an iterator
-        if word.starts_with("~") {
+        if word.starts_with('~') {
             let mut chars = word.char_indices();
 
             let tilde_prefix;
@@ -209,10 +209,10 @@ impl Variables {
                     let neg;
                     let tilde_num;
 
-                    if tilde_prefix.starts_with("+") {
+                    if tilde_prefix.starts_with('+') {
                         tilde_num = &tilde_prefix[1..];
                         neg = false;
-                    } else if tilde_prefix.starts_with("-") {
+                    } else if tilde_prefix.starts_with('-') {
                         tilde_num = &tilde_prefix[1..];
                         neg = true;
                     } else {


### PR DESCRIPTION
This change will merely modify error handling in a handful of situations to the methods provided by the `Option` and `Result` types for more functional-style error handling, which uses much less lines of code to achieve the same effect. It will also fix a few clippy warnings and makes changes to a few areas where files were being read directly into a `String::new()` without calculating the capacity beforehand, and values were being unnecessarily cloned.