### PR TITLE
Refactor Let/Alias/Export & Implement Builtin README

### DIFF
--- a/src/builtins/README.md
+++ b/src/builtins/README.md
@@ -1,0 +1,48 @@
+# Ion Shell Builtins
+
+This directory contains the source code of Ion's builtin commands and documentation for their usage.
+
+## Variables
+
+The **variables.rs** module contains commands relating to setting and removing aliases, variables, and exports. The shell stores aliases and variables within two separate `BTreeMap` structures inside the same `Variables` structure, which is contained within the `Shell` structure.
+
+### Alias
+
+The `alias` command is used to set an alias for running other commands under a different name. The most common usages of the `alias` keyword are to shorten the keystrokes required to run a command and it's specific arguments, and to rename a command to something more familiar.
+
+```ion
+alias ls = 'ls --color'
+```
+
+If the command is executed without any arguments, it will simply list all available aliases.
+
+The `unalias` command performs the reverse of `alias` in that it drops the value from existence.
+
+```ion
+unalias ls
+```
+
+### Let
+
+The `let` command sets a variable to the value of the expression that follows. These variables are stored as local values within the shell, so other processes many not access these values.
+
+```ion
+// TODO: Ion Shell does not yet implement stderr redirection.
+let git_branch = $(git rev-parse --abbrev-ref HEAD 2> /dev/null)
+```
+
+If the command is executed without any arguments, it will simply list all available variables.
+
+To drop a value from the shell, the `drop` keyword may be used:
+
+```sh
+drop git_branch
+```
+
+### Export
+
+The `export` command works similarly to the `let` command, but instead of defining a local variable, it defines a global variable that other processes can access.
+
+```sh
+export PATH = "~/.cargo/bin:${PATH}"
+```

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -1,0 +1,3 @@
+pub mod variables;
+
+pub use self::variables::{alias, drop_alias, let_, drop_variable, export_variable};

--- a/src/builtins/variables.rs
+++ b/src/builtins/variables.rs
@@ -1,0 +1,243 @@
+use std::collections::BTreeMap;
+use std::env;
+use std::io::{self, Write};
+
+use status::*;
+use variables::Variables;
+
+fn print_list(list: &BTreeMap<String, String>) {
+    let stdout = io::stdout();
+    let stdout = &mut stdout.lock();
+
+    for (key, value) in list {
+        let _ = stdout.write(key.as_bytes())
+            .and_then(|_| stdout.write_all(b" = "))
+            .and_then(|_| stdout.write_all(value.as_bytes()))
+            .and_then(|_| stdout.write_all(b"\n"));
+    }
+}
+
+enum Binding {
+    InvalidKey(String),
+    ListEntries,
+    KeyOnly(String),
+    KeyValue(String, String),
+}
+
+/// Parses let bindings, `let VAR = KEY`, returning the result as a `(key, value)` tuple.
+fn parse_assignment<I: IntoIterator>(args: I)
+    -> Binding where I::Item: AsRef<str>
+{
+    // Write all the arguments into a single `String`
+    let arguments = args.into_iter().skip(1).fold(String::new(), |a, b| a + " " + b.as_ref());
+
+    // Create a character iterator from the arguments.
+    let mut char_iter = arguments.chars();
+
+    // Find the key and advance the iterator until the equals operator is found.
+    let mut key = "".to_owned();
+    let mut found_key = false;
+
+    // Scans through characters until the key is found, then continues to scan until
+    // the equals operator is found.
+    while let Some(character) = char_iter.next() {
+        match character {
+            ' ' if key.is_empty() => (),
+            ' ' => found_key = true,
+            '=' => {
+                found_key = true;
+                break
+            },
+            _ if !found_key => key.push(character),
+            _ => ()
+        }
+    }
+
+    if !found_key && key.is_empty() {
+        Binding::ListEntries
+    } else {
+        let value = char_iter.skip_while(|&x| x == ' ').collect::<String>();
+        if value.is_empty() {
+            Binding::KeyOnly(key)
+        } else if !Variables::is_valid_variable_name(&key) {
+            Binding::InvalidKey(key)
+        } else {
+            Binding::KeyValue(key, value)
+        }
+    }
+}
+
+/// The `alias` command will define an alias for another command, and thus may be used as a
+/// command itself.
+pub fn alias<I: IntoIterator>(vars: &mut Variables, args: I) -> i32
+    where I::Item: AsRef<str>
+{
+    match parse_assignment(args) {
+        Binding::InvalidKey(key) => {
+            let stderr = io::stderr();
+            let _ = writeln!(&mut stderr.lock(), "ion: alias name, '{}', is invalid", key);
+            return FAILURE;
+        },
+        Binding::KeyValue(key, value) => { vars.aliases.insert(key, value); },
+        Binding::ListEntries => print_list(&vars.aliases),
+        Binding::KeyOnly(key) => {
+            let stderr = io::stderr();
+            let _ = writeln!(&mut stderr.lock(), "ion: please provide value for alias '{}'", key);
+            return FAILURE;
+        }
+    }
+    SUCCESS
+}
+
+
+/// Dropping an alias will erase it from the shell.
+pub fn drop_alias<I: IntoIterator>(vars: &mut Variables, args: I) -> i32
+    where I::Item: AsRef<str>
+{
+    let args = args.into_iter().collect::<Vec<I::Item>>();
+    if args.len() <= 1 {
+        let stderr = io::stderr();
+        let _ = writeln!(&mut stderr.lock(), "ion: you must specify an alias name");
+        return FAILURE;
+    }
+    for alias in args.iter().skip(1) {
+        if vars.aliases.remove(alias.as_ref()).is_none() {
+            let stderr = io::stderr();
+            let _ = writeln!(&mut stderr.lock(), "ion: undefined alias: {}", alias.as_ref());
+            return FAILURE;
+        }
+    }
+    SUCCESS
+}
+
+/// The `let` command will set a variable within the shell. This variable is only accessible by
+/// the shell that created the variable, and other programs may not access it.
+pub fn let_<I: IntoIterator>(vars: &mut Variables, args: I) -> i32
+    where I::Item: AsRef<str>
+{
+    match parse_assignment(args) {
+        Binding::InvalidKey(key) => {
+            let stderr = io::stderr();
+            let _ = writeln!(&mut stderr.lock(), "ion: variable name, '{}', is invalid", key);
+            return FAILURE;
+        },
+        Binding::KeyValue(key, value) => { vars.variables.insert(key, value); },
+        Binding::ListEntries => print_list(&vars.variables),
+        Binding::KeyOnly(key) => {
+            let stderr = io::stderr();
+            let _ = writeln!(&mut stderr.lock(), "ion: please provide value for variable '{}'", key);
+            return FAILURE;
+        }
+    }
+    SUCCESS
+}
+
+/// Dropping a variable will erase it from the shell.
+pub fn drop_variable<I: IntoIterator>(vars: &mut Variables, args: I) -> i32
+    where I::Item: AsRef<str>
+{
+    let args = args.into_iter().collect::<Vec<I::Item>>();
+    if args.len() <= 1 {
+        let stderr = io::stderr();
+        let _ = writeln!(&mut stderr.lock(), "ion: you must specify a variable name");
+        return FAILURE;
+    }
+    for variable in args.iter().skip(1) {
+        if vars.unset_var(variable.as_ref()).is_none() {
+            let stderr = io::stderr();
+            let _ = writeln!(&mut stderr.lock(), "ion: undefined variable: {}", variable.as_ref());
+            return FAILURE;
+        }
+    }
+    SUCCESS
+}
+
+
+/// Exporting a variable sets that variable as a global variable in the system.
+/// Global variables can be accessed by other programs running on the system.
+pub fn export_variable<I: IntoIterator>(vars: &mut Variables, args: I) -> i32
+    where I::Item: AsRef<str>
+{
+    match parse_assignment(args) {
+        Binding::InvalidKey(key) => {
+            let stderr = io::stderr();
+            let _ = writeln!(&mut stderr.lock(), "ion: variable name, '{}', is invalid", key);
+            return FAILURE
+        },
+        Binding::KeyValue(key, value) => env::set_var(key, value),
+        Binding::KeyOnly(key) => {
+            if let Some(local_value) = vars.get_var(&key) {
+                env::set_var(key, local_value);
+            } else {
+                let stderr = io::stderr();
+                let _ = writeln!(&mut stderr.lock(), "ion: unknown variable, '{}'", key);
+                return FAILURE;
+            }
+        },
+        _ => {
+            let stderr = io::stderr();
+            let _ = writeln!(&mut stderr.lock(), "ion usage: export KEY=VALUE");
+            return FAILURE;
+        }
+    }
+    SUCCESS
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use parser::expand_string;
+    use status::{FAILURE, SUCCESS};
+    use directory_stack::DirectoryStack;
+
+    fn new_dir_stack() -> DirectoryStack {
+        DirectoryStack::new().unwrap()
+    }
+
+    #[test]
+    fn let_and_expand_a_variable() {
+        let mut variables = Variables::default();
+        let dir_stack = new_dir_stack();
+        let_(&mut variables, vec!["let", "FOO", "=", "BAR"]);
+        let expanded = expand_string("$FOO", &variables, &dir_stack).unwrap();
+        assert_eq!("BAR", &expanded);
+    }
+
+    #[test]
+    fn let_fails_if_no_value() {
+        let mut variables = Variables::default();
+        let return_status = let_(&mut variables, vec!["let", "FOO"]);
+        assert_eq!(FAILURE, return_status);
+    }
+
+    #[test]
+    fn let_checks_variable_name() {
+        let mut variables = Variables::default();
+        let return_status = let_(&mut variables, vec!["let", ",;!:", "=", "FOO"]);
+        assert_eq!(FAILURE, return_status);
+    }
+
+    #[test]
+    fn drop_deletes_variable() {
+        let mut variables = Variables::default();
+        variables.set_var("FOO", "BAR");
+        let return_status = drop_variable(&mut variables, vec!["drop", "FOO"]);
+        assert_eq!(SUCCESS, return_status);
+        let expanded = expand_string("$FOO", &variables, &new_dir_stack()).unwrap();
+        assert_eq!("", expanded);
+    }
+
+    #[test]
+    fn drop_fails_with_no_arguments() {
+        let mut variables = Variables::default();
+        let return_status = drop_variable(&mut variables, vec!["drop"]);
+        assert_eq!(FAILURE, return_status);
+    }
+
+    #[test]
+    fn drop_fails_with_undefined_variable() {
+        let mut variables = Variables::default();
+        let return_status = drop_variable(&mut variables, vec!["drop", "FOO"]);
+        assert_eq!(FAILURE, return_status);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,17 +118,17 @@ impl Shell {
                     // Creates a list of definitions from the shell environment that will be used
                     // in the creation of a custom completer.
                     let words = Command::map().into_iter()
-                            // Add built-in commands to the completer's definitions.
-                            .map(|(s, _)| String::from(s))
-                            // Add the history list to the completer's definitions.
-                            .chain(history.iter().cloned())
-                            // Add the aliases to the completer's definitions.
-                            .chain(vars.aliases.keys().cloned())
-                            // Add the list of available functions to the completer's definitions.
-                            .chain(funcs.keys().cloned())
-                            // Add the list of available variables to the completer's definitions.
-                            .chain(vars.get_vars().into_iter().map(|s| format!("${}", s)))
-                            .collect();
+                        // Add built-in commands to the completer's definitions.
+                        .map(|(s, _)| String::from(s))
+                        // Add the history list to the completer's definitions.
+                        .chain(history.iter().cloned())
+                        // Add the aliases to the completer's definitions.
+                        .chain(vars.aliases.keys().cloned())
+                        // Add the list of available functions to the completer's definitions.
+                        .chain(funcs.keys().cloned())
+                        // Add the list of available variables to the completer's definitions.
+                        .chain(vars.get_vars().into_iter().map(|s| format!("${}", s)))
+                        .collect();
 
                     // Initialize a new completer from the definitions collected.
                     let custom_completer = BasicCompleter::new(words);

--- a/src/parser/loops/while_grammar.rs
+++ b/src/parser/loops/while_grammar.rs
@@ -1,21 +1,9 @@
 use directory_stack::DirectoryStack;
 use variables::Variables;
-use parser::shell_expand;
+use parser::expand_string;
 
 pub fn parse_while(expression: &str, dir_stack: &DirectoryStack, variables: &Variables) -> bool {
-    macro_rules! expand {
-        ($input:expr) => {{
-            let expand_tilde = |tilde: &str| variables.tilde_expansion(tilde, dir_stack);
-            let expand_variable = |variable: &str, _: bool| variables.get_var(variable);
-            let expand_command = |command: &str, quoted: bool| {
-                variables.command_expansion(command, quoted)
-            };
-            shell_expand::expand_string($input, expand_tilde, expand_variable, expand_command)
-                .unwrap_or(String::from(""))
-        }}
-    }
-
-    match expand!(expression).as_str() {
+    match expand_string(expression, variables, dir_stack).unwrap_or_else(|_| String::from("")).as_str() {
         "1" | "true" => true,
         _ => false
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,3 +1,7 @@
+use variables::Variables;
+use directory_stack::DirectoryStack;
+use parser::shell_expand::ExpandErr;
+
 mod loops;
 pub mod peg;
 pub mod pipelines;
@@ -7,3 +11,13 @@ mod statements;
 pub use self::loops::while_grammar::parse_while;
 pub use self::loops::for_grammar::ForExpression;
 pub use self::statements::StatementSplitter;
+
+/// Takes an argument string as input and expands it.
+pub fn expand_string<'a>(original: &'a str, vars: &Variables, dir_stack: &DirectoryStack) -> Result<String, ExpandErr> {
+    let tilde_fn    = |tilde:    &str| vars.tilde_expansion(tilde, dir_stack);
+    let variable_fn = |variable: &str, quoted: bool| {
+        if quoted { vars.get_var(variable) } else { vars.get_var(variable).map(|x| x.replace("\n", " ")) }
+    };
+    let command_fn  = |command:  &str, quoted: bool| vars.command_expansion(command, quoted);
+    shell_expand::expand_string(original, tilde_fn, variable_fn, command_fn)
+}

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -74,7 +74,9 @@ pub fn pipe(commands: &mut [(Command, JobKind)]) -> i32 {
                         });
                     },
                     Err(_) => {
-
+                        let stderr = io::stderr();
+                        let mut stderr = stderr.lock();
+                        let _ = writeln!(stderr, "ion: command not found: {}", get_command_name(&command));
                     }
                 }
             },

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -125,7 +125,8 @@ impl Variables {
                 for (key, value) in &self.aliases {
                     let _ = stdout.write(key.as_bytes())
                         .and_then(|_| stdout.write_all(b" = "))
-                        .and_then(|_| stdout.write_all(value.as_bytes()));
+                        .and_then(|_| stdout.write_all(value.as_bytes()))
+                        .and_then(|_| stdout.write_all(b"\n"));
                 }
             },
             Binding::KeyOnly(key) => {
@@ -175,7 +176,8 @@ impl Variables {
                 for (key, value) in &self.variables {
                     let _ = stdout.write(key.as_bytes())
                         .and_then(|_| stdout.write_all(b" = "))
-                        .and_then(|_| stdout.write_all(value.as_bytes()));
+                        .and_then(|_| stdout.write_all(value.as_bytes()))
+                        .and_then(|_| stdout.write_all(b"\n"));
                 }
             },
             Binding::KeyOnly(key) => {

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -6,57 +6,16 @@ use std::iter;
 use std::path::PathBuf;
 use std::process;
 
-use liner::Context;
-
-use parser::peg::{Pipeline, Job};
-use status::{SUCCESS, FAILURE};
 use directory_stack::DirectoryStack;
-use parser::shell_expand::{self, ExpandErr};
+use liner::Context;
+use parser::expand_string;
+use parser::peg::{Pipeline, Job};
+use parser::shell_expand::ExpandErr;
+use status::{SUCCESS, FAILURE};
 
 pub struct Variables {
-    variables: BTreeMap<String, String>,
+    pub variables: BTreeMap<String, String>,
     pub aliases: BTreeMap<String, String>
-}
-
-enum Binding {
-    ListEntries,
-    KeyOnly(String),
-    KeyValue(String, String),
-}
-
-/// Parses let bindings, `let VAR = KEY`, returning the result as a `(key, value)` tuple.
-fn parse_assignment<I: IntoIterator>(args: I) -> Binding
-    where I::Item: AsRef<str>
-{
-    // Write all the arguments into a single `String`
-    let arguments = args.into_iter().skip(1).fold(String::new(), |a, b| a + " " + b.as_ref());
-
-    // Create a character iterator from the arguments.
-    let mut char_iter = arguments.chars();
-
-    // Find the key and advance the iterator until the equals operator is found.
-    let mut key = "".to_owned();
-    let mut found_key = false;
-
-    while let Some(character) = char_iter.next() {
-        match character {
-            ' ' if key.is_empty() => (),
-            ' ' => found_key = true,
-            '=' => {
-                found_key = true;
-                break
-            },
-            _ if !found_key => key.push(character),
-            _ => ()
-        }
-    }
-
-    if !found_key && key.is_empty() {
-        Binding::ListEntries
-    } else {
-        let value = char_iter.skip_while(|&x| x == ' ').collect::<String>();
-        if value.is_empty() { Binding::KeyOnly(key) } else { Binding::KeyValue(key, value) }
-    }
 }
 
 impl Default for Variables {
@@ -106,108 +65,6 @@ impl Variables {
         SUCCESS
     }
 
-    pub fn alias_<I: IntoIterator>(&mut self, args: I) -> i32
-        where I::Item: AsRef<str>
-    {
-        match parse_assignment(args) {
-            Binding::KeyValue(key, value) => {
-                if !Variables::is_valid_variable_name(&key) {
-                    let stderr = io::stderr();
-                    let _ = writeln!(&mut stderr.lock(), "ion: alias name, '{}', is invalid", key);
-                    return FAILURE;
-                }
-                self.aliases.insert(key.to_string(), value.to_string());
-            },
-            Binding::ListEntries => {
-                let stdout = io::stdout();
-                let stdout = &mut stdout.lock();
-
-                for (key, value) in &self.aliases {
-                    let _ = stdout.write(key.as_bytes())
-                        .and_then(|_| stdout.write_all(b" = "))
-                        .and_then(|_| stdout.write_all(value.as_bytes()))
-                        .and_then(|_| stdout.write_all(b"\n"));
-                }
-            },
-            Binding::KeyOnly(key) => {
-                let stderr = io::stderr();
-                let _ = writeln!(&mut stderr.lock(), "ion: please provide value for alias '{}'", key);
-                return FAILURE;
-            }
-        }
-        SUCCESS
-    }
-
-    pub fn drop_alias<I: IntoIterator>(&mut self, args: I) -> i32
-        where I::Item: AsRef<str>
-    {
-        let args = args.into_iter().collect::<Vec<I::Item>>();
-        if args.len() <= 1 {
-            let stderr = io::stderr();
-            let _ = writeln!(&mut stderr.lock(), "ion: you must specify an alias name");
-            return FAILURE;
-        }
-        for alias in args.iter().skip(1) {
-            if self.aliases.remove(alias.as_ref()).is_none() {
-                let stderr = io::stderr();
-                let _ = writeln!(&mut stderr.lock(), "ion: undefined alias: {}", alias.as_ref());
-                return FAILURE;
-            }
-        }
-        SUCCESS
-    }
-
-    pub fn let_<I: IntoIterator>(&mut self, args: I) -> i32
-        where I::Item: AsRef<str>
-    {
-        match parse_assignment(args) {
-            Binding::KeyValue(key, value) => {
-                if !Variables::is_valid_variable_name(&key) {
-                    let stderr = io::stderr();
-                    let _ = writeln!(&mut stderr.lock(), "ion: variable name, '{}', is invalid", key);
-                    return FAILURE;
-                }
-                self.variables.insert(key.to_string(), value.to_string());
-            },
-            Binding::ListEntries => {
-                let stdout = io::stdout();
-                let stdout = &mut stdout.lock();
-
-                for (key, value) in &self.variables {
-                    let _ = stdout.write(key.as_bytes())
-                        .and_then(|_| stdout.write_all(b" = "))
-                        .and_then(|_| stdout.write_all(value.as_bytes()))
-                        .and_then(|_| stdout.write_all(b"\n"));
-                }
-            },
-            Binding::KeyOnly(key) => {
-                let stderr = io::stderr();
-                let _ = writeln!(&mut stderr.lock(), "ion: please provide value for variable '{}'", key);
-                return FAILURE;
-            }
-        }
-        SUCCESS
-    }
-
-    pub fn drop_variable<I: IntoIterator>(&mut self, args: I) -> i32
-        where I::Item: AsRef<str>
-    {
-        let args = args.into_iter().collect::<Vec<I::Item>>();
-        if args.len() <= 1 {
-            let stderr = io::stderr();
-            let _ = writeln!(&mut stderr.lock(), "ion: you must specify a variable name");
-            return FAILURE;
-        }
-        for variable in args.iter().skip(1) {
-            if self.unset_var(variable.as_ref()).is_none() {
-                let stderr = io::stderr();
-                let _ = writeln!(&mut stderr.lock(), "ion: undefined variable: {}", variable.as_ref());
-                return FAILURE;
-            }
-        }
-        SUCCESS
-    }
-
     pub fn set_var(&mut self, name: &str, value: &str) {
         if !name.is_empty() {
             if value.is_empty() {
@@ -234,36 +91,6 @@ impl Variables {
         self.variables.keys().cloned().chain(env::vars().map(|(k, _)| k)).collect()
     }
 
-    pub fn export_variable<I: IntoIterator>(&mut self, args: I) -> i32
-        where I::Item: AsRef<str>
-    {
-        match parse_assignment(args) {
-            Binding::KeyValue(key, value) => {
-                if !Variables::is_valid_variable_name(&key) {
-                    let stderr = io::stderr();
-                    let _ = writeln!(&mut stderr.lock(), "ion: variable name, '{}', is invalid", key);
-                    return FAILURE;
-                }
-                env::set_var(key, value);
-            },
-            Binding::KeyOnly(key) => {
-                if let Some(local_value) = self.get_var(&key) {
-                    env::set_var(key, local_value);
-                } else {
-                    let stderr = io::stderr();
-                    let _ = writeln!(&mut stderr.lock(), "ion: unknown variable, '{}'", key);
-                    return FAILURE;
-                }
-            },
-            _ => {
-                let stderr = io::stderr();
-                let _ = writeln!(&mut stderr.lock(), "ion usage: export KEY=VALUE");
-                return FAILURE;
-            }
-        }
-        SUCCESS
-    }
-
     pub fn expand_pipeline(&self, pipeline: &Pipeline, dir_stack: &DirectoryStack) -> Pipeline {
         // TODO don't copy everything
         // TODO ugh, I made it worse
@@ -280,7 +107,7 @@ impl Variables {
         let mut expanded: Vec<String> = Vec::new();
         let mut nth_argument = 0;
         let mut error_occurred = None;
-        for (job, result) in job.args.iter().map(|argument| self.expand_string(argument, dir_stack)).enumerate() {
+        for (job, result) in job.args.iter().map(|argument| expand_string(argument, self, dir_stack)).enumerate() {
             match result {
                 Ok(expanded_string) => expanded.push(expanded_string),
                 Err(cause) => {
@@ -405,23 +232,13 @@ impl Variables {
 
         None
     }
-
-    /// Takes an argument string as input and expands it.
-    pub fn expand_string<'a>(&'a self, original: &'a str, dir_stack: &DirectoryStack) -> Result<String, ExpandErr> {
-        let tilde_fn    = |tilde:    &str| self.tilde_expansion(tilde, dir_stack);
-        let variable_fn = |variable: &str, quoted: bool| {
-            if quoted { self.get_var(variable) } else { self.get_var(variable).map(|x| x.replace("\n", " ")) }
-        };
-        let command_fn  = |command:  &str, quoted: bool| self.command_expansion(command, quoted);
-        shell_expand::expand_string(original, tilde_fn, variable_fn, command_fn)
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use status::{FAILURE, SUCCESS};
     use directory_stack::DirectoryStack;
+    use parser::expand_string;
 
     fn new_dir_stack() -> DirectoryStack {
         DirectoryStack::new().unwrap()
@@ -430,61 +247,15 @@ mod tests {
     #[test]
     fn undefined_variable_expands_to_empty_string() {
         let variables = Variables::default();
-        let expanded = variables.expand_string("$FOO", &new_dir_stack()).unwrap();
+        let expanded = expand_string("$FOO", &variables, &new_dir_stack()).unwrap();
         assert_eq!("", &expanded);
-    }
-
-    #[test]
-    fn let_and_expand_a_variable() {
-        let mut variables = Variables::default();
-        variables.let_(vec!["let", "FOO", "=", "BAR"]);
-        let expanded = variables.expand_string("$FOO", &new_dir_stack()).unwrap();
-        assert_eq!("BAR", &expanded);
     }
 
     #[test]
     fn set_var_and_expand_a_variable() {
         let mut variables = Variables::default();
         variables.set_var("FOO", "BAR");
-        let expanded = variables.expand_string("$FOO", &new_dir_stack()).unwrap();
+        let expanded = expand_string("$FOO", &variables, &new_dir_stack()).unwrap();
         assert_eq!("BAR", &expanded);
-    }
-
-    #[test]
-    fn let_fails_if_no_value() {
-        let mut variables = Variables::default();
-        let return_status = variables.let_(vec!["let", "FOO"]);
-        assert_eq!(FAILURE, return_status);
-    }
-
-    #[test]
-    fn let_checks_variable_name() {
-        let mut variables = Variables::default();
-        let return_status = variables.let_(vec!["let", ",;!:", "=", "FOO"]);
-        assert_eq!(FAILURE, return_status);
-    }
-
-    #[test]
-    fn drop_deletes_variable() {
-        let mut variables = Variables::default();
-        variables.set_var("FOO", "BAR");
-        let return_status = variables.drop_variable(vec!["drop", "FOO"]);
-        assert_eq!(SUCCESS, return_status);
-        let expanded = variables.expand_string("$FOO", &new_dir_stack()).unwrap();
-        assert_eq!("", expanded);
-    }
-
-    #[test]
-    fn drop_fails_with_no_arguments() {
-        let mut variables = Variables::default();
-        let return_status = variables.drop_variable(vec!["drop"]);
-        assert_eq!(FAILURE, return_status);
-    }
-
-    #[test]
-    fn drop_fails_with_undefined_variable() {
-        let mut variables = Variables::default();
-        let return_status = variables.drop_variable(vec!["drop", "FOO"]);
-        assert_eq!(FAILURE, return_status);
     }
 }


### PR DESCRIPTION
- The let/alias/export/drop commands have been refactored into a builtins module
- A README.md file was created for documenting the builtins module and the commands contained within.