### PR TITLE
Implement Basic Arithmetic for Let/Export

### DIFF
--- a/src/builtins/README.md
+++ b/src/builtins/README.md
@@ -33,10 +33,29 @@ let git_branch = $(git rev-parse --abbrev-ref HEAD 2> /dev/null)
 
 If the command is executed without any arguments, it will simply list all available variables.
 
+#### Dropping variables
+
 To drop a value from the shell, the `drop` keyword may be used:
 
-```sh
+```ion
 drop git_branch
+```
+
+#### Arithmetic
+
+The `let` command also supports basic arithmetic.
+
+```ion
+let a = 1
+echo $a
+let a += 4
+echo $a
+let a *= 10
+echo $a
+let a /= 2
+echo $a
+let a -= 5
+echo $a
 ```
 
 ### Export
@@ -45,4 +64,21 @@ The `export` command works similarly to the `let` command, but instead of defini
 
 ```sh
 export PATH = "~/.cargo/bin:${PATH}"
+```
+
+#### Arithmetic
+
+The `export` command also supports basic arithmetic.
+
+```ion
+export a = 1
+echo $a
+export a += 4
+echo $a
+export a *= 10
+echo $a
+export a /= 2
+echo $a
+export a -= 5
+echo $a
 ```


### PR DESCRIPTION
WIth this change, it is possible to take variables which contain numbers, and apply basic arithmetic to them using the let command, without the need for an external application. It performs 32-bit floating point math, so irrational numbers are supported.

```ion
let a = 1
echo $a
let a += 4
echo $a
let a *= 10
echo $a
let a /= 2
echo $a
let a -= 5
echo $a
```

```ion
let a = 1;
while test $a -lt 100
    echo $a
    let a += 1
end
```