### PR TITLE
Improve Job Expansion & Better Error Handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,6 @@ use self::status::{SUCCESS, NO_SUCH_COMMAND};
 use self::function::Function;
 use self::pipe::execute_pipeline;
 use self::shell_expand::ExpandErr;
-use self::shell_expand::braces::BraceErr;
 
 pub mod completer;
 pub mod pipe;
@@ -243,13 +242,13 @@ impl Shell {
                 let prompt_var = self.variables.get_var_or_empty("PROMPT");
                 match self.variables.expand_string(&prompt_var, &self.directory_stack) {
                     Ok(ref expanded_string) => prompt.push_str(expanded_string),
-                    Err(ExpandErr::Brace(BraceErr::UnmatchedBraces(position))) => {
+                    Err(ExpandErr::UnmatchedBraces(position)) => {
                         println!("ion: expand error: unmatched braces");
                         println!("{}", prompt_var);
                         println!("{}^", iter::repeat("-").take(position).collect::<String>());
                         prompt.push_str("ERROR: ");
                     },
-                    Err(ExpandErr::Brace(BraceErr::InnerBracesNotImplemented)) => {
+                    Err(ExpandErr::InnerBracesNotImplemented) => {
                         println!("ion: expand error: inner braces not yet implemented");
                         prompt.push_str("ERROR: ");
                     }

--- a/src/shell_expand/braces.rs
+++ b/src/shell_expand/braces.rs
@@ -1,24 +1,16 @@
 use super::permutate::Permutator;
-
 /// A token primitive for the `expand_braces` function.
 enum BraceToken<'a> { Normal(&'a str), Expander }
-
-#[derive(Debug, PartialEq)]
-pub enum BraceErr {
-    UnmatchedBraces(usize),
-    InnerBracesNotImplemented,
-}
 
 /// When supplied with an `input` string which contains a single word that requires brace expansion, the string will be
 /// tokenized into a collection of `BraceToken`s, separating the expanders from the normal text. Each expander's
 /// associated elements will be collected separately and permutated together before being finally integrated into a
 /// single output string.
-pub fn expand_braces(output: &mut String, input: &str) -> Result<(), BraceErr> {
+pub fn expand_braces(output: &mut String, input: &str) {
     let mut tokens:           Vec<BraceToken> = Vec::new();
     let mut expanders:        Vec<Vec<&str>>  = Vec::new();
     let mut current_expander: Vec<&str>       = Vec::new();
     let mut start                             = 0;
-    let mut brace_id                          = 0;
     let mut expander_found                    = false;
     let mut backslash                         = false;
 
@@ -38,25 +30,15 @@ pub fn expand_braces(output: &mut String, input: &str) -> Result<(), BraceErr> {
             } else if character == ',' {
                 current_expander.push(&input[start..id]);
                 start = id+1;
-            } else if character == '{' {
-                return Err(BraceErr::InnerBracesNotImplemented);
             }
         } else if character == '{' {
-            brace_id = id;
             expander_found = true;
             if id != start {
                 tokens.push(BraceToken::Normal(&input[start..id]));
             }
             start = id+1;
-        } else if character == '}' {
-            return Err(BraceErr::UnmatchedBraces(id));
         }
     }
-
-    if expander_found {
-        return Err(BraceErr::UnmatchedBraces(brace_id));
-    }
-
     if start != input.len() {
         tokens.push(BraceToken::Normal(&input[start..]));
     }
@@ -68,28 +50,19 @@ pub fn expand_braces(output: &mut String, input: &str) -> Result<(), BraceErr> {
         let elements = expanders.get(0).unwrap();
         single_brace_expand(output, elements, &tokens);
     }
-
-    Ok(())
 }
 
 #[test]
 fn escaped_braces() {
     let mut output = String::new();
-    expand_braces(&mut output, "e\\{sdf{1\\{2,34}").unwrap();
+    expand_braces(&mut output, "e\\{sdf{1\\{2,34}");
     assert_eq!(output, "e{sdf1{2 e{sdf34");
-}
-
-#[test]
-fn test_malformed_brace_input() {
-    assert_eq!(expand_braces(&mut String::new(), "AB{CD"), Err(BraceErr::UnmatchedBraces(2)));
-    assert_eq!(expand_braces(&mut String::new(), "AB{{}"), Err(BraceErr::InnerBracesNotImplemented));
-    assert_eq!(expand_braces(&mut String::new(), "AB}CD"), Err(BraceErr::UnmatchedBraces(2)));
 }
 
 #[test]
 fn test_expand_brace_permutations() {
     let mut actual = String::new();
-    expand_braces(&mut actual, "AB{12,34}CD{4,5}EF").unwrap();
+    expand_braces(&mut actual, "AB{12,34}CD{4,5}EF");
     let expected = String::from("AB12CD4EF AB12CD5EF AB34CD4EF AB34CD5EF");
     assert_eq!(actual, expected);
 }
@@ -97,11 +70,11 @@ fn test_expand_brace_permutations() {
 #[test]
 fn test_expand_brace() {
     let mut actual = String::new();
-    expand_braces(&mut actual, "AB{12,34}EF").unwrap();
+    expand_braces(&mut actual, "AB{12,34}EF");
     let expected = String::from("AB12EF AB34EF");
     assert_eq!(actual, expected);
     let mut actual = String::new();
-    expand_braces(&mut actual, "A{12,34}").unwrap();
+    expand_braces(&mut actual, "A{12,34}");
     let expected = String::from("A12 A34");
     assert_eq!(actual, expected);
 }


### PR DESCRIPTION
Provides a handful of changes to improve the `job_expand()` method in **variables.rs**, and some improvements to the **shell_expand** module in regards to error handling. Errors are now captured in the `words.rs` module instead of in the `braces.rs` module, which was causing a bug with improperly detecting some unmatched braces. Error messages will now also fully print the original command and correctly point out the location of the unmatched brace. An additional unit test was also added for the shell expand module.