### PR TITLE
Tab completion for functions and built-in commands

### DIFF
--- a/src/completer.rs
+++ b/src/completer.rs
@@ -1,0 +1,23 @@
+use liner::Completer;
+
+/// A completer that combines suggestions from multiple completers.
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub struct MultiCompleter<A, B> where A: Completer, B: Completer {
+    a: A,
+    b: B
+}
+impl<A, B> MultiCompleter<A, B> where A: Completer, B: Completer {
+    pub fn new(a: A, b: B) -> MultiCompleter<A, B> {
+        MultiCompleter {
+            a: a,
+            b: b
+        }
+    }
+}
+impl<A, B> Completer for MultiCompleter<A, B> where A: Completer, B: Completer {
+    fn completions(&self, start: &str) -> Vec<String> {
+        let mut completions = self.a.completions(start);
+        completions.extend_from_slice(&self.b.completions(start));
+        completions
+    }
+}

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -94,6 +94,10 @@ impl Variables {
         self.variables.remove(name)
     }
 
+    pub fn get_vars(&self) -> Vec<String> {
+        self.variables.keys().cloned().chain(env::vars().map(|(k, _)| k)).collect()
+    }
+
     fn parse_assignment<I: IntoIterator>(args: I) -> (Option<String>, Option<String>)
         where I::Item: AsRef<str>
     {


### PR DESCRIPTION
This implements #183 by adding a `MultiCompleter` struct which combines several completers into one, and by adding a `BasicCompleter` with the function names and command names combined.