### PR TITLE
added description for functions

### DIFF
--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -9,7 +9,7 @@ fn print_functions(functions: &FnvHashMap<String, Function>) {
     let _ = writeln!(stdout, "# Functions");
     for fn_name in functions.keys() {
         let ref description = functions.get(fn_name).unwrap().description;
-        if description.len() > 1 {
+        if description.len() >= 1 {
             let _ = writeln!(stdout, "    {} -- {}", fn_name, description);
         } else {
             let _ = writeln!(stdout, "    {}", fn_name);

--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -6,10 +6,14 @@ use std::io::{self, Write};
 fn print_functions(functions: &FnvHashMap<String, Function>) {
     let stdout = io::stdout();
     let stdout = &mut stdout.lock();
-
     let _ = writeln!(stdout, "# Functions");
     for fn_name in functions.keys() {
-        let _ = writeln!(stdout, "    {}", fn_name);
+        let ref description = functions.get(fn_name).unwrap().description;
+        if description.len() > 1 {
+            let _ = writeln!(stdout, "    {} -- {}", fn_name, description);
+        } else {
+            let _ = writeln!(stdout, "    {}", fn_name);
+        }
     }
 }
 

--- a/src/flow_control.rs
+++ b/src/flow_control.rs
@@ -30,6 +30,7 @@ pub enum Statement {
     ElseIf(ElseIf),
     Function {
         name: String,
+        description: String,
         args: Vec<String>,
         statements: Vec<Statement>
     },
@@ -68,6 +69,7 @@ impl Default for FlowControl {
 
 #[derive(Clone)]
 pub struct Function {
+    pub description: String,
     pub name: String,
     pub args: Vec<String>,
     pub statements: Vec<Statement>

--- a/src/parser/grammar.rustpeg
+++ b/src/parser/grammar.rustpeg
@@ -71,13 +71,17 @@ end_ -> Statement
 
 #[pub]
 fn_ -> Statement
-    = whitespace* "fn " n:_name whitespace* args:_args whitespace* {
+    = whitespace* "fn " n:_name whitespace* args:_args whitespace* description:_description? {
         Statement::Function {
+            description: description.unwrap_or("".to_string()),
             name: n.to_string(),
             args: args,
             statements: Vec::new(),
         }
     }
+
+_description -> String
+      = "--" whitespace* description:$([^\r\n]*) { description.to_string() } 
 
 _name -> String
       = n:$([A-z0-9_]+) { n.to_string() }

--- a/src/parser/peg.rs
+++ b/src/parser/peg.rs
@@ -184,9 +184,10 @@ else
         // Default case where spaced normally
         let parsed_if = fn_("fn bob").unwrap();
         let correct_parse = Statement::Function{
-            name:       "bob".to_string(),
-            args:       vec!(),
-            statements: vec!()
+            description: "".to_string(),
+            name:        "bob".to_string(),
+            args:        vec!(),
+            statements:  vec!()
         };
         assert_eq!(correct_parse, parsed_if);
 
@@ -201,9 +202,10 @@ else
         // Default case where spaced normally
         let parsed_if = fn_("fn bob a b").unwrap();
         let correct_parse = Statement::Function{
-            name:       "bob".to_owned(),
-            args:       vec!("a".to_owned(), "b".to_owned()),
-            statements: vec!()
+            description: "".to_string(),
+            name:        "bob".to_owned(),
+            args:        vec!("a".to_owned(), "b".to_owned()),
+            statements:  vec!()
         };
         assert_eq!(correct_parse, parsed_if);
 
@@ -213,6 +215,19 @@ else
 
         // Leading spaces after final value
         let parsed_if = fn_("         fn bob a b").unwrap();
+        assert_eq!(correct_parse, parsed_if);
+
+        let parsed_if = fn_("fn bob a b --bob is a nice function").unwrap();
+        let correct_parse = Statement::Function{
+            description: "bob is a nice function".to_string(),
+            name:        "bob".to_owned(),
+            args:        vec!("a".to_owned(), "b".to_owned()),
+            statements:  vec!()
+        };
+        assert_eq!(correct_parse, parsed_if);
+        let parsed_if = fn_("fn bob a b --          bob is a nice function").unwrap();
+        assert_eq!(correct_parse, parsed_if);
+        let parsed_if = fn_("fn bob a b      --bob is a nice function").unwrap();
         assert_eq!(correct_parse, parsed_if);
     }
 }

--- a/src/shell/flow.rs
+++ b/src/shell/flow.rs
@@ -109,11 +109,12 @@ impl<'a> FlowLogic for Shell<'a> {
                     Statement::For { variable, values, statements } => {
                         self.execute_for(&variable, &values, statements);
                     },
-                    Statement::Function { name, args, statements } => {
+                    Statement::Function { name, args, statements, description } => {
                         self.functions.insert(name.clone(), Function {
                             name:       name,
                             args:       args,
-                            statements: statements
+                            statements: statements,
+                            description: description,
                         });
                     },
                     Statement::If { expression, success, else_if, failure } => {
@@ -173,13 +174,14 @@ impl<'a> FlowLogic for Shell<'a> {
                         Condition::NoOp     => ()
                     }
                 },
-                Statement::Function { name, args, mut statements } => {
+                Statement::Function { name, args, mut statements, description } => {
                     self.flow_control.level += 1;
                     collect_loops(&mut iterator, &mut statements, &mut self.flow_control.level);
                     self.functions.insert(name.clone(), Function {
-                        name:       name,
-                        args:       args,
-                        statements: statements
+                        description: description,
+                        name:        name,
+                        args:        args,
+                        statements:  statements
                     });
                 },
                 Statement::Pipeline(mut pipeline) => { self.run_pipeline(&mut pipeline, false); },
@@ -343,7 +345,7 @@ impl<'a> FlowLogic for Shell<'a> {
             },
             // Collect the statements needed by the function and add the function to the
             // list of functions if it is complete.
-            Statement::Function { name, args, mut statements } => {
+            Statement::Function { name, args, mut statements, description } => {
                 self.flow_control.level += 1;
 
                 // The same logic that applies to loops, also applies here.
@@ -352,16 +354,18 @@ impl<'a> FlowLogic for Shell<'a> {
                 if self.flow_control.level == 0 {
                     // All blocks were read, thus we can add it to the list
                     self.functions.insert(name.clone(), Function {
-                        name:       name,
-                        args:       args,
-                        statements: statements
+                        description: description,
+                        name:        name,
+                        args:        args,
+                        statements:  statements
                     });
                 } else {
                     // Store the partial function declaration in memory.
                     self.flow_control.current_statement = Statement::Function {
-                        name:       name,
-                        args:       args,
-                        statements: statements
+                        description: description,
+                        name:        name,
+                        args:        args,
+                        statements:  statements
                     }
                 }
             },


### PR DESCRIPTION
**Problem**: Adding description to functions.

**Solution**: I have modified the rustpeg file in order to parse the added description. I have added the description field to the Function struct and to the struct that represents a function in the Statement enum. Now a function can be declared this way: ```fn name_of_func arg1 arg2 ... argN -- description```. The  description is optional in the parser. I have changed the print_functions function in function.rs such that when a description exists it will print it alongside the name of the function. 

**Changes introduced by this pull request**: I had to add the description field in flow.rs in different points. I've added tests for parser.

**TODOs**: [what is not done yet.]

**Fixes**: #232