### PR TITLE
Increase amount of work done without allocation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ liner = "0.1.4"
 peg-syntax-ext = "0.4"
 permutate = "0.2"
 unicode-segmentation = "1.1"
+smallvec = "0.3.3"
+smallstring = { path = "src/smallstring" }
 
 [target.'cfg(all(unix, not(target_os = "redox")))'.dependencies]
 users = "0.5.1"

--- a/src/ascii_helpers.rs
+++ b/src/ascii_helpers.rs
@@ -1,0 +1,45 @@
+use std::ascii::AsciiExt;
+use std::ops::DerefMut;
+
+// TODO: These could be generalised to work on non-ASCII characters (and even
+//       strings!) as long as the byte size of the needle and haystack match.
+
+pub trait AsciiReplaceInPlace {
+    fn ascii_replace_in_place(&mut self, needle: char, haystack: char);
+}
+
+pub trait AsciiReplace: Sized {
+    fn ascii_replace(self, needle: char, haystack: char) -> Self;
+}
+
+impl<T: DerefMut<Target=str>> AsciiReplace for T {
+    fn ascii_replace(mut self, needle: char, haystack: char) -> Self {
+        self.ascii_replace_in_place(needle, haystack);
+        self
+    }
+}
+
+impl AsciiReplaceInPlace for str {
+    // I tried replacing these `assert!` calls with `debug_assert!` but it looks
+    // like they get const-folded away anyway since it doesn't affect the speed
+    fn ascii_replace_in_place(&mut self, needle: char, haystack: char) {
+        assert!(
+            needle.is_ascii(),
+            "AsciiReplace functions can only be used for ascii characters"
+        );
+        assert!(
+            haystack.is_ascii(),
+            "AsciiReplace functions can only be used for ascii characters"
+        );
+        let (needle, haystack): (u32, u32) = (needle.into(), haystack.into());
+        let (needle, haystack) = (needle as u8, haystack as u8);
+
+        // This is safe because we verify that we don't modify non-ascii bytes
+        let mut_bytes = unsafe { self.as_bytes_mut() };
+        for chr in mut_bytes.iter_mut() {
+            if *chr == needle {
+                *chr = haystack;
+            }
+        }
+    }
+}

--- a/src/builtins/calc.rs
+++ b/src/builtins/calc.rs
@@ -11,6 +11,7 @@ pub enum Token {
     Exponent,
     OpenParen,
     CloseParen,
+    // TODO: Don't pass around a string when we can pass around a number
     Number(String),
 }
 
@@ -287,7 +288,7 @@ fn eval(input: &str) -> Result<String, CalcError> {
     tokenize(input).and_then(|x| parse(&x))
 }
 
-pub fn calc(args: &[String]) -> Result<(), String> {
+pub fn calc(args: &[&str]) -> Result<(), String> {
     let stdout = io::stdout();
     let mut stdout = stdout.lock();
     if !args.is_empty() {

--- a/src/builtins/echo.rs
+++ b/src/builtins/echo.rs
@@ -36,12 +36,12 @@ OPTIONS
         \v  vertical tab (VT)
 "#; /* @MANEND */
 
-pub fn echo(args: &[String]) -> Result<(), io::Error> {
+pub fn echo(args: &[&str]) -> Result<(), io::Error> {
     let mut flags = 0u8;
     let mut data: Vec<&str> = vec![];
 
     for arg in args {
-        match arg.as_str() {
+        match *arg {
             "--help" => flags |= HELP,
             "--escape" => flags |= ESCAPE,
             "--no-newline" => flags |= NO_NEWLINE,

--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -2,8 +2,9 @@ use shell::flow_control::Function;
 use fnv::FnvHashMap;
 use shell::status::*;
 use std::io::{self, Write};
+use types::Identifier;
 
-fn print_functions(functions: &FnvHashMap<String, Function>) {
+fn print_functions(functions: &FnvHashMap<Identifier, Function>) {
     let stdout = io::stdout();
     let stdout = &mut stdout.lock();
     let _ = writeln!(stdout, "# Functions");
@@ -17,7 +18,7 @@ fn print_functions(functions: &FnvHashMap<String, Function>) {
     }
 }
 
-pub fn fn_(functions: &mut FnvHashMap<String, Function>) -> i32
+pub fn fn_(functions: &mut FnvHashMap<Identifier, Function>) -> i32
 {
     print_functions(functions);
     SUCCESS

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -31,7 +31,7 @@ use shell::status::*;
 /// let my_command = Builtin {
 ///     name: "my_command",
 ///     help: "Describe what my_command does followed by a newline showing usage",
-///     main: box|args: &[String], &mut Shell| -> i32 {
+///     main: box|args: &[&str], &mut Shell| -> i32 {
 ///         println!("Say 'hello' to my command! :-D");
 ///     }
 /// }
@@ -39,20 +39,21 @@ use shell::status::*;
 pub struct Builtin {
     pub name: &'static str,
     pub help: &'static str,
-    pub main: Box<Fn(&[String], &mut Shell) -> i32>,
+    pub main: Box<Fn(&[&str], &mut Shell) -> i32>,
 }
 
 impl Builtin {
     /// Return the map from command names to commands
     pub fn map() -> FnvHashMap<&'static str, Self> {
-        let mut commands: FnvHashMap<&str, Self> = FnvHashMap::with_capacity_and_hasher(32, Default::default());
+        let mut commands: FnvHashMap<&str, Self> =
+            FnvHashMap::with_capacity_and_hasher(32, Default::default());
 
         /* Directories */
         commands.insert("cd",
                         Builtin {
                             name: "cd",
                             help: "Change the current directory\n    cd <path>",
-                            main: box |args: &[String], shell: &mut Shell| -> i32 {
+                            main: box |args: &[&str], shell: &mut Shell| -> i32 {
                                 match shell.directory_stack.cd(args, &shell.variables) {
                                     Ok(()) => SUCCESS,
                                     Err(why) => {
@@ -69,7 +70,7 @@ impl Builtin {
                         Builtin {
                             name: "dirs",
                             help: "Display the current directory stack",
-                            main: box |args: &[String], shell: &mut Shell| -> i32 {
+                            main: box |args: &[&str], shell: &mut Shell| -> i32 {
                                 shell.directory_stack.dirs(args)
                             },
                         });
@@ -78,7 +79,7 @@ impl Builtin {
                         Builtin {
                             name: "pushd",
                             help: "Push a directory to the stack",
-                            main: box |args: &[String], shell: &mut Shell| -> i32 {
+                            main: box |args: &[&str], shell: &mut Shell| -> i32 {
                                 match shell.directory_stack.pushd(args, &shell.variables) {
                                     Ok(()) => SUCCESS,
                                     Err(why) => {
@@ -95,7 +96,7 @@ impl Builtin {
                         Builtin {
                             name: "popd",
                             help: "Pop a directory from the stack",
-                            main: box |args: &[String], shell: &mut Shell| -> i32 {
+                            main: box |args: &[&str], shell: &mut Shell| -> i32 {
                                 match shell.directory_stack.popd(args) {
                                     Ok(()) => SUCCESS,
                                     Err(why) => {
@@ -113,7 +114,7 @@ impl Builtin {
                         Builtin {
                             name: "alias",
                             help: "View, set or unset aliases",
-                            main: box |args: &[String], shell: &mut Shell| -> i32 {
+                            main: box |args: &[&str], shell: &mut Shell| -> i32 {
                                 alias(&mut shell.variables, args)
                             },
                         });
@@ -122,7 +123,7 @@ impl Builtin {
                         Builtin {
                             name: "drop",
                             help: "Delete an alias",
-                            main: box |args: &[String], shell: &mut Shell| -> i32 {
+                            main: box |args: &[&str], shell: &mut Shell| -> i32 {
                                 drop_alias(&mut shell.variables, args)
                             },
                         });
@@ -132,7 +133,7 @@ impl Builtin {
                         Builtin {
                             name: "export",
                             help: "Set an environment variable",
-                            main: box |args: &[String], shell: &mut Shell| -> i32 {
+                            main: box |args: &[&str], shell: &mut Shell| -> i32 {
                                 export_variable(&mut shell.variables, args)
                             }
                         });
@@ -141,7 +142,7 @@ impl Builtin {
                         Builtin {
                             name: "fn",
                             help: "Print list of functions",
-                            main: box |_: &[String], shell: &mut Shell| -> i32 {
+                            main: box |_: &[&str], shell: &mut Shell| -> i32 {
                                 fn_(&mut shell.functions)
                             },
                         });
@@ -150,7 +151,7 @@ impl Builtin {
                         Builtin {
                             name: "read",
                             help: "Read some variables\n    read <variable>",
-                            main: box |args: &[String], shell: &mut Shell| -> i32 {
+                            main: box |args: &[&str], shell: &mut Shell| -> i32 {
                                 shell.variables.read(args)
                             },
                         });
@@ -159,7 +160,7 @@ impl Builtin {
                         Builtin {
                             name: "drop",
                             help: "Delete a variable",
-                            main: box |args: &[String], shell: &mut Shell| -> i32 {
+                            main: box |args: &[&str], shell: &mut Shell| -> i32 {
                                 drop_variable(&mut shell.variables, args)
                             },
                         });
@@ -169,7 +170,7 @@ impl Builtin {
             Builtin {
                 name: "set",
                 help: "Set or unset values of shell options and positional parameters.",
-                main: box |args: &[String], shell: &mut Shell| -> i32 {
+                main: box |args: &[&str], shell: &mut Shell| -> i32 {
                     set::set(args, shell)
                 },
             });
@@ -178,7 +179,7 @@ impl Builtin {
             Builtin {
                 name: "eval",
                 help: "evaluates the evaluated expression",
-                main: box |args: &[String], shell: &mut Shell| -> i32 {
+                main: box |args: &[&str], shell: &mut Shell| -> i32 {
                     let evaluated_command = args[1..].join(" ");
                     let mut buffer = QuoteTerminator::new(evaluated_command);
                     if buffer.check_termination() {
@@ -197,7 +198,7 @@ impl Builtin {
                 Builtin {
                     name: "exit",
                     help: "To exit the curent session",
-                    main: box |args: &[String], shell: &mut Shell| -> i32 {
+                    main: box |args: &[&str], shell: &mut Shell| -> i32 {
                         process::exit(args.get(1).and_then(|status| status.parse::<i32>().ok())
                             .unwrap_or(shell.previous_status))
                     },
@@ -207,7 +208,7 @@ impl Builtin {
                         Builtin {
                             name: "history",
                             help: "Display a log of all commands previously executed",
-                            main: box |args: &[String], shell: &mut Shell| -> i32 {
+                            main: box |args: &[&str], shell: &mut Shell| -> i32 {
                                 shell.print_history(args)
                             },
                         });
@@ -216,7 +217,7 @@ impl Builtin {
                         Builtin {
                             name: "source",
                             help: "Evaluate the file following the command or re-initialize the init file",
-                            main: box |args: &[String], shell: &mut Shell| -> i32 {
+                            main: box |args: &[&str], shell: &mut Shell| -> i32 {
                                 match source(shell, args) {
                                     Ok(()) => SUCCESS,
                                     Err(why) => {
@@ -234,7 +235,7 @@ impl Builtin {
                         Builtin {
                             name: "echo",
                             help: "Display a line of text",
-                            main: box |args: &[String], _: &mut Shell| -> i32 {
+                            main: box |args: &[&str], _: &mut Shell| -> i32 {
                                 match echo(args) {
                                     Ok(()) => SUCCESS,
                                     Err(why) => {
@@ -251,7 +252,7 @@ impl Builtin {
                         Builtin {
                             name: "test",
                             help: "Performs tests on files and text",
-                            main: box |args: &[String], _: &mut Shell| -> i32 {
+                            main: box |args: &[&str], _: &mut Shell| -> i32 {
                                 match test(args) {
                                     Ok(true) => SUCCESS,
                                     Ok(false) => FAILURE,
@@ -269,7 +270,7 @@ impl Builtin {
                         Builtin {
                             name: "calc",
                             help: "Calculate a mathematical expression",
-                            main: box |args: &[String], _: &mut Shell| -> i32 {
+                            main: box |args: &[&str], _: &mut Shell| -> i32 {
                                 match calc::calc(&args[1..]) {
                                     Ok(()) => SUCCESS,
                                     Err(why) => {
@@ -286,7 +287,7 @@ impl Builtin {
                         Builtin {
                             name: "time",
                             help: "Measures the time to execute an external command",
-                            main: box |args: &[String], _: &mut Shell| -> i32 {
+                            main: box |args: &[&str], _: &mut Shell| -> i32 {
                                 match time::time(&args[1..]) {
                                     Ok(()) => SUCCESS,
                                     Err(why) => {
@@ -303,7 +304,7 @@ impl Builtin {
                         Builtin {
                             name: "true",
                             help: "Do nothing, successfully",
-                            main: box |_: &[String], _: &mut Shell| -> i32 {
+                            main: box |_: &[&str], _: &mut Shell| -> i32 {
                                 SUCCESS
                             },
                         });
@@ -312,7 +313,7 @@ impl Builtin {
                         Builtin {
                             name: "false",
                             help: "Do nothing, unsuccessfully",
-                            main: box |_: &[String], _: &mut Shell| -> i32 {
+                            main: box |_: &[&str], _: &mut Shell| -> i32 {
                                 FAILURE
                             },
                         });
@@ -328,12 +329,12 @@ impl Builtin {
                             name: "help",
                             help: "Display helpful information about a given command, or list \
                                    commands if none specified\n    help <command>",
-                            main: box move |args: &[String], _: &mut Shell| -> i32 {
+                            main: box move |args: &[&str], _: &mut Shell| -> i32 {
                                 let stdout = io::stdout();
                                 let mut stdout = stdout.lock();
                                 if let Some(command) = args.get(1) {
-                                    if command_helper.contains_key(command.as_str()) {
-                                        if let Some(help) = command_helper.get(command.as_str()) {
+                                    if command_helper.contains_key(command) {
+                                        if let Some(help) = command_helper.get(command) {
                                             let _ = stdout.write_all(help.as_bytes());
                                             let _ = stdout.write_all(b"\n");
                                         }

--- a/src/builtins/source.rs
+++ b/src/builtins/source.rs
@@ -3,7 +3,7 @@ use std::io::Read;
 use shell::{Shell, FlowLogic};
 
 /// Evaluates the given file and returns 'SUCCESS' if it succeeds.
-pub fn source(shell: &mut Shell, arguments: &[String]) -> Result<(), String> {
+pub fn source(shell: &mut Shell, arguments: &[&str]) -> Result<(), String> {
     match arguments.get(1) {
         Some(argument) => {
             if let Ok(mut file) = File::open(&argument) {

--- a/src/builtins/time.rs
+++ b/src/builtins/time.rs
@@ -18,12 +18,12 @@ OPTIONS
         display this help and exit
 "#;
 
-pub fn time(args: &[String]) -> Result<(), String> {
+pub fn time(args: &[&str]) -> Result<(), String> {
     let stdout = stdout();
     let mut stdout = stdout.lock();
 
     for arg in args {
-        if arg.as_str() == "-h" || arg == "--help" {
+        if *arg == "-h" || *arg == "--help" {
             return match stdout.write_all(MAN_PAGE.as_bytes()).and_then(|_| stdout.flush()) {
                 Ok(_)    => Ok(()),
                 Err(err) => Err(err.description().to_owned())

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 #![allow(while_let_on_iterator)]
 #![feature(box_syntax)]
 #![feature(plugin)]
+#![feature(str_mut_extras)]
 #![plugin(peg_syntax_ext)]
 
 // For a performance boost on Linux
@@ -11,6 +12,8 @@
 extern crate fnv;
 extern crate glob;
 extern crate liner;
+extern crate smallvec;
+extern crate smallstring;
 
 #[cfg(all(unix, not(target_os = "redox")))]
 extern crate users as users_unix;
@@ -18,6 +21,8 @@ extern crate users as users_unix;
 #[macro_use] mod parser;
 mod builtins;
 mod shell;
+mod ascii_helpers;
+mod types;
 
 use std::io::{stderr, Write, ErrorKind};
 use builtins::Builtin;

--- a/src/parser/assignments.rs
+++ b/src/parser/assignments.rs
@@ -1,12 +1,20 @@
 use shell::variables::Variables;
+use types::{Identifier, Value as VString, Array};
+
+#[derive(Debug, PartialEq, Clone)]
+// TODO: Have the expand_string function return the `Value` type.
+pub enum Value {
+    String(VString),
+    Array(Array)
+}
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Binding {
-    InvalidKey(String),
+    InvalidKey(Identifier),
     ListEntries,
-    KeyOnly(String),
-    KeyValue(String, String),
-    Math(String, Operator, String),
+    KeyOnly(Identifier),
+    KeyValue(Identifier, VString),
+    Math(Identifier, Operator, VString),
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -16,6 +24,12 @@ pub enum Operator {
     Divide,
     Multiply,
     Exponent,
+}
+
+#[allow(dead_code)]
+enum Expression {
+    Arithmetic,
+    Regular
 }
 
 /// Parses let bindings, `let VAR = KEY`, returning the result as a `(key, value)` tuple.
@@ -75,15 +89,15 @@ pub fn parse_assignment(arguments: &str) -> Binding {
     if !found_key && key.is_empty() {
         Binding::ListEntries
     } else {
-        let value = char_iter.skip_while(|&x| x == ' ').collect::<String>();
+        let value = char_iter.skip_while(|&x| x == ' ').collect::<VString>();
         if value.is_empty() {
-            Binding::KeyOnly(key)
+            Binding::KeyOnly(key.into())
         } else if !Variables::is_valid_variable_name(&key) {
-            Binding::InvalidKey(key)
+            Binding::InvalidKey(key.into())
         } else {
             match operator {
-                Some(operator) => Binding::Math(key, operator, value),
-                None => Binding::KeyValue(key, value)
+                Some(operator) => Binding::Math(key.into(), operator, value),
+                None => Binding::KeyValue(key.into(), value)
             }
         }
     }

--- a/src/parser/grammar.rustpeg
+++ b/src/parser/grammar.rustpeg
@@ -74,30 +74,30 @@ end_ -> Statement
 fn_ -> Statement
     = whitespace* "fn " n:_name whitespace* args:_args whitespace* description:_description? {
         Statement::Function {
-            description: description.unwrap_or("".to_string()),
-            name: n.to_string(),
+            description: description.unwrap_or("".into()),
+            name: n.into(),
             args: args,
             statements: Vec::new(),
         }
     }
 
 _description -> String
-      = "--" whitespace* description:$([^\r\n]*) { description.to_string() }
+      = "--" whitespace* description:$([^\r\n]*) { description.into() }
 
 _name -> String
-      = n:$([A-z0-9_]+) { n.to_string() }
+      = n:$([A-z0-9_]+) { n.into() }
 
 _args -> Vec<String>
       = _arg ** " "
 
 _arg -> String
-     = n:$([A-z0-9]+) { n.to_string() }
+     = n:$([A-z0-9]+) { n.into() }
 
 #[pub]
 for_ -> Statement
     = whitespace* "for" whitespace? n:_name whitespace? "in" whitespace? expr:$(.*) {
         Statement::For {
-            variable: n.to_string(),
+            variable: n.into(),
             values: ArgumentSplitter::new(expr).map(String::from).collect(),
             statements: Vec::new(),
         }

--- a/src/parser/loops/for_grammar.rs
+++ b/src/parser/loops/for_grammar.rs
@@ -1,17 +1,18 @@
 use shell::directory_stack::DirectoryStack;
 use shell::variables::Variables;
+use types::Value;
 use parser::{expand_string, ExpanderFunctions, Index, IndexEnd};
 
 #[derive(Debug, PartialEq)]
 pub enum ForExpression {
-    Multiple(Vec<String>),
-    Normal(String),
+    Multiple(Vec<Value>),
+    Normal(Value),
     Range(usize, usize)
 }
 
 impl ForExpression {
     pub fn new(expression: &[String], dir_stack: &DirectoryStack, variables: &Variables) -> ForExpression {
-        let output: Vec<String> = expression.iter()
+        let output: Vec<_> = expression.iter()
             .flat_map(|expression| expand_string(expression, &get_expanders!(variables, dir_stack), true))
             .collect();
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4,17 +4,22 @@ macro_rules! get_expanders {
         ExpanderFunctions {
             tilde: &|tilde: &str| $vars.tilde_expansion(tilde, $dir_stack),
             array: &|array: &str, index: Index| {
+                use std::iter::FromIterator;
+                use $crate::types::*;
+
                 match $vars.get_array(array) {
                     Some(array) => match index {
                         Index::None   => None,
-                        Index::All    => Some(array.to_owned()),
-                        Index::ID(id) => array.get(id).map(|x| vec![x.to_owned()]),
+                        Index::All    => Some(array.clone()),
+                        Index::ID(id) => array.get(id).map(
+                            |x| Array::from_iter(Some(x.to_owned()))
+                        ),
                         Index::Range(start, end) => {
-                            let array = match end {
+                            let array: Array = match end {
                                 IndexEnd::CatchAll => array.iter().skip(start)
-                                    .map(|x| x.to_owned()).collect::<Vec<String>>(),
+                                    .map(|x| x.to_owned()).collect::<_>(),
                                 IndexEnd::ID(end) => array.iter().skip(start).take(end-start)
-                                    .map(|x| x.to_owned()).collect::<Vec<String>>()
+                                    .map(|x| x.to_owned()).collect::<_>()
                             };
                             if array.is_empty() { None } else { Some(array) }
                         }
@@ -23,7 +28,13 @@ macro_rules! get_expanders {
                 }
             },
             variable: &|variable: &str, quoted: bool| {
-                if quoted { $vars.get_var(variable) } else { $vars.get_var(variable).map(|x| x.replace("\n", " ")) }
+                use ascii_helpers::AsciiReplace;
+                if quoted {
+                    $vars.get_var(variable)
+                } else {
+                    $vars.get_var(variable)
+                        .map(|x| x.ascii_replace('\n', ' ').into())
+                }
             },
             command: &|command: &str, quoted: bool| $vars.command_expansion(command, quoted),
         }

--- a/src/parser/peg.rs
+++ b/src/parser/peg.rs
@@ -130,7 +130,12 @@ else
         let correct_parse = Statement::If {
             expression: Pipeline::new(
                 vec!(Job::new(
-                    vec!("test".to_owned(), "1".to_owned(), "-eq".to_owned(), "2".to_owned()), JobKind::Last)
+                    vec![
+                        "test".to_owned(),
+                        "1".to_owned(),
+                        "-eq".to_owned(),
+                        "2".to_owned(),
+                    ].into_iter().collect(), JobKind::Last)
                 ), None, None),
             success: vec!(),
             else_if: vec!(),
@@ -184,10 +189,10 @@ else
         // Default case where spaced normally
         let parsed_if = fn_("fn bob").unwrap();
         let correct_parse = Statement::Function{
-            description: "".to_string(),
-            name:        "bob".to_string(),
-            args:        vec!(),
-            statements:  vec!()
+            description: "".into(),
+            name:        "bob".into(),
+            args:        Default::default(),
+            statements:  Default::default(),
         };
         assert_eq!(correct_parse, parsed_if);
 
@@ -202,10 +207,10 @@ else
         // Default case where spaced normally
         let parsed_if = fn_("fn bob a b").unwrap();
         let correct_parse = Statement::Function{
-            description: "".to_string(),
-            name:        "bob".to_owned(),
-            args:        vec!("a".to_owned(), "b".to_owned()),
-            statements:  vec!()
+            description: "".into(),
+            name:        "bob".into(),
+            args:        vec!["a".to_owned(), "b".to_owned()],
+            statements:  Default::default(),
         };
         assert_eq!(correct_parse, parsed_if);
 
@@ -220,7 +225,7 @@ else
         let parsed_if = fn_("fn bob a b --bob is a nice function").unwrap();
         let correct_parse = Statement::Function{
             description: "bob is a nice function".to_string(),
-            name:        "bob".to_owned(),
+            name:        "bob".into(),
             args:        vec!("a".to_owned(), "b".to_owned()),
             statements:  vec!()
         };

--- a/src/shell/flow.rs
+++ b/src/shell/flow.rs
@@ -226,12 +226,12 @@ impl<'a> FlowLogic for Shell<'a> {
         let ignore_variable = variable == "_";
         match ForExpression::new(values, &self.directory_stack, &self.variables) {
             ForExpression::Multiple(ref values) if ignore_variable => {
-                for _ in values.iter().flat_map(|x| glob_expand(x.as_str())) {
+                for _ in values.iter().flat_map(|x| glob_expand(&x)) {
                     if let Condition::Break = self.execute_statements(statements.clone()) { break }
                 }
             },
             ForExpression::Multiple(values) => {
-                for value in values.iter().flat_map(|x| glob_expand(x.as_str())) {
+                for value in values.iter().flat_map(|x| glob_expand(&x)) {
                     self.variables.set_var(variable, &value);
                     if let Condition::Break = self.execute_statements(statements.clone()) { break }
                 }

--- a/src/shell/flow_control.rs
+++ b/src/shell/flow_control.rs
@@ -1,3 +1,4 @@
+use types::Identifier;
 use parser::peg::Pipeline;
 use parser::assignments::Binding;
 
@@ -20,13 +21,13 @@ pub enum Statement {
     },
     ElseIf(ElseIf),
     Function {
-        name: String,
+        name: Identifier,
         description: String,
         args: Vec<String>,
         statements: Vec<Statement>
     },
     For {
-        variable: String,
+        variable: Identifier,
         values: Vec<String>,
         statements: Vec<Statement>
     },
@@ -61,7 +62,7 @@ impl Default for FlowControl {
 #[derive(Clone)]
 pub struct Function {
     pub description: String,
-    pub name: String,
+    pub name: Identifier,
     pub args: Vec<String>,
     pub statements: Vec<Statement>
 }

--- a/src/shell/history.rs
+++ b/src/shell/history.rs
@@ -5,7 +5,7 @@ use super::Shell;
 /// Contains all history-related functionality for the `Shell`.
 pub trait ShellHistory {
     /// Prints the commands contained within the history buffers to standard output.
-    fn print_history(&self, _arguments: &[String]) -> i32;
+    fn print_history(&self, _arguments: &[&str]) -> i32;
 
     /// Sets the history size for the shell context equal to the HISTORY_SIZE shell variable if it
     /// is set otherwise to a default value (1000).
@@ -21,7 +21,7 @@ pub trait ShellHistory {
 }
 
 impl<'a> ShellHistory for Shell<'a> {
-    fn print_history(&self, _arguments: &[String]) -> i32 {
+    fn print_history(&self, _arguments: &[&str]) -> i32 {
         let mut buffer = Vec::with_capacity(8*1024);
         for command in &self.context.history.buffers {
             let _ = writeln!(buffer, "{}", command);
@@ -40,9 +40,9 @@ impl<'a> ShellHistory for Shell<'a> {
 
         self.context.history.set_max_size(max_history_size);
 
-        if self.variables.get_var_or_empty("HISTORY_FILE_ENABLED") == "1" {
+        if &*self.variables.get_var_or_empty("HISTORY_FILE_ENABLED") == "1" {
             let file_name = self.variables.get_var("HISTORY_FILE");
-            self.context.history.set_file_name(file_name);
+            self.context.history.set_file_name(file_name.map(|f| f.into()));
 
             let max_history_file_size = self.variables
                 .get_var_or_empty("HISTORY_FILE_SIZE")

--- a/src/shell/job.rs
+++ b/src/shell/job.rs
@@ -3,20 +3,22 @@ use std::process::Command;
 use glob::glob;
 use parser::{expand_string, ExpanderFunctions};
 use parser::peg::RedirectFrom;
+use smallstring::SmallString;
+use types::*;
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum JobKind { And, Background, Last, Or, Pipe(RedirectFrom) }
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Job {
-    pub command: String,
-    pub args: Vec<String>,
+    pub command: Identifier,
+    pub args: Array,
     pub kind: JobKind,
 }
 
 impl Job {
-    pub fn new(args: Vec<String>, kind: JobKind) -> Self {
-        let command = args[0].clone();
+    pub fn new(args: Array, kind: JobKind) -> Self {
+        let command = SmallString::from_str(&args[0]);
         Job {
             command: command,
             args: args,
@@ -27,15 +29,25 @@ impl Job {
     /// Takes the current job's arguments and expands them, one argument at a
     /// time, returning a new `Job` with the expanded arguments.
     pub fn expand(&mut self, expanders: &ExpanderFunctions) {
-        let mut expanded: Vec<String> = Vec::with_capacity(self.args.len());
+        use smallvec::SmallVec;
+
+        let mut expanded = SmallVec::new();
+        expanded.grow(self.args.len());
         {
-            let mut iterator = self.args.drain(..);
+            let mut iterator = self.args.drain();
             expanded.push(iterator.next().unwrap());
             for arg in iterator.flat_map(|argument| expand_string(&argument, expanders, false)) {
                 if arg.contains(|chr| chr == '?' || chr == '*' || chr == '[') {
                     if let Ok(glob) = glob(&arg) {
+                        use std::borrow::Cow;
+                        
                         for path in glob.filter_map(Result::ok) {
-                            expanded.push(path.to_string_lossy().into_owned());
+                            expanded.push(
+                                match path.to_string_lossy() {
+                                    Cow::Owned(s) => s.into(),
+                                    Cow::Borrowed(s) => s.into(),
+                                }
+                            );
                             continue
                         }
                     }
@@ -48,21 +60,21 @@ impl Job {
     }
 
     pub fn build_command(&mut self) -> Command {
-        match CommandType::from(self.command.as_str()) {
+        match CommandType::from(self.command.as_ref()) {
             CommandType::Builtin => {
                 use std::env;
                 let process = env::current_exe().unwrap();
                 let mut command = Command::new(process);
                 command.arg("-c");
                 command.arg(&self.command);
-                for arg in self.args.drain(..).skip(1) {
+                for arg in self.args.drain().skip(1) {
                     command.arg(arg);
                 }
                 command
             },
             CommandType::External => {
                 let mut command = Command::new(&self.command);
-                for arg in self.args.drain(..).skip(1) {
+                for arg in self.args.drain().skip(1) {
                     command.arg(arg);
                 }
                 command

--- a/src/smallstring/Cargo.toml
+++ b/src/smallstring/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "smallstring"
+version = "0.1.0"
+authors = ["Jack Fransham <moonfudgeman@hotmail.co.uk>"]
+
+[dependencies]
+smallvec = "*"

--- a/src/smallstring/src/lib.rs
+++ b/src/smallstring/src/lib.rs
@@ -1,0 +1,188 @@
+#![feature(str_mut_extras)]
+extern crate smallvec;
+
+use std::str;
+use std::ffi::OsStr;
+use std::ops::Deref;
+use std::borrow::Borrow;
+use std::iter::{FromIterator, IntoIterator};
+use smallvec::{Array, SmallVec};
+
+// TODO: FromIterator without having to allocate a String
+#[derive(Clone, Default)]
+pub struct SmallString<B: Array<Item=u8> = [u8; 8]> {
+    buffer: SmallVec<B>,
+}
+
+impl<B: Array<Item=u8>> std::hash::Hash for SmallString<B> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        let s: &str = self;
+        s.hash(state)
+    }
+}
+
+impl<B: Array<Item=u8>> std::cmp::PartialEq for SmallString<B> {
+    fn eq(&self, other: &Self) -> bool {
+        let (s1, s2): (&str, &str) = (self, other);
+        s1 == s2
+    }
+}
+
+impl<B: Array<Item=u8>> std::cmp::Eq for SmallString<B> {}
+
+impl<'a, B: Array<Item=u8>> PartialEq<SmallString<B>> for &'a str {
+    fn eq(&self, other: &SmallString<B>) -> bool {
+        *self == (other as &str)
+    }
+}
+
+impl<B: Array<Item=u8>> std::fmt::Display for SmallString<B> {
+    fn fmt(&self, fm: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        let s: &str = SmallString::deref(self);
+        s.fmt(fm)
+    }
+}
+
+impl<B: Array<Item=u8>> std::fmt::Debug for SmallString<B> {
+    fn fmt(&self, fm: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let s: &str = SmallString::deref(self);
+        s.fmt(fm)
+    }
+}
+
+impl<B: Array<Item=u8>> SmallString<B> {
+    pub fn from_str(s: &str) -> Self {
+        SmallString {
+            buffer: s.as_bytes().into_iter()
+                .cloned()
+                .collect(),
+        }
+    }
+}
+
+impl<'a, B: Array<Item=u8>> From<&'a str> for SmallString<B> {
+    fn from(s: &str) -> Self {
+        Self::from_str(s)
+    }
+}
+
+impl<B: Array<Item=u8>> Deref for SmallString<B> {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        // We only allow `buffer` to be created from an existing valid string,
+        // so this is safe.
+        unsafe {
+            str::from_utf8_unchecked(self.buffer.as_ref())
+        }
+    }
+}
+
+impl AsRef<str> for SmallString {
+    fn as_ref(&self) -> &str {
+        // We only allow `buffer` to be created from an existing valid string,
+        // so this is safe.
+        unsafe {
+            str::from_utf8_unchecked(self.buffer.as_ref())
+        }
+    }
+}
+
+struct Utf8Iterator<I>(I, Option<smallvec::IntoIter<[u8; 4]>>);
+
+impl<I: Iterator<Item=char>> Utf8Iterator<I> {
+    pub fn new<In: IntoIterator<IntoIter=I, Item=char>>(into: In) -> Self {
+        Utf8Iterator(into.into_iter(), None)
+    }
+}
+
+impl<I: Iterator<Item=char>> Iterator for Utf8Iterator<I> {
+    type Item = u8;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(mut into) = self.1.take() {
+            if let Some(n) = into.next() {
+                self.1 = Some(into);
+                return Some(n);
+            }
+        }
+
+        let out = self.0.next();
+
+        out.and_then(|chr| {
+            let mut dest = [0u8; 4];
+            let outstr = chr.encode_utf8(&mut dest);
+
+            self.1 = Some(
+                outstr.as_bytes()
+                    .into_iter()
+                    .cloned()
+                    .collect::<SmallVec<[u8; 4]>>()
+                    .into_iter()
+            );
+
+            self.1.as_mut().and_then(|i| i.next())
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let hint = self.0.size_hint();
+
+        (hint.0, hint.1.map(|x| x * 4))
+    }
+}
+
+impl FromIterator<char> for SmallString {
+    fn from_iter<T: IntoIterator<Item=char>>(into_iter: T) -> Self {
+        // We're a shell so we mostly work with ASCII data - optimise for this
+        // case since we have to optimise for _some_ fixed size of char.
+        let utf8 = Utf8Iterator::new(into_iter);
+
+        SmallString {
+            buffer: utf8.collect(),
+        }
+    }
+}
+
+impl AsMut<str> for SmallString {
+    fn as_mut(&mut self) -> &mut str {
+        // We only allow `buffer` to be created from an existing valid string,
+        // so this is safe.
+        unsafe {
+            str::from_utf8_unchecked_mut(self.buffer.as_mut())
+        }
+    }
+}
+
+impl AsRef<OsStr> for SmallString {
+    fn as_ref(&self) -> &OsStr {
+        let s: &str = self.as_ref();
+        s.as_ref()
+    }
+}
+
+impl Borrow<str> for SmallString {
+    fn borrow(&self) -> &str {
+        // We only allow `buffer` to be created from an existing valid string,
+        // so this is safe.
+        unsafe {
+            str::from_utf8_unchecked(self.buffer.as_ref())
+        }
+    }
+}
+
+impl From<String> for SmallString {
+    fn from(s: String) -> SmallString {
+        SmallString {
+            buffer: SmallVec::from_vec(s.into_bytes()),
+        }
+    }
+}
+
+impl From<SmallString> for String {
+    fn from(s: SmallString) -> String {
+        unsafe {
+            String::from_utf8_unchecked(s.buffer.into_vec())
+        }
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,9 @@
+use smallvec::SmallVec;
+use fnv::FnvHashMap;
+use smallstring::SmallString;
+
+pub type Array = SmallVec<[Value; 4]>;
+pub type Identifier = SmallString;
+pub type Value = String;
+pub type VariableContext = FnvHashMap<Identifier, Value>;
+pub type ArrayVariableContext = FnvHashMap<Identifier, Array>;


### PR DESCRIPTION
**Problem**: [describe the problem you try to solve with this PR.]

We allocate a lot

**Solution**: [describe carefully what you change by this PR.]

Use `SmallVec` and `SmallString` (based on `SmallVec`) to allow small vectors and strings to be stored on the stack.

**Changes introduced by this pull request**:

Some public API functions that took `String`s take `SmallString`s now. Also, it's now even faster on my machine.

- [...]
- [...]
- [...]

**Drawbacks**: [if any, describe the drawbacks of this pull request.]

**TODOs**: [what is not done yet.]

Clean up the code, unify the methods of creating a singleton smallvec (probably with a macro), move the typedefs to a `types` module.

**Fixes**: [what issues this fixes.]

**State**: [the state of this PR, e.g. WIP, ready, etc.]

WIP

**Blocking/related**: [issues or PRs blocking or being related to this issue.]

**Other**: [optional: for other relevant information that should be known or cannot be described in the other fields.]

------

_The above template is not necessary for smaller PRs._
