### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = "0.1.5"
 dependencies = [
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "liner 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "peg 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "peg 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "peg"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -48,6 +48,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "044d1360593a78f5c8e5e710beccdc24ab71d1f01bc19a29bcacdba22e8475d8"
 "checksum liner 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4e6c746268f45f34e965025f1b6d928bfe21148e8417fab9fb36d399713e0df9"
-"checksum peg 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "f7bee4a8d7e3655f9e64245d326f0a7dcbe9e3763e05159bcdd4747e0e96fc03"
+"checksum peg 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "c4310f4230a6da1f72225ed28e3f0e04595095a7b742135c398a13b666d1a0ab"
 "checksum termion 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce9884af069456867e19fd5648b8908d5c9378f586b2659aaa6f3a4088fdb867"
 "checksum unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2d6722facc10989f63ee0e20a83cd4e1714a9ae11529403ac7e0afd069abc39e"


### PR DESCRIPTION
Updating dependency from peg 0.3.16 (which doesn't build) to peg 0.3.17 (which does).