### PR TITLE
Moving the glob parser

### DIFF
--- a/examples/glob.ion
+++ b/examples/glob.ion
@@ -1,0 +1,8 @@
+echo *argo.toml
+echo examples/br*.*
+echo [A-Z]argo.toml
+echo ?argo.toml
+echo Cargo.*
+echo Cargo?toml
+echo Cargo.[tqr]oml
+echo examples/[ef]*.ion

--- a/examples/glob.out
+++ b/examples/glob.out
@@ -1,0 +1,8 @@
+Cargo.toml
+examples/braces.ion examples/braces.out examples/break.ion examples/break.out
+Cargo.toml
+Cargo.toml
+Cargo.lock Cargo.toml
+Cargo.toml
+Cargo.toml
+examples/else_if.ion examples/fail.ion examples/fibonacci.ion examples/fn.ion examples/for.ion

--- a/src/parser/shell_expand/mod.rs
+++ b/src/parser/shell_expand/mod.rs
@@ -146,7 +146,7 @@ pub fn expand_tokens<'a>(token_buffer: &[WordToken], expand_func: &'a ExpanderFu
 {
     let mut output = String::new();
     let mut expanded_words = Array::new();
-    //let mut is_glob = false;
+    let mut is_glob = false;
     if !token_buffer.is_empty() {
         if contains_brace {
             let mut tokens: Vec<BraceToken> = Vec::new();
@@ -245,11 +245,8 @@ pub fn expand_tokens<'a>(token_buffer: &[WordToken], expand_func: &'a ExpanderFu
                     WordToken::Normal(text,true) => {
                         let globbed = glob(text);
                         if let Ok(var)=globbed{
-                            //is_glob=true;
                             for path in var.filter_map(Result::ok) {
-                                println!("Debug! : {}",path.to_string_lossy());
-                                println!("Debug! : {}",output);
-                                output.push_str(&path.to_string_lossy());
+                                expanded_words.push(path.to_string_lossy().into_owned());
                             }
                         }
                     },
@@ -408,11 +405,10 @@ pub fn expand_tokens<'a>(token_buffer: &[WordToken], expand_func: &'a ExpanderFu
                 WordToken::Normal(text,true) => {
                     let globbed = glob(text);
                     if let Ok(var)=globbed{
-                        //is_glob=true;
+                        is_glob=true;
                         for path in var.filter_map(Result::ok) {
-                            println!("Debug! : {}",path.to_string_lossy());
-                            println!("Debug! : {}",output);
-                            output.push_str(&path.to_string_lossy());
+                            expanded_words.push(path.to_string_lossy().into_owned());
+
                         }
                     }
                 },
@@ -433,24 +429,12 @@ pub fn expand_tokens<'a>(token_buffer: &[WordToken], expand_func: &'a ExpanderFu
 
                     slice_string(&mut output, &expanded, index);
                 },
-                /*WordToken::Glob(text) => {
-                    //println!("Gotten into glob mod.rs, text:{}",text);
-                    let globbed = glob(text);
-                    if let Ok(var)=globbed{
-                        //println!("Entered if let");
-                        is_glob=true;
-                        for path in var.filter_map(Result::ok) {
-                            expanded_words.push(path.to_string_lossy().into_owned());
-
-                        }
-                    }
-                }*/
             }
         }
         //the is_glob variable can probably be removed, I'm not entirely sure if empty strings are valid in any case- maarten
-        //if !(is_glob && output == "") {
+        if !(is_glob && output == "") {
             expanded_words.push(output.into());
-        //}
+        }
     }
 
     expanded_words

--- a/src/parser/shell_expand/mod.rs
+++ b/src/parser/shell_expand/mod.rs
@@ -146,7 +146,7 @@ pub fn expand_tokens<'a>(token_buffer: &[WordToken], expand_func: &'a ExpanderFu
 {
     let mut output = String::new();
     let mut expanded_words = Array::new();
-    let mut is_glob = false;
+    //let mut is_glob = false;
     if !token_buffer.is_empty() {
         if contains_brace {
             let mut tokens: Vec<BraceToken> = Vec::new();
@@ -223,7 +223,7 @@ pub fn expand_tokens<'a>(token_buffer: &[WordToken], expand_func: &'a ExpanderFu
                     },
                     WordToken::Brace(ref nodes) =>
                         expand_brace(&mut output, &mut expanders, &mut tokens, nodes, expand_func, reverse_quoting),
-                    WordToken::Normal(text) => output.push_str(text),
+                    WordToken::Normal(text,false) => output.push_str(text),
                     WordToken::Whitespace(_) => unreachable!(),
                     WordToken::Tilde(text) => output.push_str(match (expand_func.tilde)(text) {
                         Some(ref expanded) => expanded,
@@ -242,10 +242,13 @@ pub fn expand_tokens<'a>(token_buffer: &[WordToken], expand_func: &'a ExpanderFu
 
                         slice_string(&mut output, &expanded, index);
                     },
-                    WordToken::Glob(text) => {
+                    WordToken::Normal(text,true) => {
                         let globbed = glob(text);
                         if let Ok(var)=globbed{
+                            //is_glob=true;
                             for path in var.filter_map(Result::ok) {
+                                println!("Debug! : {}",path.to_string_lossy());
+                                println!("Debug! : {}",output);
                                 output.push_str(&path.to_string_lossy());
                             }
                         }
@@ -399,8 +402,19 @@ pub fn expand_tokens<'a>(token_buffer: &[WordToken], expand_func: &'a ExpanderFu
                     }
                 },
                 WordToken::Brace(_) => unreachable!(),
-                WordToken::Normal(text) | WordToken::Whitespace(text) => {
+                WordToken::Normal(text,false) | WordToken::Whitespace(text) => {
                     output.push_str(text);
+                },
+                WordToken::Normal(text,true) => {
+                    let globbed = glob(text);
+                    if let Ok(var)=globbed{
+                        //is_glob=true;
+                        for path in var.filter_map(Result::ok) {
+                            println!("Debug! : {}",path.to_string_lossy());
+                            println!("Debug! : {}",output);
+                            output.push_str(&path.to_string_lossy());
+                        }
+                    }
                 },
                 WordToken::Process(command, quoted, index) => {
                     let quoted = if reverse_quoting { !quoted } else { quoted };
@@ -419,7 +433,7 @@ pub fn expand_tokens<'a>(token_buffer: &[WordToken], expand_func: &'a ExpanderFu
 
                     slice_string(&mut output, &expanded, index);
                 },
-                WordToken::Glob(text) => {
+                /*WordToken::Glob(text) => {
                     //println!("Gotten into glob mod.rs, text:{}",text);
                     let globbed = glob(text);
                     if let Ok(var)=globbed{
@@ -430,13 +444,13 @@ pub fn expand_tokens<'a>(token_buffer: &[WordToken], expand_func: &'a ExpanderFu
 
                         }
                     }
-                }
+                }*/
             }
         }
         //the is_glob variable can probably be removed, I'm not entirely sure if empty strings are valid in any case- maarten
-        if !(is_glob && output == "") {
+        //if !(is_glob && output == "") {
             expanded_words.push(output.into());
-        }
+        //}
     }
 
     expanded_words

--- a/src/parser/shell_expand/mod.rs
+++ b/src/parser/shell_expand/mod.rs
@@ -243,6 +243,7 @@ pub fn expand_tokens<'a>(token_buffer: &[WordToken], expand_func: &'a ExpanderFu
                         slice_string(&mut output, &expanded, index);
                     },
                     WordToken::Normal(text,true) => {
+                        //if this is a normal string that can be globbed, do it!
                         let globbed = glob(text);
                         if let Ok(var)=globbed{
                             for path in var.filter_map(Result::ok) {
@@ -403,7 +404,8 @@ pub fn expand_tokens<'a>(token_buffer: &[WordToken], expand_func: &'a ExpanderFu
                     output.push_str(text);
                 },
                 WordToken::Normal(text,true) => {
-                    let globbed = glob(text);                    
+                    //if this is a normal string that can be globbed, do it!
+                    let globbed = glob(text);
                     if let Ok(var)=globbed{
                         is_glob=true;
                         for path in var.filter_map(Result::ok) {

--- a/src/parser/shell_expand/mod.rs
+++ b/src/parser/shell_expand/mod.rs
@@ -244,7 +244,9 @@ pub fn expand_tokens<'a>(token_buffer: &[WordToken], expand_func: &'a ExpanderFu
                     },
                     WordToken::Normal(text,true) => {
                         let globbed = glob(text);
+                        println!("Gotten into mod/247");
                         if let Ok(var)=globbed{
+                            println!("Gotten into mod/249");
                             for path in var.filter_map(Result::ok) {
                                 expanded_words.push(path.to_string_lossy().into_owned());
                             }

--- a/src/parser/shell_expand/mod.rs
+++ b/src/parser/shell_expand/mod.rs
@@ -244,9 +244,7 @@ pub fn expand_tokens<'a>(token_buffer: &[WordToken], expand_func: &'a ExpanderFu
                     },
                     WordToken::Normal(text,true) => {
                         let globbed = glob(text);
-                        println!("Gotten into mod/247");
                         if let Ok(var)=globbed{
-                            println!("Gotten into mod/249");
                             for path in var.filter_map(Result::ok) {
                                 expanded_words.push(path.to_string_lossy().into_owned());
                             }
@@ -405,7 +403,7 @@ pub fn expand_tokens<'a>(token_buffer: &[WordToken], expand_func: &'a ExpanderFu
                     output.push_str(text);
                 },
                 WordToken::Normal(text,true) => {
-                    let globbed = glob(text);
+                    let globbed = glob(text);                    
                     if let Ok(var)=globbed{
                         is_glob=true;
                         for path in var.filter_map(Result::ok) {

--- a/src/parser/shell_expand/mod.rs
+++ b/src/parser/shell_expand/mod.rs
@@ -8,7 +8,7 @@ use types::Array;
 mod braces;
 mod ranges;
 mod words;
-
+use glob::glob;
 use self::braces::BraceToken;
 use self::ranges::parse_range;
 pub use self::words::{WordIterator, WordToken};
@@ -242,6 +242,14 @@ pub fn expand_tokens<'a>(token_buffer: &[WordToken], expand_func: &'a ExpanderFu
 
                         slice_string(&mut output, &expanded, index);
                     },
+                    WordToken::Glob(text) => {
+                        let globbed = glob(text);
+                        if let Ok(var)=globbed{
+                            for path in var.filter_map(Result::ok) {
+                                output.push_str(&path.to_string_lossy());
+                            }
+                        }
+                    },
                 }
             }
 
@@ -411,6 +419,21 @@ pub fn expand_tokens<'a>(token_buffer: &[WordToken], expand_func: &'a ExpanderFu
 
                     slice_string(&mut output, &expanded, index);
                 },
+                WordToken::Glob(text) => {
+                    //println!("Gotten into glob mod.rs, text:{}",text);
+                    let globbed = glob(text);
+                    if let Ok(var)=globbed{
+                        //println!("Entered if let");
+                        for path in var.filter_map(Result::ok) {
+                            /*println!("A path: {}",path.to_string_lossy());
+                            println!("Output: {}",output);*/
+                            output.push_str(&path.to_string_lossy());
+                        }
+                    }
+                    else{
+                        //println!("Globbing failed");
+                    }
+                }
             }
         }
 

--- a/src/parser/shell_expand/mod.rs
+++ b/src/parser/shell_expand/mod.rs
@@ -146,7 +146,7 @@ pub fn expand_tokens<'a>(token_buffer: &[WordToken], expand_func: &'a ExpanderFu
 {
     let mut output = String::new();
     let mut expanded_words = Array::new();
-
+    let mut is_glob = false;
     if !token_buffer.is_empty() {
         if contains_brace {
             let mut tokens: Vec<BraceToken> = Vec::new();
@@ -424,20 +424,19 @@ pub fn expand_tokens<'a>(token_buffer: &[WordToken], expand_func: &'a ExpanderFu
                     let globbed = glob(text);
                     if let Ok(var)=globbed{
                         //println!("Entered if let");
+                        is_glob=true;
                         for path in var.filter_map(Result::ok) {
-                            /*println!("A path: {}",path.to_string_lossy());
-                            println!("Output: {}",output);*/
-                            output.push_str(&path.to_string_lossy());
+                            expanded_words.push(path.to_string_lossy().into_owned());
+
                         }
-                    }
-                    else{
-                        //println!("Globbing failed");
                     }
                 }
             }
         }
-
-        expanded_words.push(output.into());
+        //the is_glob variable can probably be removed, I'm not entirely sure if empty strings are valid in any case- maarten
+        if !(is_glob && output == "") {
+            expanded_words.push(output.into());
+        }
     }
 
     expanded_words

--- a/src/parser/shell_expand/words.rs
+++ b/src/parser/shell_expand/words.rs
@@ -705,6 +705,7 @@ impl<'a> Iterator for WordIterator<'a> {
                         let mut rewind = true;
                         let mut iter = iterator.clone();
                         while let Some(character) = iter.next() {
+                            moves+=1;
                             match character
                             {
                                 b'[' => {
@@ -714,23 +715,21 @@ impl<'a> Iterator for WordIterator<'a> {
                                     break;
                                 },
                                 b']' => {
-                                    if moves<=2 && square_bracket == 1 {
+                                    if moves<=3 && square_bracket == 1 {
                                     }
                                     else{
                                         rewind = false;
-                                        moves+=1;
                                         break;
                                     }
                                 }
                                 _=> (),
                             }
-                            moves+=1;
                         }
                         if rewind == false{
                             for _ in 0..moves {
                                 iterator.next();
                             }
-                            self.read+=moves;
+                            self.read+=moves+1;
                             glob = true;
                             break;
                         }
@@ -830,6 +829,7 @@ impl<'a> Iterator for WordIterator<'a> {
                     let mut rewind = true;
                     let mut iter = iterator.clone();
                     while let Some(character) = iter.next() {
+                        moves+=1;
                         match character
                         {
                             b'[' => {
@@ -839,24 +839,21 @@ impl<'a> Iterator for WordIterator<'a> {
                                 break;
                             },
                             b']' => {
-                                if moves<=2 && square_bracket == 1 {
-                                    break;
+                                if moves<=3 && square_bracket == 1 {
                                 }
                                 else{
-                                    moves+=1;
                                     rewind = false;
                                     break;
                                 }
                             }
                             _=> (),
                         }
-                        moves+=1;
                     }
                     if rewind == false{
                         for _ in 0..moves {
                             iterator.next();
                         }
-                        self.read+=moves;
+                        self.read+=moves+1;
                         glob = true;
                     }
                     else {

--- a/src/parser/shell_expand/words.rs
+++ b/src/parser/shell_expand/words.rs
@@ -700,6 +700,8 @@ impl<'a> Iterator for WordIterator<'a> {
                         return Some(self.braces(&mut iterator));
                     },
                     b'[' if self.flags & SQUOTE == 0 => {
+                        //we peek into the future of the iterator by copying it and checking if any illegal characters get found before we hit the next ]
+                        //there might be more illegal characters or less, I don't know
                         let mut moves = 0;
                         let mut square_bracket= 0;
                         let mut rewind = true;
@@ -715,6 +717,8 @@ impl<'a> Iterator for WordIterator<'a> {
                                     break;
                                 },
                                 b']' => {
+                                    //we ignore the glob if it's smaller than 3, because [a] is a valid wild card and array
+                                    //but the array meaning interpreted as a glob would actually be correct, whilst vice versa it wouldnt
                                     if moves<=3 && square_bracket == 1 {
                                     }
                                     else{
@@ -783,6 +787,7 @@ impl<'a> Iterator for WordIterator<'a> {
                         }
                     },
                     b'*'|b'?' => {
+                        // if a word is not special, make sure you return the globbed variant at the end
                         self.read+=1;
                         glob=true; //warning is incorrect it does get read
                     },
@@ -839,6 +844,8 @@ impl<'a> Iterator for WordIterator<'a> {
                                 break;
                             },
                             b']' => {
+                                //we ignore the glob if it's smaller than 3, because [a] is a valid wild card and array
+                                //but the array meaning interpreted as a glob would actually be correct, whilst vice versa it wouldnt   
                                 if moves<=3 && square_bracket == 1 {
                                 }
                                 else{
@@ -861,6 +868,7 @@ impl<'a> Iterator for WordIterator<'a> {
                     }
                 },
                 b'*'|b'?' if self.flags & SQUOTE == 0 => {
+                    // if a word is not special, make sure you return the globbed variant at the end
                     self.read+=1;
                     glob=true; //warning is incorrect it does get read
                 },

--- a/src/parser/shell_expand/words.rs
+++ b/src/parser/shell_expand/words.rs
@@ -988,7 +988,7 @@ mod tests {
     fn words_process_with_quotes() {
         let input = "echo $(git branch | rg '[*]' | awk '{print $2}')";
         let expected = vec![
-            WordToken::Normal("echo"),
+            WordToken::Normal("echo",false),
             WordToken::Whitespace(" "),
             WordToken::Process("git branch | rg '[*]' | awk '{print $2}'", false, Index::All),
         ];
@@ -996,7 +996,7 @@ mod tests {
 
         let input = "echo $(git branch | rg \"[*]\" | awk '{print $2}')";
         let expected = vec![
-            WordToken::Normal("echo"),
+            WordToken::Normal("echo",false),
             WordToken::Whitespace(" "),
             WordToken::Process("git branch | rg \"[*]\" | awk '{print $2}'", false, Index::All),
         ];
@@ -1007,13 +1007,13 @@ mod tests {
     fn test_words() {
         let input = "echo $ABC \"${ABC}\" one{$ABC,$ABC} ~ $(echo foo) \"$(seq 1 100)\"";
         let expected = vec![
-            WordToken::Normal("echo"),
+            WordToken::Normal("echo",false),
             WordToken::Whitespace(" "),
             WordToken::Variable("ABC", false, Index::All),
             WordToken::Whitespace(" "),
             WordToken::Variable("ABC", true, Index::All),
             WordToken::Whitespace(" "),
-            WordToken::Normal("one"),
+            WordToken::Normal("one",false),
             WordToken::Brace(vec!["$ABC", "$ABC"]),
             WordToken::Whitespace(" "),
             WordToken::Tilde("~"),
@@ -1029,13 +1029,13 @@ mod tests {
     fn test_multiple_escapes() {
         let input = "foo\\(\\) bar\\(\\)";
         let expected = vec![
-            WordToken::Normal("foo"),
-            WordToken::Normal("("),
-            WordToken::Normal(")"),
-            WordToken::Whitespace(" "),
-            WordToken::Normal("bar"),
-            WordToken::Normal("("),
-            WordToken::Normal(")"),
+            WordToken::Normal("foo",false),
+            WordToken::Normal("(",false),
+            WordToken::Normal(")",false),
+            WordToken::Whitespace(" ",false),
+            WordToken::Normal("bar",false),
+            WordToken::Normal("(",false),
+            WordToken::Normal(")",false),
         ];
         compare(input, expected);
     }

--- a/src/parser/shell_expand/words.rs
+++ b/src/parser/shell_expand/words.rs
@@ -875,7 +875,7 @@ impl<'a> Iterator for WordIterator<'a> {
         if start == self.read {
             None
         } else {
-            println!("Normal exit");
+            //println!("Normal exit");
             Some(WordToken::Normal(&self.data[start..],glob))
         }
     }

--- a/src/parser/shell_expand/words.rs
+++ b/src/parser/shell_expand/words.rs
@@ -975,7 +975,7 @@ mod tests {
     fn nested_processes() {
         let input = "echo $(echo $(echo one)) $(echo one $(echo two) three)";
         let expected = vec![
-            WordToken::Normal("echo"),
+            WordToken::Normal("echo",false),
             WordToken::Whitespace(" "),
             WordToken::Process("echo $(echo one)", false, Index::All),
             WordToken::Whitespace(" "),
@@ -1032,7 +1032,7 @@ mod tests {
             WordToken::Normal("foo",false),
             WordToken::Normal("(",false),
             WordToken::Normal(")",false),
-            WordToken::Whitespace(" ",false),
+            WordToken::Whitespace(" "),
             WordToken::Normal("bar",false),
             WordToken::Normal("(",false),
             WordToken::Normal(")",false),

--- a/src/parser/shell_expand/words.rs
+++ b/src/parser/shell_expand/words.rs
@@ -911,10 +911,10 @@ mod tests {
         let input = "\\$FOO\\$BAR \\$FOO";
         let expected =
             vec![
-                WordToken::Normal("$FOO"),
-                WordToken::Normal("$BAR"),
+                WordToken::Normal("$FOO",false),
+                WordToken::Normal("$BAR",false),
                 WordToken::Whitespace(" "),
-                WordToken::Normal("$FOO")
+                WordToken::Normal("$FOO",false)
             ];
         compare(input, expected);
     }

--- a/src/shell/flow.rs
+++ b/src/shell/flow.rs
@@ -9,7 +9,7 @@ use parser::{ForExpression, StatementSplitter, check_statement};
 use parser::peg::Pipeline;
 use super::assignments::let_assignment;
 
-use glob::glob;
+//use glob::glob;
 
 pub enum Condition {
     Continue,
@@ -211,7 +211,7 @@ impl<'a> FlowLogic for Shell<'a> {
     }
 
     fn execute_for(&mut self, variable: &str, values: &[String], statements: Vec<Statement>) {
-        fn glob_expand(arg: &str) -> Vec<String> {
+        /*fn glob_expand(arg: &str) -> Vec<String> {
             let mut expanded = Vec::new();
             if arg.contains(|chr| chr == '?' || chr == '*' || chr == '[') {
                 if let Ok(glob) = glob(arg) {
@@ -223,28 +223,28 @@ impl<'a> FlowLogic for Shell<'a> {
             } else {
                 vec![arg.to_owned()]
             }
-        }
+        }*/
 
         let ignore_variable = variable == "_";
         match ForExpression::new(values, &self.directory_stack, &self.variables) {
             ForExpression::Multiple(ref values) if ignore_variable => {
-                for _ in values.iter().flat_map(|x| glob_expand(&x)) {
+                for _ in values.iter()/*.flat_map(|x| glob_expand(&x))*/ {
                     if let Condition::Break = self.execute_statements(statements.clone()) { break }
                 }
             },
             ForExpression::Multiple(values) => {
-                for value in values.iter().flat_map(|x| glob_expand(&x)) {
+                for value in values.iter()/*.flat_map(|x| glob_expand(&x))*/ {
                     self.variables.set_var(variable, &value);
                     if let Condition::Break = self.execute_statements(statements.clone()) { break }
                 }
             },
             ForExpression::Normal(ref values) if ignore_variable => {
-                for _ in values.lines().flat_map(glob_expand) {
+                for _ in values.lines()/*.flat_map(glob_expand)*/ {
                     if let Condition::Break = self.execute_statements(statements.clone()) { break }
                 }
             },
             ForExpression::Normal(values) => {
-                for value in values.lines().flat_map(glob_expand) {
+                for value in values.lines()/*.flat_map(glob_expand)*/ {
                     self.variables.set_var(variable, &value);
                     if let Condition::Break = self.execute_statements(statements.clone()) { break }
                 }

--- a/src/shell/job.rs
+++ b/src/shell/job.rs
@@ -1,6 +1,6 @@
 use std::process::Command;
 
-use glob::glob;
+//use glob::glob;
 use parser::{expand_string, ExpanderFunctions};
 use parser::peg::RedirectFrom;
 use smallstring::SmallString;
@@ -37,10 +37,10 @@ impl Job {
             let mut iterator = self.args.drain();
             expanded.push(iterator.next().unwrap());
             for arg in iterator.flat_map(|argument| expand_string(&argument, expanders, false)) {
-                if arg.contains(|chr| chr == '?' || chr == '*' || chr == '[') {
+                /*if arg.contains(|chr| chr == '?' || chr == '*' || chr == '[') {
                     if let Ok(glob) = glob(&arg) {
                         use std::borrow::Cow;
-                        
+
                         for path in glob.filter_map(Result::ok) {
                             expanded.push(
                                 match path.to_string_lossy() {
@@ -51,7 +51,7 @@ impl Job {
                             continue
                         }
                     }
-                }
+                }*/
                 expanded.push(arg);
             }
         }

--- a/src/shell/job.rs
+++ b/src/shell/job.rs
@@ -37,21 +37,7 @@ impl Job {
             let mut iterator = self.args.drain();
             expanded.push(iterator.next().unwrap());
             for arg in iterator.flat_map(|argument| expand_string(&argument, expanders, false)) {
-                /*if arg.contains(|chr| chr == '?' || chr == '*' || chr == '[') {
-                    if let Ok(glob) = glob(&arg) {
-                        use std::borrow::Cow;
-
-                        for path in glob.filter_map(Result::ok) {
-                            expanded.push(
-                                match path.to_string_lossy() {
-                                    Cow::Owned(s) => s.into(),
-                                    Cow::Borrowed(s) => s.into(),
-                                }
-                            );
-                            continue
-                        }
-                    }
-                }*/
+                
                 expanded.push(arg);
             }
         }


### PR DESCRIPTION
**Problem**:Globbing during shell expansion (see https://github.com/redox-os/ion/issues/258)

**Solution**: I added an extra param to the Normal token which designates it as a normal token that's globable or not.
**Changes introduced by this pull request**:

- Globbing gets moved and probably (isn't) yet parsed 100% correctly. I'm just submitting this PR so I can get in touch with contributors and notify other people of my attempt at trying to fix this.

**Drawbacks**:

Wildcards during quotes don't parse correctly.

**TODOs**: [what is not done yet.]

Make sure wildcards in quotes get parsed as text (if this happened during the previous version).

**Fixes**: [what issues this fixes.]
https://github.com/redox-os/ion/issues/258
**State**: [the state of this PR, e.g. WIP, ready, etc.]
Ready for review
**Blocking/related**: [issues or PRs blocking or being related to this issue.]

**Other**: The author isn't all that used to programming in Rust.