### PR TITLE
Expose type of word to Variable logic via Word Enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,3 +44,10 @@ name = "unicode-width"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[metadata]
+"checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "39dfaaa0f4da0f1a06876c5d94329d739ad0150868069cc235f1ddf80a0480e7"
+"checksum liner 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "35e3e9a9a59faa8e143577b76173cb2b1225b77333b07ad27730269e70bcefd0"
+"checksum peg 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2b5eb263593c6dde7cebf6422e655e1b7fddd0827721c00c05ac0c964ebed4da"
+"checksum termion 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "88dc2050416bbfaa5f42a939c4e1748f12b58546377eff8d1499a533cbcf4f80"
+"checksum unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2d6722facc10989f63ee0e20a83cd4e1714a9ae11529403ac7e0afd069abc39e"

--- a/examples/variable_expansion.ion
+++ b/examples/variable_expansion.ion
@@ -3,3 +3,7 @@ export test=world
 echo hello $test
 echo "hello $test"
 echo 'hello $test'
+
+cd '~'
+cd "~"
+cd ~

--- a/examples/variable_expansion.ion
+++ b/examples/variable_expansion.ion
@@ -1,0 +1,5 @@
+export test=world
+
+echo hello $test
+echo "hello $test"
+echo 'hello $test'

--- a/examples/variable_expansion.out
+++ b/examples/variable_expansion.out
@@ -1,3 +1,4 @@
 hello world
 hello world
 hello $test
+ion: failed to set current dir to ~: No such file or directory (os error 2)

--- a/examples/variable_expansion.out
+++ b/examples/variable_expansion.out
@@ -1,0 +1,3 @@
+hello world
+hello world
+hello $test

--- a/src/grammar.rustpeg
+++ b/src/grammar.rustpeg
@@ -1,6 +1,7 @@
 use peg::Pipeline;
 use peg::Job;
 use peg::Redirection;
+use peg::Word;
 use flow_control::Statement;
 use flow_control::Comparitor;
 
@@ -63,7 +64,7 @@ pipeline -> Pipeline
 
 job -> Job
     = args:word ++ whitespace background:background_token? {
-        Job::new(args.iter().map(|arg|arg.to_string()).collect(), background.is_some())
+        Job::new(args.iter().map(|v| v.clone()).collect(), background.is_some())
     }
 
 redirection -> (Option<Redirection>, Option<Redirection>)
@@ -85,19 +86,19 @@ background_token -> ()
     = [&]
     / whitespace [&]
 
-word -> &'input str
+word -> Word
     = double_quoted_word
     / single_quoted_word
-    / [^ \t\r\n#;&|<>]+ { match_str }
+    / [^ \t\r\n#;&|<>]+ { Word::Bare(match_str.to_string()) }
 
-double_quoted_word -> &'input str
-    = ["] word:_double_quoted_word ["] { word }
+double_quoted_word -> Word
+    = ["] word:_double_quoted_word ["] { Word::DoubleQuoted(word.to_string()) }
 
 _double_quoted_word -> &'input str
     = [^"]+ { match_str }
 
-single_quoted_word -> &'input str
-    = ['] word:_single_quoted_word ['] { word }
+single_quoted_word -> Word
+    = ['] word:_single_quoted_word ['] { Word::SingleQuoted(word.to_string()) }
 
 _single_quoted_word -> &'input str
     = [^']+ { match_str }

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,7 +223,7 @@ impl Shell {
                 prompt.push_str("fn> ");
             },
             _ => {
-                prompt.push_str(&format!("{}", self.variables.expand_string(&peg::Word::Bare(self.variables.get_var_or_empty("PROMPT")), &self.directory_stack)));
+                prompt.push_str(&format!("{}", self.variables.expand_string(&Word::Bare(self.variables.get_var_or_empty("PROMPT")), &self.directory_stack)));
             }
         }
 

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -283,6 +283,7 @@ mod tests {
     use super::*;
     use status::{FAILURE, SUCCESS};
     use directory_stack::DirectoryStack;
+    use peg::Word;
 
     fn new_dir_stack() -> DirectoryStack {
         DirectoryStack::new().unwrap()
@@ -291,7 +292,7 @@ mod tests {
     #[test]
     fn undefined_variable_expands_to_empty_string() {
         let variables = Variables::default();
-        let expanded = variables.expand_string("$FOO", &new_dir_stack());
+        let expanded = variables.expand_string(&Word::Bare("$FOO".to_string()), &new_dir_stack());
         assert_eq!("", &expanded);
     }
 
@@ -299,7 +300,7 @@ mod tests {
     fn let_and_expand_a_variable() {
         let mut variables = Variables::default();
         variables.let_(vec!["let", "FOO", "=", "BAR"]);
-        let expanded = variables.expand_string("$FOO", &new_dir_stack());
+        let expanded = variables.expand_string(&Word::Bare("$FOO".to_string()), &new_dir_stack());
         assert_eq!("BAR", &expanded);
     }
 
@@ -307,7 +308,7 @@ mod tests {
     fn set_var_and_expand_a_variable() {
         let mut variables = Variables::default();
         variables.set_var("FOO", "BAR");
-        let expanded = variables.expand_string("$FOO", &new_dir_stack());
+        let expanded = variables.expand_string(&Word::Bare("$FOO".to_string()), &new_dir_stack());
         assert_eq!("BAR", &expanded);
     }
 
@@ -323,7 +324,7 @@ mod tests {
         let mut variables = Variables::default();
         variables.let_(vec!["let", "FOO", "=", "BAR"]);
         variables.let_(vec!["let", "X", "=", "Y"]);
-        let expanded = variables.expand_string("variables: $FOO $X", &new_dir_stack());
+        let expanded = variables.expand_string(&Word::Bare("variables: $FOO $X".to_string()), &new_dir_stack());
         assert_eq!("variables: BAR Y", &expanded);
     }
 
@@ -337,7 +338,7 @@ mod tests {
     #[test]
     fn escape_with_backslash() {
         let variables = Variables::default();
-        let expanded = variables.expand_string("\\$FOO", &new_dir_stack());
+        let expanded = variables.expand_string(&Word::Bare("\\$FOO".to_string()), &new_dir_stack());
         assert_eq!("\\$FOO", &expanded);
     }
 
@@ -354,7 +355,7 @@ mod tests {
         variables.set_var("FOO", "BAR");
         let return_status = variables.drop_variable(vec!["drop", "FOO"]);
         assert_eq!(SUCCESS, return_status);
-        let expanded = variables.expand_string("$FOO", &new_dir_stack());
+        let expanded = variables.expand_string(&Word::Bare("$FOO".to_string()), &new_dir_stack());
         assert_eq!("", expanded);
     }
 

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -6,6 +6,7 @@ use liner::Context;
 use super::peg::{Pipeline, Job};
 use super::status::{SUCCESS, FAILURE};
 use super::directory_stack::DirectoryStack;
+use super::peg::Word;
 
 pub struct Variables {
     variables: BTreeMap<String, String>,
@@ -142,7 +143,7 @@ impl Variables {
         // TODO don't copy everything
         Job::new(job.args
                      .iter()
-                     .map(|original: &String| self.expand_string(original, dir_stack))
+                     .map(|original: &Word| Word::Bare(self.expand_string(&original, dir_stack).clone()))
                      .collect(),
                  job.background)
     }
@@ -234,11 +235,15 @@ impl Variables {
         word
     }
 
-    pub fn expand_string<'a>(&'a self, original: &'a str, dir_stack: &DirectoryStack) -> String {
-        let mut new = original.to_owned();
-        new = self.tilde_expansion(new, dir_stack);
+    pub fn expand_string<'a>(&'a self, original: &'a Word, dir_stack: &DirectoryStack) -> String {
+        let mut new = original.to_string();
+        if let &Word::SingleQuoted(_) = original {
+            return new.to_string()
+        }
+        new = self.tilde_expansion(new.to_string(), dir_stack);
         let mut replacements: Vec<(usize, usize, String)> = vec![];
         for (n, _) in original.match_indices('$') {
+            // Skip this dollar sign if it is escaped by a backslash
             if n > 0 {
                 if let Some(c) = original.chars().nth(n-1) {
                     if c == '\\' {
@@ -247,6 +252,7 @@ impl Variables {
                 }
             }
             let mut var_name = "".to_owned();
+            // Why not compare against the known variables?
             for (i, c) in original.char_indices().skip(n+1) { // skip the dollar sign
                 if Variables::is_valid_variable_character(c) {
                     var_name.push(c);


### PR DESCRIPTION
**Problem**: 

Single quoted words are currently expaned during variable expansion.

**Solution**: 

Add a mechanism to allow variable expansion logic to not expand single quoted words.

**Changes introduced by this pull request**:

Introduces a Word enum with Bare, SingleQuoted, and DoubleQuoted
variants.

This allows logic related to variable expansion to not expand single
quoted words while expanding bare and double quoted words.

The Word Enum Derefs to String so it can access the functions / methods
of the string type.

**Drawbacks**: 

More clones

**TODOs**: 
- [x] Fix cargo test `PartialEq` error
- [x] Example test
- [x] Ensure this prevents all expansions not just variable
- [ ] Adjust variable expansion logic to search only for $[names of variables in scope]
- [ ] Remove commented code

**Fixes**: #123 #84

**State**: 

WIP

**Blocking/related**: #123 #84

**Other**:

I am seeking feedback on whether this is a good approach, or refinements. 

---
