### PR TITLE
Implement `&&` and `||` Operators

### DIFF
--- a/src/flow_control.rs
+++ b/src/flow_control.rs
@@ -17,12 +17,12 @@ pub enum Statement {
     },
     Else,
     End,
+    // TODO: Vec is unnecessary here because there will always be one pipeline parsed
     Pipelines(Vec<Pipeline>),
     Default
 }
 
 impl Statement {
-
     pub fn is_flow_control(&self) -> bool {
         match *self {
             Statement::If{..}  |

--- a/src/parser/peg.rs
+++ b/src/parser/peg.rs
@@ -39,19 +39,22 @@ impl Pipeline {
 }
 
 #[derive(Debug, PartialEq, Clone)]
+pub enum JobKind { And, Background, Or, Pipe }
+
+#[derive(Debug, PartialEq, Clone)]
 pub struct Job {
     pub command: String,
     pub args: Vec<String>,
-    pub background: bool,
+    pub kind: JobKind,
 }
 
 impl Job {
-    pub fn new(args: Vec<String>, background: bool) -> Self {
+    pub fn new(args: Vec<String>, kind: JobKind) -> Self {
         let command = args[0].clone();
         Job {
             command: command,
             args: args,
-            background: background,
+            kind: kind,
         }
     }
 

--- a/src/parser/peg.rs
+++ b/src/parser/peg.rs
@@ -38,8 +38,8 @@ impl Pipeline {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
-pub enum JobKind { And, Background, Or, Pipe }
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum JobKind { And, Background, Last, Or, Pipe }
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Job {

--- a/src/parser/pipelines.rs
+++ b/src/parser/pipelines.rs
@@ -1,4 +1,4 @@
-use parser::peg::{Job, Pipeline, Redirection};
+use parser::peg::{Job, JobKind, Pipeline, Redirection};
 
 const BACKSLASH:    u8 = 1;
 const SINGLE_QUOTE: u8 = 2;
@@ -146,8 +146,8 @@ pub fn collect(pipelines: &mut Vec<Pipeline>, possible_error: &mut Option<&str>,
                                     arg_start += 1;
                                 }
                             },
-                            b'|' if (flags & (255 ^ BACKSLASH) == 0) => job_found!(false),
-                            b'&' if (flags & IS_VALID == 0) => job_found!(true),
+                            b'|' if (flags & (255 ^ BACKSLASH) == 0) => job_found!(JobKind::Pipe),
+                            b'&' if (flags & IS_VALID == 0) => job_found!(JobKind::And),
                             b'>' if (flags & IS_VALID == 0) => redir_found!(RedirMode::Stdout),
                             b'<' if (flags & IS_VALID == 0) => redir_found!(RedirMode::Stdin),
                             _   if (flags >> 6 != 2)        => flags &= 255 ^ (PROCESS_ONE + PROCESS_TWO),
@@ -282,7 +282,7 @@ pub fn collect(pipelines: &mut Vec<Pipeline>, possible_error: &mut Option<&str>,
         }
 
         if !arguments.is_empty() {
-            jobs.push(Job::new(arguments, false));
+            jobs.push(Job::new(arguments, JobKind::Pipe));
         }
 
         pipelines.push(Pipeline::new(jobs, in_file, out_file));

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -308,7 +308,7 @@ impl Variables {
             }
         }
 
-        Job::new(expanded, job.kind.clone())
+        Job::new(expanded, job.kind)
     }
 
     pub fn is_valid_variable_character(c: char) -> bool {

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -308,7 +308,7 @@ impl Variables {
             }
         }
 
-        Job::new(expanded, job.background)
+        Job::new(expanded, job.kind.clone())
     }
 
     pub fn is_valid_variable_character(c: char) -> bool {


### PR DESCRIPTION
Resolves issue #227 by implementing support for `&&` (**AND**) and `||` (**OR**) operators. There's also basic background support, so background jobs will run in the background and print when they are complete.

The following command:

```sh
echo one && echo two && echo three
```

Will print

```
one
two
three
```

While the following:

```sh
echo one && echo two || echo one
```

Will print

```
one
two
```

And the following:

```sh
ecsdf one && echo two && echo three || echo four
```

Will print

```
ion: command not found: ecsdf
four
```