### PR TITLE
change shebang of run_examples.sh to make the script to be ran on both Linux or BSD

### DIFF
--- a/examples/run_examples.sh
+++ b/examples/run_examples.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
This commit is for the discussion of issue [#952](https://github.com/redox-os/redox/issues/952) of `redox` repository.
This change is very similar to https://github.com/redox-os/libc-artifacts/pull/7.