### PR TITLE
Add semantics for indexing into arrays with negative indices 

### DIFF
--- a/src/builtins/variables.rs
+++ b/src/builtins/variables.rs
@@ -238,7 +238,7 @@ pub fn export_variable<'a, S: AsRef<str> + 'a>(vars: &mut Variables, args: &[S])
 #[cfg(test)]
 mod test {
     use super::*;
-    use parser::{expand_string, ExpanderFunctions, Index, IndexEnd};
+    use parser::{expand_string, ExpanderFunctions, Index};
     use shell::status::{FAILURE, SUCCESS};
     use shell::directory_stack::DirectoryStack;
 

--- a/src/parser/loops/for_grammar.rs
+++ b/src/parser/loops/for_grammar.rs
@@ -1,7 +1,7 @@
 use shell::directory_stack::DirectoryStack;
 use shell::variables::Variables;
 use types::Value;
-use parser::{expand_string, ExpanderFunctions, Index, IndexEnd};
+use parser::{expand_string, ExpanderFunctions, Index};
 
 #[derive(Debug, PartialEq)]
 pub enum ForExpression {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -15,12 +15,13 @@ macro_rules! get_expanders {
                             |x| Array::from_iter(Some(x.to_owned()))
                         ),
                         Index::Range(start, end) => {
-                            let array: Array = match end {
-                                IndexEnd::CatchAll => array.iter().skip(start)
-                                    .map(|x| x.to_owned()).collect::<_>(),
-                                IndexEnd::ID(end) => array.iter().skip(start).take(end-start)
-                                    .map(|x| x.to_owned()).collect::<_>()
-                            };
+                            let len = array.len();
+                            let array : Array =
+                                array.iter()
+                                     .skip(start.resolve(len))
+                                     .take(end.diff(&start, len))
+                                     .map(|x| x.to_owned())
+                                     .collect::<_>();
                             if array.is_empty() { None } else { Some(array) }
                         }
                     },

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -14,9 +14,14 @@ macro_rules! get_expanders {
                         Index::ID(id) => array.get(id).map(
                             |x| Array::from_iter(Some(x.to_owned()))
                         ),
-                        Index::FromEnd(idx) => array.get(array.len() - idx).map(
-                            |x| Array::from_iter(Some(x.to_owned()))
-                        ),
+                        Index::FromEnd(idx) => {
+                            if array.len() < idx {
+                                None
+                            } else {
+                                array.get(array.len() - idx)
+                                     .map(|x| Array::from_iter(Some(x.to_owned())))
+                            }
+                        },
                         Index::Range(start, end) => {
                             let len = array.len();
                             let array : Array =

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -14,6 +14,9 @@ macro_rules! get_expanders {
                         Index::ID(id) => array.get(id).map(
                             |x| Array::from_iter(Some(x.to_owned()))
                         ),
+                        Index::FromEnd(idx) => array.get(array.len() - idx).map(
+                            |x| Array::from_iter(Some(x.to_owned()))
+                        ),
                         Index::Range(start, end) => {
                             let len = array.len();
                             let array : Array =

--- a/src/parser/peg.rs
+++ b/src/parser/peg.rs
@@ -5,7 +5,7 @@ use self::grammar::parse_;
 use shell::directory_stack::DirectoryStack;
 use shell::Job;
 use shell::variables::Variables;
-use parser::{expand_string, ExpanderFunctions, Index, IndexEnd};
+use parser::{expand_string, ExpanderFunctions, Index};
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum RedirectFrom { Stdout, Stderr, Both}

--- a/src/parser/shell_expand/mod.rs
+++ b/src/parser/shell_expand/mod.rs
@@ -525,4 +525,17 @@ mod test {
         let expanded = expand_string(line, &functions!(), false);
         assert_eq!(&expected, &expanded);
     }
+
+    #[test]
+    fn array_indexing() {
+        let base = |idx : &str| format!("[1 2 3][{}]", idx);
+        let expander = functions!();
+        {
+            let expected = Array::from_vec(vec!["1".to_owned()]);
+            let idxs = vec!["-3", "0", "..-2"];
+            for idx in idxs {
+                assert_eq!(expected, expand_string(&base(idx), &expander, false));
+            }
+        }
+    }
 }

--- a/src/parser/shell_expand/mod.rs
+++ b/src/parser/shell_expand/mod.rs
@@ -537,5 +537,12 @@ mod test {
                 assert_eq!(expected, expand_string(&base(idx), &expander, false));
             }
         }
+        {
+            let expected = Array::from_vec(vec!["2".to_owned(), "3".to_owned()]);
+            let idxs = vec!["1...2", "1...-1"];
+            for idx in idxs {
+                assert_eq!(expected, expand_string(&base(idx), &expander, false));
+            }
+        }
     }
 }

--- a/src/parser/shell_expand/mod.rs
+++ b/src/parser/shell_expand/mod.rs
@@ -280,10 +280,13 @@ pub fn expand_tokens<'a>(token_buffer: &[WordToken], expand_func: &'a ExpanderFu
                         Index::ID(id) =>
                             Some(array_nth(elements, expand_func, id))
                                 .into_iter().collect(),
-                        Index::FromEnd(id) =>
-                            Some(array_nth(elements, expand_func, elements.len() - id))
-                                .into_iter()
-                                .collect(),
+                        Index::FromEnd(id) => {
+                            if id > elements.len() {
+                               Array::new()
+                            } else {
+                               Some(array_nth(elements, expand_func, elements.len() - id)) .into_iter().collect()
+                            }
+                        },
                         Index::Range(start, end) => array_range(elements, expand_func, start, end),
                     };
                 },

--- a/src/parser/shell_expand/mod.rs
+++ b/src/parser/shell_expand/mod.rs
@@ -547,5 +547,12 @@ mod test {
                 assert_eq!(expected, expand_string(&base(idx), &expander, false));
             }
         }
+        {
+            let expected = Array::new();
+            let idxs = vec!["-17", "4..-4"];
+            for idx in idxs {
+                assert_eq!(expected, expand_string(&base(idx), &expander, false));
+            }
+        }
     }
 }

--- a/src/parser/shell_expand/ranges.rs
+++ b/src/parser/shell_expand/ranges.rs
@@ -101,7 +101,10 @@ pub fn parse_index_range(input: &str) -> Option<(IndexStart, IndexEnd)> {
                 if let Ok(start) = first.parse::<isize>() {
                     if let Ok(end) = end.parse::<isize>() {
                         return if inclusive {
-                            Some((IndexStart::new(start), IndexEnd::new(end+1)))
+                            let start = IndexStart::new(start);
+                            let end = if end == -1 { IndexEnd::FromEnd(0) } 
+                                      else { IndexEnd::new(end) };
+                            Some((start, end))
                         } else {
                             Some((IndexStart::new(start), IndexEnd::new(end)))
                         }

--- a/src/parser/shell_expand/ranges.rs
+++ b/src/parser/shell_expand/ranges.rs
@@ -103,7 +103,7 @@ pub fn parse_index_range(input: &str) -> Option<(IndexStart, IndexEnd)> {
                         return if inclusive {
                             let start = IndexStart::new(start);
                             let end = if end == -1 { IndexEnd::FromEnd(0) } 
-                                      else { IndexEnd::new(end) };
+                                      else { IndexEnd::new(end + 1) };
                             Some((start, end))
                         } else {
                             Some((IndexStart::new(start), IndexEnd::new(end)))

--- a/src/parser/shell_expand/ranges.rs
+++ b/src/parser/shell_expand/ranges.rs
@@ -1,4 +1,4 @@
-use super::words::IndexEnd;
+use super::words::{IndexStart, IndexEnd};
 
 pub fn parse_range(input: &str) -> Option<Vec<String>> {
     let mut bytes_iterator = input.bytes().enumerate();
@@ -61,7 +61,7 @@ pub fn parse_range(input: &str) -> Option<Vec<String>> {
     None
 }
 
-pub fn parse_index_range(input: &str) -> Option<(usize, IndexEnd)> {
+pub fn parse_index_range(input: &str) -> Option<(IndexStart, IndexEnd)> {
     let mut bytes_iterator = input.bytes().enumerate();
     while let Some((id, byte)) = bytes_iterator.next() {
         match byte {
@@ -86,32 +86,24 @@ pub fn parse_index_range(input: &str) -> Option<(usize, IndexEnd)> {
                     return if end.is_empty() {
                         None
                     } else {
-                        match end.parse::<usize>() {
-                            Ok(end) => Some((0, IndexEnd::ID(end))),
+                        match end.parse::<isize>() {
+                            Ok(end) => Some((IndexStart::new(0), IndexEnd::new(end))),
                             Err(_)  => None
                         }
                     }
                 } else if end.is_empty() {
-                    return match first.parse::<usize>() {
-                        Ok(start) => Some((start, IndexEnd::CatchAll)),
+                    return match first.parse::<isize>() {
+                        Ok(start) => Some((IndexStart::new(start), IndexEnd::CatchAll)),
                         Err(_)    => None
                     }
                 }
 
-                if let Ok(start) = first.parse::<usize>() {
-                    if let Ok(end) = end.parse::<usize>() {
+                if let Ok(start) = first.parse::<isize>() {
+                    if let Ok(end) = end.parse::<isize>() {
                         return if inclusive {
-                            if end < start {
-                                None
-                            } else if end == start {
-                                Some((start, IndexEnd::ID(start+1)))
-                            } else {
-                                Some((start, IndexEnd::ID(end+1)))
-                            }
-                        } else if end <= start {
-                            None
+                            Some((IndexStart::new(start), IndexEnd::FromEnd((end+1) as usize)))
                         } else {
-                            Some((start, IndexEnd::ID(end)))
+                            Some((IndexStart::new(start), IndexEnd::new(end)))
                         }
                     }
                 } else {
@@ -128,8 +120,8 @@ pub fn parse_index_range(input: &str) -> Option<(usize, IndexEnd)> {
 
 #[test]
 fn index_ranges() {
-    assert_eq!(Some((0, IndexEnd::ID(3))), parse_index_range("0..3"));
-    assert_eq!(Some((0, IndexEnd::ID(3))), parse_index_range("0...2"));
+    assert_eq!(Some((IndexStart::new(0), IndexEnd::new(3))), parse_index_range("0..3"));
+    assert_eq!(Some((IndexStart::new(0), IndexEnd::new(3))), parse_index_range("0...2"));
     assert_eq!(None, parse_index_range("0..A"));
 }
 

--- a/src/parser/shell_expand/ranges.rs
+++ b/src/parser/shell_expand/ranges.rs
@@ -101,7 +101,7 @@ pub fn parse_index_range(input: &str) -> Option<(IndexStart, IndexEnd)> {
                 if let Ok(start) = first.parse::<isize>() {
                     if let Ok(end) = end.parse::<isize>() {
                         return if inclusive {
-                            Some((IndexStart::new(start), IndexEnd::FromEnd((end+1) as usize)))
+                            Some((IndexStart::new(start), IndexEnd::new(end+1)))
                         } else {
                             Some((IndexStart::new(start), IndexEnd::new(end)))
                         }
@@ -121,7 +121,9 @@ pub fn parse_index_range(input: &str) -> Option<(IndexStart, IndexEnd)> {
 #[test]
 fn index_ranges() {
     assert_eq!(Some((IndexStart::new(0), IndexEnd::new(3))), parse_index_range("0..3"));
-    assert_eq!(Some((IndexStart::new(0), IndexEnd::FromEnd(3))), parse_index_range("0...2"));
+    assert_eq!(Some((IndexStart::new(0), IndexEnd::new(3))), parse_index_range("0...2"));
+    assert_eq!(Some((IndexStart::new(2), IndexEnd::FromEnd(1))), parse_index_range("2...-2"));
+    assert_eq!(Some((IndexStart::new(0), IndexEnd::FromEnd(0))), parse_index_range("0...-1"));
     assert_eq!(None, parse_index_range("0..A"));
 }
 

--- a/src/parser/shell_expand/ranges.rs
+++ b/src/parser/shell_expand/ranges.rs
@@ -121,7 +121,7 @@ pub fn parse_index_range(input: &str) -> Option<(IndexStart, IndexEnd)> {
 #[test]
 fn index_ranges() {
     assert_eq!(Some((IndexStart::new(0), IndexEnd::new(3))), parse_index_range("0..3"));
-    assert_eq!(Some((IndexStart::new(0), IndexEnd::new(3))), parse_index_range("0...2"));
+    assert_eq!(Some((IndexStart::new(0), IndexEnd::FromEnd(3))), parse_index_range("0...2"));
     assert_eq!(None, parse_index_range("0..A"));
 }
 

--- a/src/parser/shell_expand/words.rs
+++ b/src/parser/shell_expand/words.rs
@@ -944,7 +944,7 @@ mod tests {
         let expected = vec![
             WordToken::ArrayVariable("array", false, Index::Range(IndexStart::new(0), IndexEnd::new(3))),
             WordToken::Whitespace(" "),
-            WordToken::ArrayVariable("array", false, Index::Range(IndexStart::new(0), IndexEnd::new(4))),
+            WordToken::ArrayVariable("array", false, Index::Range(IndexStart::new(0), IndexEnd::FromEnd(4))),
             WordToken::Whitespace(" "),
             WordToken::ArrayVariable("array", false, Index::None),
             WordToken::Whitespace(" "),

--- a/src/parser/shell_expand/words.rs
+++ b/src/parser/shell_expand/words.rs
@@ -117,7 +117,7 @@ impl FromStr for Index {
         }
 
         if let Some((start, end)) = parse_index_range(data) {
-            return Ok(Index::Range(start, end))
+            return Ok(Index::Range(start, end));
         }
 
         let stderr = io::stderr();
@@ -944,7 +944,7 @@ mod tests {
         let expected = vec![
             WordToken::ArrayVariable("array", false, Index::Range(IndexStart::new(0), IndexEnd::new(3))),
             WordToken::Whitespace(" "),
-            WordToken::ArrayVariable("array", false, Index::Range(IndexStart::new(0), IndexEnd::FromEnd(4))),
+            WordToken::ArrayVariable("array", false, Index::Range(IndexStart::new(0), IndexEnd::new(4))),
             WordToken::Whitespace(" "),
             WordToken::ArrayVariable("array", false, Index::None),
             WordToken::Whitespace(" "),

--- a/src/parser/shell_expand/words.rs
+++ b/src/parser/shell_expand/words.rs
@@ -1023,8 +1023,4 @@ mod tests {
         ];
         compare(input, expected);
     }
-<<<<<<< HEAD
-=======
-
->>>>>>> 960be93... Add negative range indexes
 }

--- a/src/shell/assignments.rs
+++ b/src/shell/assignments.rs
@@ -72,8 +72,14 @@ pub fn let_assignment(binding: Binding, vars: &mut Variables, dir_stack: &Direct
                         Index::All => Some(array.clone()),
                         Index::ID(id) => array.get(id)
                             .map(|x| Some(x.to_owned()).into_iter().collect()),
-                        Index::FromEnd(id) => array.get(array.len() - id)
-                            .map(|x| Some(x.to_owned()).into_iter().collect()),
+                        Index::FromEnd(id) => {
+                            if id > array.len() {
+                                None
+                            } else {
+                               array.get(array.len() - id)
+                                    .map(|x| Some(x.to_owned()).into_iter().collect())
+                            }
+                        },
                         Index::Range(start, end) => {
                             let len = array.len();
                             let array : VArray = array.iter()

--- a/src/shell/assignments.rs
+++ b/src/shell/assignments.rs
@@ -72,6 +72,8 @@ pub fn let_assignment(binding: Binding, vars: &mut Variables, dir_stack: &Direct
                         Index::All => Some(array.clone()),
                         Index::ID(id) => array.get(id)
                             .map(|x| Some(x.to_owned()).into_iter().collect()),
+                        Index::FromEnd(id) => array.get(array.len() - id)
+                            .map(|x| Some(x.to_owned()).into_iter().collect()),
                         Index::Range(start, end) => {
                             let len = array.len();
                             let array : VArray = array.iter()

--- a/src/shell/assignments.rs
+++ b/src/shell/assignments.rs
@@ -8,7 +8,6 @@ use parser::assignments::{
 use parser::{
     ExpanderFunctions,
     Index,
-    IndexEnd,
     ArgumentSplitter,
     expand_string,
 };
@@ -74,12 +73,12 @@ pub fn let_assignment(binding: Binding, vars: &mut Variables, dir_stack: &Direct
                         Index::ID(id) => array.get(id)
                             .map(|x| Some(x.to_owned()).into_iter().collect()),
                         Index::Range(start, end) => {
-                            let array: VArray = match end {
-                                IndexEnd::CatchAll => array.iter().skip(start)
-                                    .map(|x| x.to_owned()).collect(),
-                                IndexEnd::ID(end) => array.iter().skip(start).take(end-start)
-                                    .map(|x| x.to_owned()).collect()
-                            };
+                            let len = array.len();
+                            let array : VArray = array.iter()
+                                                      .skip(start.resolve(len))
+                                                      .take(end.diff(&start, len))
+                                                      .map(|x| x.to_owned())
+                                                      .collect();
                             if array.is_empty() { None } else { Some(array) }
                         }
                     },

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -41,7 +41,6 @@ use parser::{
     QuoteTerminator,
     ExpanderFunctions,
     Index,
-    IndexEnd
 };
 use parser::peg::Pipeline;
 

--- a/src/shell/variables.rs
+++ b/src/shell/variables.rs
@@ -252,7 +252,7 @@ fn get_user_home(_username: &str) -> Option<String> {
 mod tests {
     use super::*;
     use shell::directory_stack::DirectoryStack;
-    use parser::{expand_string, ExpanderFunctions, Index, IndexEnd};
+    use parser::{expand_string, ExpanderFunctions, Index};
 
     fn new_dir_stack() -> DirectoryStack {
         DirectoryStack::new().unwrap()


### PR DESCRIPTION
**Problem**: There is no way to refer to, for example, the second to last element of an array aside from `@array[len(array) - 2]` where `len` gets the number of elements in an array.

**Solution**: Extend Ion's syntax to allow for this through negative indices, such as in Python:
```
$ let array = [ 1 2 3 4 5 6 ]
$ echo @array[-1]
6
$ echo @array[1..-2]
2 3 4
```

**Changes introduced by this pull request**:
- Introduce new data structures that represent indexing from the end of an array
- Update parsing of array ranges and indices to use these new structures

**Drawbacks**:
- `parser::shell_expand::words` has become a bit of a mess with a bunch of `Index` named classes everywhere. As discussed in #263 it would be useful to refactor this and move some of the logic repeated at call-sites, but that's a little too broad for a single PR.

**TODOs**: 
- [x] Outstanding bug where `@array[2...-2]` results in an empty output for arrays where it is well defined.
- [x] Add in more regression / unit tests, including failure-like cases

**State**: WIP

**Blocking/related**: Closes #263
