### PR TITLE
Add LTO and panic=abort for ~15% speedup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,4 +37,5 @@ version_check = "0.1"
 [profile.release]
 # debug = true
 # rustflags = [ "-C", "target-cpu=native"]
-# lto = true
+lto = true
+panic = "abort"


### PR DESCRIPTION
**Problem**: [describe the problem you try to solve with this PR.]

Ion still takes literally any time to run

**Solution**: [describe carefully what you change by this PR.]

Add LTO and panic=abort. Unfortunately, this still causes Ion to take some time to run, but it's 15% closer to the eventual goal of completing instantly.

**Changes introduced by this pull request**:

- [...]
- [...]
- [...]

**Drawbacks**: [if any, describe the drawbacks of this pull request.]

**TODOs**: [what is not done yet.]

**Fixes**: [what issues this fixes.]

**State**: [the state of this PR, e.g. WIP, ready, etc.]

**Blocking/related**: [issues or PRs blocking or being related to this issue.]

**Other**: [optional: for other relevant information that should be known or cannot be described in the other fields.]

LTO gives ~10% speedup, panic=abort another 5%

------

_The above template is not necessary for smaller PRs._
