### PR TITLE
Split Statements

### DIFF
--- a/src/grammar.rustpeg
+++ b/src/grammar.rustpeg
@@ -39,11 +39,8 @@ _arg -> String
 
 #[pub]
 for_ -> Statement
-    = whitespace* "for " n:_name " in " expr:$(.*) {
-        Statement::For{
-            variable: n.to_string(),
-            values:   expr.to_string(),
-        }
+    = whitespace* "for " n:_name " in " whitespace* expr:$(.*) {
+        Statement::For { variable: n.to_string(), values: expr.to_string() }
     }
 
 comparitor -> Comparitor


### PR DESCRIPTION
This makes it possible to now write commands like so:

```fish
for index in $(seq 1 10); echo $index; end
```