### PR TITLE
Print currently defined functions - Issue #242

### DIFF
--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -1,0 +1,20 @@
+use flow_control::{Function};
+use std::collections::HashMap;
+use status::*;
+use std::io::{self, Write};
+
+fn print_functions(functions: &HashMap<String, Function>) {
+    let stdout = io::stdout();
+    let stdout = &mut stdout.lock();
+
+    let _ = writeln!(stdout, "# Functions");
+    for fn_name in functions.keys() {
+        let _ = writeln!(stdout, "    {}", fn_name);
+    }
+}
+
+pub fn fn_(functions: &mut HashMap<String, Function>) -> i32
+{
+    print_functions(functions);
+    SUCCESS
+}

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -1,7 +1,9 @@
 pub mod source;
 pub mod variables;
+pub mod functions;
 
 use self::variables::{alias, drop_alias, drop_variable, export_variable};
+use self::functions::fn_;
 use self::source::source;
 
 use std::collections::HashMap;
@@ -123,6 +125,15 @@ impl Builtin {
                             main: box |args: &[String], shell: &mut Shell| -> i32 {
                                 export_variable(&mut shell.variables, args)
                             }
+                        });
+
+        commands.insert("fn",
+                        Builtin {
+                            name: "fn",
+                            help: "Print list of functions",
+                            main: box |_: &[String], shell: &mut Shell| -> i32 {
+                                fn_(&mut shell.functions)
+                            },
                         });
 
         commands.insert("read",

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -35,7 +35,7 @@ pub struct Shell<'a> {
     pub variables: Variables,
     flow_control: FlowControl,
     pub directory_stack: DirectoryStack,
-    functions: HashMap<String, Function>,
+    pub functions: HashMap<String, Function>,
     pub previous_status: i32,
 }
 


### PR DESCRIPTION
When fn is typed with no arguments, print a list of functions that are
currently defined. For [Issue 242](https://github.com/redox-os/ion/issues/242)

Example output:

<img width="651" alt="screen shot 2017-03-30 at 10 01 42 pm" src="https://cloud.githubusercontent.com/assets/4043433/24533269/969b7d68-1594-11e7-86b1-562def7aad38.png">

**Problem**: [describe the problem you try to solve with this PR.]

**Solution**: [describe carefully what you change by this PR.]

**Changes introduced by this pull request**:

- [...]
- [...]
- [...]

**Drawbacks**: [if any, describe the drawbacks of this pull request.]

**TODOs**: [what is not done yet.]

**Fixes**: [what issues this fixes.]

**State**: [the state of this PR, e.g. WIP, ready, etc.]
ready
**Blocking/related**: [issues or PRs blocking or being related to this issue.]

**Other**: [optional: for other relevant information that should be known or cannot be described in the other fields.]

------

_The above template is not necessary for smaller PRs._
