### PR TITLE
Add support for herestrings

### DIFF
--- a/src/grammar.rustpeg
+++ b/src/grammar.rustpeg
@@ -72,11 +72,12 @@ redirection -> (Option<Redirection>, Option<Redirection>)
     / { (None, None) }
 
 redirect_stdin -> Redirection
-    = [<] whitespace? file:word { Redirection { file: file.to_string(), append: false } }
+    = [<] whitespace? file:word { Redirection::File { file: file.to_string(), append: false } }
+    / [<]*<3> whitespace? lit:word { Redirection::Herestring { literal: lit.to_string() } }
 
 redirect_stdout -> Redirection
-    = [>]*<2> whitespace? file:word { Redirection { file: file.to_string(), append: true } }
-    / [>] whitespace? file:word { Redirection { file: file.to_string(), append: false } }
+    = [>]*<2> whitespace? file:word { Redirection::File { file: file.to_string(), append: true } }
+    / [>] whitespace? file:word { Redirection::File { file: file.to_string(), append: false } }
 
 pipeline_sep -> ()
     = (whitespace? [|] whitespace?) { }


### PR DESCRIPTION
**Problem**: #133 

**Solution**: 

This adds a rule in the grammar for the <<< operator. It will capture a
word/quoted string after it and feed that literal string, including an
additional newline, to the stdin of the first process after it is
spawned.

**Drawbacks**: This combines the `execute_pipeline` and `pipe` methods, making a pretty big single method.

**Fixes**: #133 
