### PR TITLE
Expand Variables In Process Expansions

### DIFF
--- a/src/parser/shell_expand/variables.rs
+++ b/src/parser/shell_expand/variables.rs
@@ -15,11 +15,113 @@ pub fn expand<V, C>(output: &mut String, input: &str, expand_variable: V, expand
                 }
             },
             VariableToken::Command(command) => {
-                if let Some(result) = expand_command(&command) {
+                // Expand variables within the command before executing the command within a subshell.
+                let mut expanded = String::with_capacity(command.len());
+                for token in CommandExpander::new(&command) {
+                    match token {
+                        CommandToken::Normal(string) => expanded.push_str(string),
+                        CommandToken::Variable(var) => {
+                            if let Some(result) = expand_variable(var) {
+                                expanded.push_str(&result);
+                            }
+                        }
+                    }
+                }
+
+                if let Some(result) = expand_command(&expanded) {
                     output.push_str(&result);
                 }
             }
         }
+    }
+}
+
+/// Bit flags used by `VariableIterator`'s and `CommandExpander`'s flags fields.
+const BACK:       u8 = 1;
+const BRACED_VAR: u8 = 2;
+const PARENS_VAR: u8 = 4;
+const VAR_FOUND:  u8 = 8;
+
+/// Commands need to have variables expanded before they are submitted. This custom `Iterator` structure is
+/// responsible for slicing the variables from within commands so that they can be expanded beforehand.
+struct CommandExpander<'a> {
+    data:  &'a str,
+    read:  usize,
+    flags: u8,
+}
+
+impl<'a> CommandExpander<'a> {
+    fn new(data: &'a str) -> CommandExpander<'a> {
+        CommandExpander { data: data, read: 0, flags: 0 }
+    }
+}
+
+enum CommandToken<'a> {
+    Normal(&'a str),
+    Variable(&'a str),
+}
+
+impl<'a> Iterator for CommandExpander<'a> {
+    type Item = CommandToken<'a>;
+
+    fn next(&mut self) -> Option<CommandToken<'a>> {
+        let start = self.read;
+        let mut iterator = self.data.bytes().skip(self.read);
+
+        while let Some(character) = iterator.next()  {
+            self.read += 1;
+            match character {
+                b'\\' => { self.flags ^= BACK; continue },
+                b'$' if self.flags & (VAR_FOUND + BACK) == 0 => {
+                    if let Some(character) = self.data.bytes().nth(self.read) {
+                        if character == b'(' { continue }
+                    }
+
+                    self.flags |= VAR_FOUND;
+                    if start != self.read {
+                        return Some(CommandToken::Normal(&self.data[start..self.read-1]));
+                    }
+                },
+                _ if self.flags & VAR_FOUND != 0 => {
+                    self.flags ^= VAR_FOUND;
+                    if character == b'{' {
+                        // Slice the braced variable from the command string.
+                        while let Some(character) = iterator.next() {
+                            self.read += 1;
+                            match character {
+                                b'\\' => { self.flags ^= BACK; self.read += 1; continue },
+                                b'}' if self.flags & BACK == 0 => {
+                                    return Some(CommandToken::Variable(&self.data[start+1..self.read-1]))
+                                },
+                                _ => ()
+                            }
+                            self.flags &= 255 ^ BACK;
+                        }
+                    } else {
+                        // Slice the non-braced variable from the command string.
+                        for character in iterator {
+                            match character {
+                                b'$' => {
+                                    self.flags |= VAR_FOUND;
+                                    self.read += 1;
+                                    return Some(CommandToken::Variable(&self.data[start..self.read-1]))
+                                }
+                                b'{' | b'}' | b'(' | b')' | b' ' | b':' | b',' | b'@' | b'#' =>
+                                    return Some(CommandToken::Variable(&self.data[start..self.read])),
+                                _ => ()
+                            }
+                            self.read += 1;
+                        }
+
+                        return Some(CommandToken::Variable(&self.data[start..self.read]));
+                    }
+                },
+                _ => ()
+            }
+            self.flags &= 255 ^ BACK;
+        }
+
+        if start == self.read { None } else { Some(CommandToken::Normal(&self.data[start..])) }
     }
 }
 
@@ -38,12 +140,6 @@ struct VariableIterator<'a> {
     flags:  u8,
     read:   usize,
 }
-
-/// Bit flags used by `VariableIterator`'s flags field.
-const BACK:       u8 = 1;
-const BRACED_VAR: u8 = 2;
-const PARENS_VAR: u8 = 4;
-const VAR_FOUND:  u8 = 8;
 
 impl<'a> VariableIterator<'a> {
     fn new(input: &'a str) -> VariableIterator<'a> {


### PR DESCRIPTION
Adds the ability to pass variables into subshells by expanding inner variables before performing process expansion. Therefore, the following command is now valid:

```sh
let A = "abc"; echo $(echo ${A} $A$A $(echo $A))
```