### PR TITLE
Fix : src/main.rs : 103 file_completers for all directories in ${PATH}

### DIFF
--- a/src/completer.rs
+++ b/src/completer.rs
@@ -1,13 +1,13 @@
 use liner::Completer;
 
 /// A completer that combines suggestions from multiple completers.
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct MultiCompleter<A, B> where A: Completer, B: Completer {
-    a: A,
+    a: Vec<A>,
     b: B
 }
 impl<A, B> MultiCompleter<A, B> where A: Completer, B: Completer {
-    pub fn new(a: A, b: B) -> MultiCompleter<A, B> {
+    pub fn new(a: Vec<A>, b: B) -> MultiCompleter<A, B> {
         MultiCompleter {
             a: a,
             b: b
@@ -16,8 +16,10 @@ impl<A, B> MultiCompleter<A, B> where A: Completer, B: Completer {
 }
 impl<A, B> Completer for MultiCompleter<A, B> where A: Completer, B: Completer {
     fn completions(&self, start: &str) -> Vec<String> {
-        let mut completions = self.a.completions(start);
-        completions.extend_from_slice(&self.b.completions(start));
+        let mut completions = self.b.completions(start);
+        for x in &self.a {
+            completions.extend_from_slice(&x.completions(start));
+        }
         completions
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,8 +104,14 @@ impl Shell {
                     let file_completers = match env::var("PATH") {
                         Ok(val) => {
                             let mut compl = Vec::new();
-                            for x in val.split(":") {
-                                compl.push(FilenameCompleter::new(Some(x)));
+                            if cfg!(target_os="linux") {
+                                for x in val.split(":") {
+                                    compl.push(FilenameCompleter::new(Some(x)));
+                                }
+                            }else{
+                                for x in val.split(";") {
+                                    compl.push(FilenameCompleter::new(Some(x)));
+                                }
                             }
                             compl
                         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,8 +101,20 @@ impl Shell {
                     }
                 } else {
                     // TODO: Definitions should be collected from all paths listed in `${PATH}`.
+                    let file_completers = match env::var("PATH") {
+                        Ok(val) => {
+                            let mut compl = Vec::new();
+                            for x in val.split(":") {
+                                compl.push(FilenameCompleter::new(Some(x)));
+                            }
+                            compl
+                        },
+                        Err(_) => {
+                            vec![FilenameCompleter::new(Some("/bin/"))]
+                        },
+                    };
                     // Creates a completer containing definitions from `/bin/`
-                    let file_completer = FilenameCompleter::new(Some("/bin/"));
+                    //let file_completer = FilenameCompleter::new(Some("/bin/"));
 
                     // Creates a list of definitions from the shell environment that will be used
                     // in the creation of a custom completer.
@@ -122,7 +134,7 @@ impl Shell {
                     // Initialize a new completer from the definitions collected.
                     let custom_completer = BasicCompleter::new(words);
                     // Merge the collected definitions with the file path definitions.
-                    let completer = MultiCompleter::new(file_completer, custom_completer);
+                    let completer = MultiCompleter::new(file_completers, custom_completer);
 
                     // Replace the shell's current completer with the newly-created completer.
                     mem::replace(&mut editor.context().completer, Some(Box::new(completer)));

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,7 @@ impl Shell {
                     let file_completers = match env::var("PATH") {
                         Ok(val) => {
                             let mut compl = Vec::new();
-                            if cfg!(target_os="linux") {
+                            if cfg!(unix) {
                                 for x in val.split(":") {
                                     compl.push(FilenameCompleter::new(Some(x)));
                                 }


### PR DESCRIPTION
Sorry for my awful english

**Problem**: I add some code for add completions from all ${PATH} directories;

**Changes introduced by this pull request**:

- I rewrite ```MultiCompleter``` to use ```Vec<FileCompleter>``` instead of ```FileCompleter```
