### PR TITLE
Upgrade peg to 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = "0.1.5"
 dependencies = [
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "liner 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "peg 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "peg-syntax-ext 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "permutate 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -29,12 +29,28 @@ dependencies = [
 
 [[package]]
 name = "peg"
-version = "0.3.18"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "peg-syntax-ext"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "peg 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "permutate"
 version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "quote"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -54,7 +70,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "044d1360593a78f5c8e5e710beccdc24ab71d1f01bc19a29bcacdba22e8475d8"
 "checksum liner 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4e6c746268f45f34e965025f1b6d928bfe21148e8417fab9fb36d399713e0df9"
-"checksum peg 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)" = "7ea7024cd8b605f95590abe0512a71000d8c596dd364c27e64f039db9647ec8b"
+"checksum peg 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b2f7b0a8240dbf3d5cca65bba9791de310ce783d6e1426e56dc1278356b8017a"
+"checksum peg-syntax-ext 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "40f9e24d396d5d1857dbacd9b8a12c9e9922f40a52ab56bfdb681194fbdd6bdc"
 "checksum permutate 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a96a584a2502ad54ee0be4911b8ca1392a2825f8f976e464c6fd07116ef0e6b9"
+"checksum quote 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "558126f84c2489e31ed39ec149d7d834cdff9c048fd721d77912a51304dc3077"
 "checksum termion 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d94a5aea537a27dd9412585d7d77f2c382a2361f2b6a7cf0a6a56ea04aa5b71a"
 "checksum unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2d6722facc10989f63ee0e20a83cd4e1714a9ae11529403ac7e0afd069abc39e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,5 @@ name = "ion"
 [dependencies]
 glob = "0.2"
 liner = "0.1"
-peg = "0.3"
+peg-syntax-ext = "0.4"
 permutate = "0.1"

--- a/src/grammar.rustpeg
+++ b/src/grammar.rustpeg
@@ -30,13 +30,13 @@ fn_ -> Statement
     = whitespace* "fn " n:_name whitespace* args:_args whitespace* { Statement::Function{name: n.to_string(), args: args} }
 
 _name -> String
-      = [A-z]+ { match_str.to_string() }
+      = n:$([A-z]+) { n.to_string() }
 
 _args -> Vec<String>
       = _arg ** " "
 
 _arg -> String
-     = [A-z0-9]+ { match_str.to_string() }
+     = n:$([A-z0-9]+) { n.to_string() }
 
 #[pub]
 for_ -> Statement
@@ -51,7 +51,7 @@ comparitor -> Comparitor
     / ">"  { Comparitor::GreaterThan }
 
 _not_comparitor -> String
-    = !comparitor [^ ]+ { match_str.to_string() }
+    = !comparitor n:$([^ ]+) { n.to_string() }
 
 #[pub]
 pipelines -> Statement
@@ -75,7 +75,7 @@ redirect_stdin -> Redirection
     = [<] whitespace? file:word { Redirection { file: file.to_string(), append: false } }
 
 redirect_stdout -> Redirection
-    = [>]{2} whitespace? file:word { Redirection { file: file.to_string(), append: true } }
+    = [>]*<2> whitespace? file:word { Redirection { file: file.to_string(), append: true } }
     / [>] whitespace? file:word { Redirection { file: file.to_string(), append: false } }
 
 pipeline_sep -> ()
@@ -88,19 +88,19 @@ background_token -> ()
 word -> &'input str
     = double_quoted_word
     / single_quoted_word
-    / [^ \t\r\n#;&|<>]+ { match_str }
+    / $([^ \t\r\n#;&|<>]+)
 
 double_quoted_word -> &'input str
     = ["] word:_double_quoted_word ["] { word }
 
 _double_quoted_word -> &'input str
-    = [^"]+ { match_str }
+    = $([^"]+)
 
 single_quoted_word -> &'input str
     = ['] word:_single_quoted_word ['] { word }
 
 _single_quoted_word -> &'input str
-    = [^']+ { match_str }
+    = $([^']+)
 
 unused -> ()
     = whitespace comment? { () }


### PR DESCRIPTION
peg 0.3 was no longer building on nightly, and updates are now to 0.4 with breaking changes. This upgrades to 0.4 and unbreaks those changes in the grammar.