### PR TITLE
add tilde expansion for other users' home directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,6 +5,7 @@ dependencies = [
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "liner 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "peg 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "users 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -44,6 +45,14 @@ name = "unicode-width"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "044d1360593a78f5c8e5e710beccdc24ab71d1f01bc19a29bcacdba22e8475d8"
@@ -51,3 +60,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum peg 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)" = "7ea7024cd8b605f95590abe0512a71000d8c596dd364c27e64f039db9647ec8b"
 "checksum termion 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d94a5aea537a27dd9412585d7d77f2c382a2361f2b6a7cf0a6a56ea04aa5b71a"
 "checksum unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2d6722facc10989f63ee0e20a83cd4e1714a9ae11529403ac7e0afd069abc39e"
+"checksum users 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7ae8fdf783cb9652109c99886459648feb92ecc749e6b8e7930f6decba74c7c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ name = "ion"
 glob = "0.2"
 liner = "0.1"
 peg = "0.3"
+
+[target.'cfg(all(unix, not(target_os = "redox")))'.dependencies]
+users = "0.5.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,9 @@
 extern crate glob;
 extern crate liner;
 
+#[cfg(all(unix, not(target_os = "redox")))]
+extern crate users as users_unix;
+
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -214,15 +214,22 @@ impl Variables {
                         neg = false;
                     }
 
-                    if let Ok(num) = tilde_num.parse::<usize>() {
-                        let res = if neg {
-                            dir_stack.dir_from_top(num)
-                        } else {
-                            dir_stack.dir_from_bottom(num)
-                        };
+                    match tilde_num.parse() {
+                        Ok(num) => {
+                            let res = if neg {
+                                dir_stack.dir_from_top(num)
+                            } else {
+                                dir_stack.dir_from_bottom(num)
+                            };
 
-                        if let Some(path) = res {
-                            return path.to_str().unwrap().to_string();
+                            if let Some(path) = res {
+                                return path.to_str().unwrap().to_string();
+                            }
+                        }
+                        Err(_) => {
+                            if let Some(home) = get_user_home(tilde_prefix) {
+                                return home + remainder;
+                            }
                         }
                     }
                 }
@@ -356,6 +363,29 @@ impl Variables {
         }
         output
     }
+}
+
+#[cfg(all(unix, not(target_os = "redox")))]
+fn get_user_home(username: &str) -> Option<String> {
+    use users_unix::get_user_by_name;
+    use users_unix::os::unix::UserExt;
+
+    match get_user_by_name(username) {
+        Some(user) => Some(user.home_dir().to_string_lossy().into_owned()),
+        None => None,
+    }
+}
+
+#[cfg(target_os = "redox")]
+fn get_user_home(_username: &str) -> Option<String> {
+    // TODO
+    None
+}
+
+#[cfg(not(any(unix, target_os = "redox")))]
+fn get_user_home(_username: &str) -> Option<String> {
+    // TODO
+    None
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add support for #155 on non-Redox unix systems.

Redox and Windows both have stub implementations of `get_user_home`.
