### PR TITLE
For Grammar Improvements

### DIFF
--- a/src/flow_control.rs
+++ b/src/flow_control.rs
@@ -1,4 +1,8 @@
 use super::peg::Pipeline;
+use directory_stack::DirectoryStack;
+use variables::Variables;
+use shell_expand::words::{WordIterator, WordToken};
+use shell_expand::{braces, variables};
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Statement {
@@ -13,7 +17,7 @@ pub enum Statement {
     },
     For{
         variable: String,
-        values: Vec<String>
+        values: String,
     },
     Else,
     End,
@@ -72,4 +76,46 @@ impl Default for FlowControl {
             current_statement: Statement::Default,
         }
     }
+}
+
+pub fn parse_for(expression: &str, dir_stack: &DirectoryStack, variables: &Variables) -> String {
+    let mut output = String::new();
+    let mut word_iterator = WordIterator::new(expression);
+
+    let expand_variable = |variable: &str, _: bool| {
+        variables.get_var(variable)
+    };
+    let expand_command = |command:  &str, quoted: bool| {
+        variables.command_expansion(command, quoted)
+    };
+
+    while let Some(Ok(word)) = word_iterator.next() {
+        match word {
+            WordToken::Brace(text, contains_variables) => {
+                if contains_variables {
+                    let mut temp = String::new();
+                    variables::expand(&mut temp, text,
+                        |variable| expand_variable(variable, false),
+                        |command| expand_command(command, false)
+                    );
+                    braces::expand_braces(&mut output, &temp);
+                } else {
+                    braces::expand_braces(&mut output, text);
+                }
+            },
+            WordToken::Normal(expr) => output.push_str(expr),
+            WordToken::Tilde(tilde) => match variables.tilde_expansion(tilde, dir_stack) {
+                Some(expanded) => output.push_str(&expanded),
+                None           => output.push_str(tilde),
+            },
+            WordToken::Variable(text, quoted) => {
+                variables::expand(&mut output, text,
+                    |variable| expand_variable(variable, quoted),
+                    |command| expand_command(command, quoted)
+                );
+            }
+        }
+    }
+
+    output
 }

--- a/src/grammar.rustpeg
+++ b/src/grammar.rustpeg
@@ -39,7 +39,12 @@ _arg -> String
 
 #[pub]
 for_ -> Statement
-    = whitespace* "for " n:_name " in " args:_args whitespace* { Statement::For{variable: n.to_string(), values: args} }
+    = whitespace* "for " n:_name " in " expr:$(.*) {
+        Statement::For{
+            variable: n.to_string(),
+            values:   expr.to_string(),
+        }
+    }
 
 comparitor -> Comparitor
     = "==" { Comparitor::Equal }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@
 #![feature(box_syntax)]
 #![feature(plugin)]
 #![plugin(peg_syntax_ext)]
-
 extern crate glob;
 extern crate liner;
 mod shell_expand;
@@ -18,15 +17,15 @@ use std::time::SystemTime;
 
 use liner::{Context, CursorPosition, Event, EventKind, FilenameCompleter, BasicCompleter};
 
-use self::completer::MultiCompleter;
-use self::directory_stack::DirectoryStack;
-use self::peg::{parse, Pipeline};
-use self::variables::Variables;
-use self::flow_control::{FlowControl, Statement, Comparitor};
-use self::status::{SUCCESS, NO_SUCH_COMMAND};
-use self::function::Function;
-use self::pipe::execute_pipeline;
-use self::shell_expand::ExpandErr;
+use completer::MultiCompleter;
+use directory_stack::DirectoryStack;
+use peg::{parse, Pipeline};
+use variables::Variables;
+use flow_control::{FlowControl, Statement, Comparitor, parse_for};
+use status::{SUCCESS, NO_SUCH_COMMAND};
+use function::Function;
+use pipe::execute_pipeline;
+use shell_expand::ExpandErr;
 
 pub mod completer;
 pub mod pipe;
@@ -283,24 +282,21 @@ impl Shell {
         self.flow_control.modes.push(flow_control::Mode{value: value})
     }
 
-
     fn handle_end(&mut self){
         self.flow_control.collecting_block = false;
         match self.flow_control.current_statement.clone() {
             Statement::For{variable: ref var, values: ref vals} => {
-                    let block_jobs: Vec<Pipeline> = self.flow_control
-                        .current_block
-                        .pipelines
-                        .drain(..)
-                        .collect();
-                let variable = var.clone();
-                let values = vals.clone();
-                for value in values {
-                    self.variables.set_var(&variable, &value);
+                let block_jobs: Vec<Pipeline> = self.flow_control
+                    .current_block
+                    .pipelines
+                    .drain(..)
+                    .collect();
+                for value in parse_for(vals.as_str(), &self.directory_stack, &self.variables).split_whitespace() {
+                    self.variables.set_var(&var, value);
                     for pipeline in &block_jobs {
                         self.run_pipeline(pipeline);
-                        }
                     }
+                }
             },
             Statement::Function{ref name, ref args} => {
                     let block_jobs: Vec<Pipeline> = self.flow_control

--- a/src/peg.rs
+++ b/src/peg.rs
@@ -125,11 +125,11 @@ struct PipelineIterator<'a> {
 impl<'a> PipelineIterator<'a> {
     fn new(match_str: &'a str) -> PipelineIterator<'a> {
         PipelineIterator {
-            match_str:       match_str,
-            flags:           if match_str.bytes().next().unwrap() == b'#' { COMMENT } else { 0 },
-            index_start:     0,
-            index_end:       0,
-            white_pos:       0,
+            match_str:   match_str,
+            flags:       if match_str.bytes().next().unwrap() == b'#' { COMMENT } else { 0 },
+            index_start: 0,
+            index_end:   0,
+            white_pos:   0,
         }
     }
 }
@@ -288,7 +288,7 @@ pub fn collect_pipelines(pipelines: &mut Vec<Pipeline>, possible_error: &mut Opt
                             b'&' if (flags & IS_VALID == 0) => job_found!(true),
                             b'>' if (flags & IS_VALID == 0) => redir_found!(RedirMode::Stdout),
                             b'<' if (flags & IS_VALID == 0) => redir_found!(RedirMode::Stdin),
-                            _   if (flags >> 6 != 2)       => flags &= 255 ^ (PROCESS_ONE + PROCESS_TWO),
+                            _   if (flags >> 6 != 2)        => flags &= 255 ^ (PROCESS_ONE + PROCESS_TWO),
                             _ => (),
                         }
                         index += 1;
@@ -938,22 +938,6 @@ else
 
         // Leading spaces after final value
         let parsed_if = fn_("         fn bob a b").unwrap();
-        assert_eq!(correct_parse, parsed_if);
-    }
-
-    #[test]
-    fn parsing_fors() {
-        // Default case where spaced normally
-        let parsed_if = for_("for i in a b").unwrap();
-        let correct_parse = Statement::For{variable: "i".to_string(), values: vec!("a".to_string(), "b".to_string())};
-        assert_eq!(correct_parse, parsed_if);
-
-        // Trailing spaces after final value
-        let parsed_if = for_("for i in a b        ").unwrap();
-        assert_eq!(correct_parse, parsed_if);
-
-        // Leading spaces after final value
-        let parsed_if = for_("         for i in a b").unwrap();
         assert_eq!(correct_parse, parsed_if);
     }
 }

--- a/src/shell_expand/mod.rs
+++ b/src/shell_expand/mod.rs
@@ -1,8 +1,8 @@
 extern crate permutate;
 
 pub mod braces;
-mod variables;
-mod words;
+pub mod variables;
+pub mod words;
 
 use self::words::{WordIterator, WordToken};
 

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -115,7 +115,7 @@ impl Variables {
     }
 
     pub fn get_var(&self, name: &str) -> Option<String> {
-        self.variables.get(name).cloned().or(env::var(name).ok())
+        self.variables.get(name).cloned().or_else(|| env::var(name).ok())
     }
 
     pub fn get_var_or_empty(&self, name: &str) -> String {
@@ -337,7 +337,7 @@ impl Variables {
     pub fn expand_string<'a>(&'a self, original: &'a str, dir_stack: &DirectoryStack) -> Result<String, ExpandErr> {
         let tilde_fn    = |tilde:    &str| self.tilde_expansion(tilde, dir_stack);
         let variable_fn = |variable: &str, quoted: bool| {
-            if quoted { self.get_var(variable) } else { self.get_var(variable).map(|x| x.replace("\n", " ")) } 
+            if quoted { self.get_var(variable) } else { self.get_var(variable).map(|x| x.replace("\n", " ")) }
         };
         let command_fn  = |command:  &str, quoted: bool| self.command_expansion(command, quoted);
         shell_expand::expand_string(original, tilde_fn, variable_fn, command_fn)


### PR DESCRIPTION
This change will connect the for grammar to shell_expand, thus enabling
the possibility to write expressions like so:

```fish
for index in $(seq 0 10)
    echo $index
end
```

This also implements inclusive and exclusive ranges. Not sure if we want to go with this syntax, but I figured I'd use the same syntax as Rust.

### Inclusive Range

```fish
for index in 0...10
    echo $index
end
```

### Exclusive Range

```fish
for index in 0..11
    echo $index
end
```

Eliminates the need to use the `seq` command.