### PR TITLE
Remove unncessary attribute #![feature(deque_extras)]

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 #![deny(warnings)]
-#![feature(deque_extras)]
 #![feature(box_syntax)]
 #![feature(plugin)]
 #![plugin(peg_syntax_ext)]


### PR DESCRIPTION
this fixes the build on the latest rust nightly build 2017-01-31. It's apparently no longer needed. Not really sure why it counts as a full-on build stopping error, though.