### PR TITLE
Bit Twiddling in Shell Expansion

### DIFF
--- a/src/shell_expand/braces.rs
+++ b/src/shell_expand/braces.rs
@@ -47,7 +47,7 @@ pub fn expand_braces(output: &mut String, input: &str) {
         let vector_of_arrays: Vec<&[&str]> = expanders.iter().map(AsRef::as_ref).collect();
         multiple_brace_expand(output, &vector_of_arrays[..], &tokens);
     } else if expanders.len() == 1 {
-        let elements = expanders.get(0).unwrap();
+        let elements = &expanders[0];
         single_brace_expand(output, elements, &tokens);
     }
 }

--- a/src/shell_expand/words.rs
+++ b/src/shell_expand/words.rs
@@ -1,5 +1,21 @@
 use super::ExpandErr;
 
+// Bit Twiddling Guide:
+// var & FLAG == FLAG checks if FLAG is enabled
+// var & FLAG != FLAG checks if FLAG is disabled
+// var |= FLAG enables the FLAG
+// var &= 255 ^ FLAG disables the FLAG
+// var ^= FLAG swaps the state of FLAG
+
+const WHITESPACE:   u8 = 1;
+const SINGLE_QUOTE: u8 = 2;
+const DOUBLE_QUOTE: u8 = 4;
+const PREV_WAS_VAR: u8 = 8;
+const BRACES:       u8 = 16;
+const VARIABLES:    u8 = 32;
+const TILDE:        u8 = 64;
+const OPEN_BRACE:   u8 = 128;
+
 #[derive(Debug, PartialEq)]
 pub enum WordToken<'a> {
     Normal(&'a str),
@@ -11,14 +27,91 @@ pub enum WordToken<'a> {
 pub struct WordIterator<'a> {
     data:         &'a str,
     read:         usize,
-    whitespace:   bool,
-    single_quote: bool,
-    double_quote: bool,
+    flags:        u8
 }
 
 impl<'a> WordIterator<'a> {
     pub fn new(data: &'a str) -> WordIterator<'a> {
-        WordIterator { data: data, read: 0, whitespace: false, single_quote: false, double_quote: false }
+        WordIterator { data: data, read: 0, flags: 0u8 }
+    }
+}
+
+impl<'a> Iterator for WordIterator<'a> {
+    type Item = Result<WordToken<'a>, ExpandErr>;
+
+    fn next(&mut self) -> Option<Result<WordToken<'a>, ExpandErr>> {
+        let mut start = self.read;
+        let mut open_brace_id = 0;
+
+        if self.flags & WHITESPACE == WHITESPACE {
+            self.flags &= 255 ^ WHITESPACE;
+            collect_whitespaces(&mut self.read, start, self.data).map(Ok)
+        } else {
+            let mut break_char = None;
+            let mut backslash = false;
+            self.flags &= 255 ^ (BRACES + TILDE + VARIABLES + PREV_WAS_VAR + OPEN_BRACE);
+            for character in self.data.chars().skip(self.read) {
+                if backslash {
+                    backslash = false;
+                    if character == '$' { self.flags |= VARIABLES; }
+                } else if character == '\\' {
+                    backslash = true;
+                    self.flags &= 255 ^ PREV_WAS_VAR;
+                } else if character == '\'' && self.flags & DOUBLE_QUOTE != DOUBLE_QUOTE {
+                    if start != self.read {
+                        let return_value = collect_at_single_quote(self.flags, start, self.read, self.data);
+                        self.read += 1;
+                        self.flags ^= SINGLE_QUOTE;
+                        return Some(Ok(return_value));
+                    }
+                    start += 1;
+                    self.flags ^= SINGLE_QUOTE
+                } else if character == '"' && self.flags & SINGLE_QUOTE != SINGLE_QUOTE {
+                    if start != self.read {
+                        let return_value = collect_at_double_quote(self.flags, start, self.read, self.data);
+                        self.read += 1;
+                        self.flags ^= DOUBLE_QUOTE;
+                        return Some(Ok(return_value));
+                    }
+                    start += 1;
+                    self.flags ^= DOUBLE_QUOTE;
+                } else if character == '{' && self.flags & SINGLE_QUOTE != SINGLE_QUOTE && self.flags & DOUBLE_QUOTE != DOUBLE_QUOTE {
+                    if self.flags & PREV_WAS_VAR != PREV_WAS_VAR { self.flags |= BRACES; }
+                    if self.flags & OPEN_BRACE == OPEN_BRACE { return Some(Err(ExpandErr::InnerBracesNotImplemented)); }
+                    open_brace_id = self.read;
+                    self.flags |= OPEN_BRACE;
+                } else if character == '}' && self.flags & SINGLE_QUOTE != SINGLE_QUOTE && self.flags & DOUBLE_QUOTE != DOUBLE_QUOTE {
+                    if self.flags & OPEN_BRACE != OPEN_BRACE { return Some(Err(ExpandErr::UnmatchedBraces(self.read))); }
+                    self.flags &= 255 ^ OPEN_BRACE;
+                } else if self.flags & SINGLE_QUOTE != SINGLE_QUOTE && character == '(' && self.flags & PREV_WAS_VAR == PREV_WAS_VAR {
+                    break_char = Some(')');
+                    self.flags &= 255 ^ PREV_WAS_VAR;
+                } else if self.flags & SINGLE_QUOTE != SINGLE_QUOTE && character == '$' {
+                    self.flags |= VARIABLES + PREV_WAS_VAR;
+                } else if self.flags & SINGLE_QUOTE != SINGLE_QUOTE && self.flags & DOUBLE_QUOTE != DOUBLE_QUOTE && character == '~' && start == self.read {
+                    self.flags |= TILDE;
+                    self.flags &= 255 ^ PREV_WAS_VAR;
+                } else if character == ' ' && break_char.is_none() {
+                    self.flags |= WHITESPACE;
+                    return if self.flags & BRACES == BRACES {
+                        Some(Ok(WordToken::Brace(&self.data[start..self.read], self.flags & VARIABLES == VARIABLES)))
+                    } else if self.flags & VARIABLES == VARIABLES {
+                        Some(Ok(WordToken::Variable(&self.data[start..self.read], self.flags & DOUBLE_QUOTE == DOUBLE_QUOTE)))
+                    } else if self.flags & TILDE == TILDE {
+                        Some(Ok(WordToken::Tilde(&self.data[start..self.read])))
+                    } else {
+                        Some(Ok(WordToken::Normal(&self.data[start..self.read])))
+                    };
+                } else if break_char == Some(character) {
+                    break_char = None;
+                } else {
+                    self.flags &= 255 ^ PREV_WAS_VAR;
+                }
+                self.read += 1;
+            }
+
+            collect_at_end(self.flags, start, self.read, open_brace_id, self.data)
+        }
     }
 }
 
@@ -33,120 +126,53 @@ fn collect_whitespaces<'a>(read: &mut usize, start: usize, data: &'a str) -> Opt
     if start != *read { Some(WordToken::Normal(&data[start..*read])) } else { None }
 }
 
-impl<'a> Iterator for WordIterator<'a> {
-    type Item = Result<WordToken<'a>, ExpandErr>;
+fn collect_at_single_quote(flags: u8, start: usize, end: usize, data: &str) -> WordToken {
+    if flags & SINGLE_QUOTE == SINGLE_QUOTE {
+        WordToken::Normal(&data[start..end])
+    } else if flags & BRACES == BRACES {
+        WordToken::Brace(&data[start..end], flags & VARIABLES == VARIABLES)
+    } else if flags & VARIABLES == VARIABLES {
+        WordToken::Variable(&data[start..end], flags & DOUBLE_QUOTE == DOUBLE_QUOTE)
+    } else if flags & TILDE == TILDE {
+        WordToken::Tilde(&data[start..end])
+    } else {
+        WordToken::Normal(&data[start..end])
+    }
+}
 
-    fn next(&mut self) -> Option<Result<WordToken<'a>, ExpandErr>> {
-        let mut start = self.read;
-        let mut open_brace_id = 0;
-
-        if self.whitespace {
-            self.whitespace = false;
-            collect_whitespaces(&mut self.read, start, self.data).map(Ok)
+fn collect_at_double_quote(flags: u8, start: usize, end: usize, data: &str) -> WordToken {
+    if flags & SINGLE_QUOTE == SINGLE_QUOTE {
+        if flags & VARIABLES == VARIABLES {
+            WordToken::Variable(&data[start..end], flags & DOUBLE_QUOTE == DOUBLE_QUOTE)
         } else {
-            let mut break_char = None;
-            let (mut contains_braces, mut contains_variables, mut contains_tilde,
-                mut backslash, mut previous_char_was_dollar, mut open_brace) =
-                    (false, false, false, false, false, false);
-            for character in self.data.chars().skip(self.read) {
-                if backslash {
-                    backslash = false;
-                    if character == '$' { contains_variables = true; }
-                } else if character == '\\' {
-                    backslash = true;
-                    previous_char_was_dollar = false;
-                } else if character == '\'' && !self.double_quote {
-                    if start != self.read {
-                        let return_value = if self.single_quote {
-                            Ok(WordToken::Normal(&self.data[start..self.read]))
-                        } else if contains_braces {
-                            Ok(WordToken::Brace(&self.data[start..self.read], contains_variables))
-                        } else if contains_variables {
-                            Ok(WordToken::Variable(&self.data[start..self.read], self.double_quote))
-                        } else if contains_tilde {
-                            Ok(WordToken::Tilde(&self.data[start..self.read]))
-                        } else {
-                            Ok(WordToken::Normal(&self.data[start..self.read]))
-                        };
-                        self.read += 1;
-                        self.single_quote = !self.single_quote;
-                        return Some(return_value);
-                    }
-                    start += 1;
-                    self.single_quote = !self.single_quote;
-                } else if character == '"' && !self.single_quote {
-                    if start != self.read {
-                        let return_value = if self.single_quote {
-                            if contains_variables {
-                                Ok(WordToken::Variable(&self.data[start..self.read], self.double_quote))
-                            } else {
-                                Ok(WordToken::Normal(&self.data[start..self.read]))
-                            }
-                        } else if contains_braces {
-                            Ok(WordToken::Brace(&self.data[start..self.read], contains_variables))
-                        } else if contains_variables {
-                            Ok(WordToken::Variable(&self.data[start..self.read], self.double_quote))
-                        } else if contains_tilde {
-                            Ok(WordToken::Tilde(&self.data[start..self.read]))
-                        } else {
-                            Ok(WordToken::Normal(&self.data[start..self.read]))
-                        };
-                        self.read += 1;
-                        self.double_quote = !self.double_quote;
-                        return Some(return_value);
-                    }
-                    start += 1;
-                    self.double_quote = !self.double_quote;
-                } else if character == '{' && !self.single_quote && !self.double_quote {
-                    if !previous_char_was_dollar { contains_braces = true; }
-                    if open_brace { return Some(Err(ExpandErr::InnerBracesNotImplemented)); }
-                    open_brace_id = self.read;
-                    open_brace = true;
-                } else if character == '}' && !self.single_quote && !self.double_quote {
-                    if !open_brace { return Some(Err(ExpandErr::UnmatchedBraces(self.read))); }
-                    open_brace = false;
-                } else if !self.single_quote && character == '(' && previous_char_was_dollar {
-                    break_char = Some(')');
-                    previous_char_was_dollar = false;
-                } else if !self.single_quote && character == '$' {
-                    contains_variables = true;
-                    previous_char_was_dollar = true;
-                } else if !self.single_quote && !self.double_quote && character == '~' && start == self.read {
-                    contains_tilde = true;
-                    previous_char_was_dollar = false;
-                } else if character == ' ' && break_char.is_none() {
-                    self.whitespace = true;
-                    return if contains_braces {
-                        Some(Ok(WordToken::Brace(&self.data[start..self.read], contains_variables)))
-                    } else if contains_variables {
-                        Some(Ok(WordToken::Variable(&self.data[start..self.read], self.double_quote)))
-                    } else if contains_tilde {
-                        Some(Ok(WordToken::Tilde(&self.data[start..self.read])))
-                    } else {
-                        Some(Ok(WordToken::Normal(&self.data[start..self.read])))
-                    };
-                } else if break_char == Some(character) {
-                    break_char = None;
-                } else {
-                    previous_char_was_dollar = false;
-                }
-                self.read += 1;
-            }
-
-            if open_brace {
-                Some(Err(ExpandErr::UnmatchedBraces(open_brace_id)))
-            } else if start == self.read {
-                None
-            } else if contains_braces {
-                Some(Ok(WordToken::Brace(&self.data[start..self.read], contains_variables)))
-            } else if contains_variables {
-                Some(Ok(WordToken::Variable(&self.data[start..self.read], self.double_quote)))
-            } else if contains_tilde {
-                Some(Ok(WordToken::Tilde(&self.data[start..self.read])))
-            } else {
-                Some(Ok(WordToken::Normal(&self.data[start..self.read])))
-            }
+            WordToken::Normal(&data[start..end])
         }
+    } else if flags & BRACES == BRACES {
+        WordToken::Brace(&data[start..end], flags & VARIABLES == VARIABLES)
+    } else if flags & VARIABLES == VARIABLES {
+        WordToken::Variable(&data[start..end], flags & DOUBLE_QUOTE == DOUBLE_QUOTE)
+    } else if flags & TILDE == TILDE {
+        WordToken::Tilde(&data[start..end])
+    } else {
+        WordToken::Normal(&data[start..end])
+    }
+}
+
+fn collect_at_end(flags: u8, start: usize, end: usize, open_brace_id: usize, data: &str)
+    -> Option<Result<WordToken, ExpandErr>>
+{
+    if flags & OPEN_BRACE == OPEN_BRACE {
+        Some(Err(ExpandErr::UnmatchedBraces(open_brace_id)))
+    } else if start == end {
+        None
+    } else if flags & BRACES == BRACES {
+        Some(Ok(WordToken::Brace(&data[start..end], flags & VARIABLES == VARIABLES)))
+    } else if flags & VARIABLES == VARIABLES {
+        Some(Ok(WordToken::Variable(&data[start..end], flags & DOUBLE_QUOTE == DOUBLE_QUOTE)))
+    } else if flags & TILDE == TILDE {
+        Some(Ok(WordToken::Tilde(&data[start..end])))
+    } else {
+        Some(Ok(WordToken::Normal(&data[start..end])))
     }
 }
 


### PR DESCRIPTION
The shell expansion logic contains a large number of boolean values, each which will consume 8 bits of memory and an 8-bit register even though booleans are logically 1-bit values. By collapsing all the booleans into a single 8-bit integer and using bit-twiddling operations, shell expansion should be much faster and use less memory.

This also allows me to refactor some code in shell expansion to keep Clippy quiet.
