### PR TITLE
Expand variables in if statements (fixes #212)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -260,6 +260,17 @@ impl Shell {
     }
 
     fn handle_if(&mut self, left: String, comparitor: Comparitor, right: String) {
+
+        let left = match self.variables.expand_string(&left, &self.directory_stack) {
+            Ok(ref expanded_string) => { expanded_string.clone() },
+            Err(_) => { "".to_string() },
+        };
+
+        let right = match self.variables.expand_string(&right, &self.directory_stack) {
+            Ok(ref expanded_string) => { expanded_string.clone() },
+            Err(_) => { "".to_string() },
+        };
+
         let value = match comparitor {
             Comparitor::GreaterThan        => { left >  right },
             Comparitor::GreaterThanOrEqual => { left >= right },


### PR DESCRIPTION
Added expansion of variables when evaluating if statements.
Undefined variables will evaluate to empty strings, thus the equality of two undefined variables will evaluate to True.
This is the same behaviour of other shells such as Bash, Sh, Zsh, ...