### PR TITLE
Correctly parse statements with multiple escaped characters

### DIFF
--- a/src/parser/shell_expand/words.rs
+++ b/src/parser/shell_expand/words.rs
@@ -932,4 +932,19 @@ mod tests {
         ];
         compare(input, expected);
     }
+
+    #[test]
+    fn test_multiple_escapes() {
+        let input = "foo\\(\\) bar\\(\\)";
+        let expected = vec![
+            WordToken::Normal("foo"),
+            WordToken::Normal("("),
+            WordToken::Normal(")"),
+            WordToken::Whitespace(" "),
+            WordToken::Normal("bar"),
+            WordToken::Normal("("),
+            WordToken::Normal(")"),
+        ];
+        compare(input, expected);
+    }
 }

--- a/src/parser/shell_expand/words.rs
+++ b/src/parser/shell_expand/words.rs
@@ -655,7 +655,11 @@ impl<'a> Iterator for WordIterator<'a> {
         loop {
             if let Some(character) = iterator.next() {
                 match character {
-                    _ if self.flags & BACKSL != 0 => { self.read += 1; break },
+                    _ if self.flags & BACKSL != 0 => {
+                        self.read += 1;
+                        self.flags ^= BACKSL;
+                        break
+                    },
                     b'\\' => {
                         start += 1;
                         self.read += 1;


### PR DESCRIPTION
**Problem**: Statements such as `foo\(\)` were not being correctly parsed, see #291.

**Solution**: Whenever a character is read by a `WordIterator` when the `BACKSL` flag is set, the flag gets unset.

**Changes introduced by this pull request**:
- Backslash flag now reset upon reading the escaped character
- Add regression test for multiple backslashes

**Drawbacks**:
- It could use some more tests for these sorts of use cases
- It is unclear if this affects the other uses of the `WordIterator` beyond parsing command line statements.

**Fixes**: Resolves #291.
**State**: Ready with the caveat of adding more unit / regression tests, also formatting and such.