### PR TITLE
Refactor `Index`, etc. into `Select`, `Range`, and `Index`

### DIFF
--- a/src/builtins/variables.rs
+++ b/src/builtins/variables.rs
@@ -238,7 +238,7 @@ pub fn export_variable<'a, S: AsRef<str> + 'a>(vars: &mut Variables, args: &[S])
 #[cfg(test)]
 mod test {
     use super::*;
-    use parser::{expand_string, ExpanderFunctions, Index};
+    use parser::{expand_string, ExpanderFunctions, Select};
     use shell::status::{FAILURE, SUCCESS};
     use shell::directory_stack::DirectoryStack;
 

--- a/src/parser/loops/for_grammar.rs
+++ b/src/parser/loops/for_grammar.rs
@@ -1,7 +1,7 @@
 use shell::directory_stack::DirectoryStack;
 use shell::variables::Variables;
 use types::Value;
-use parser::{expand_string, ExpanderFunctions, Index};
+use parser::{expand_string, ExpanderFunctions, Select};
 
 #[derive(Debug, PartialEq)]
 pub enum ForExpression {

--- a/src/parser/peg.rs
+++ b/src/parser/peg.rs
@@ -5,7 +5,7 @@ use self::grammar::parse_;
 use shell::directory_stack::DirectoryStack;
 use shell::Job;
 use shell::variables::Variables;
-use parser::{expand_string, ExpanderFunctions, Index};
+use parser::{expand_string, ExpanderFunctions, Select};
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum RedirectFrom { Stdout, Stderr, Both}

--- a/src/parser/shell_expand/mod.rs
+++ b/src/parser/shell_expand/mod.rs
@@ -206,15 +206,13 @@ pub fn expand_tokens<'a>(token_buffer: &[WordToken], expand_func: &'a ExpanderFu
                                 let mut temp = String::new();
                                 expand_process(&mut temp, command, quoted, Select::All, expand_func);
                                 let len = temp.split_whitespace().count();
-                                let temp = if let Some((start, length)) = range.bounds(len) {
-                                     temp.split_whitespace()
-                                               .skip(start)
-                                               .take(length)
-                                               .collect::<Vec<&str>>()
-                                } else {
-                                    Vec::new()
-                                };
-                                output.push_str(&temp.join(" "));
+                                if let Some((start, length)) = range.bounds(len) {
+                                    let res = temp.split_whitespace()
+                                                  .skip(start)
+                                                  .take(length)
+                                                  .collect::<Vec<&str>>();
+                                    output.push_str(&res.join(" "));
+                                }
                             }
                         }
                     },

--- a/src/parser/shell_expand/mod.rs
+++ b/src/parser/shell_expand/mod.rs
@@ -313,19 +313,19 @@ pub fn expand_tokens<'a>(token_buffer: &[WordToken], expand_func: &'a ExpanderFu
                         Select::Index(Index::Forward(id)) => {
                             expand_process(&mut output, command, quoted, Select::All, expand_func);
                             return output.split_whitespace()
-                                  .nth(id)
-                                  .map(Into::into)
-                                  .into_iter()
-                                  .collect();
+                                         .nth(id)
+                                         .map(Into::into)
+                                         .into_iter()
+                                         .collect();
                         },
                         Select::Index(Index::Backward(id)) => {
                             expand_process(&mut output, command, quoted, Select::All, expand_func);
                             return output.split_whitespace()
-                                  .rev()
-                                  .nth(id)
-                                  .map(Into::into)
-                                  .into_iter()
-                                  .collect();
+                                         .rev()
+                                         .nth(id)
+                                         .map(Into::into)
+                                         .into_iter()
+                                         .collect();
                         }
                         Select::Range(range) => {
                             expand_process(&mut output, command, quoted, Select::All, expand_func);

--- a/src/parser/shell_expand/ranges.rs
+++ b/src/parser/shell_expand/ranges.rs
@@ -124,10 +124,14 @@ fn index_ranges() {
     let range2 = Range::inclusive(Index::Forward(0), Index::Forward(2));
     let range3 = Range::inclusive(Index::Forward(2), Index::Backward(1));
     let range4 = Range::inclusive(Index::Forward(0), Index::Backward(0));
+    let range5 = Range::exclusive(Index::Backward(2), Index::Backward(0));
+    let range6 = Range::from(Index::Backward(2));
     assert_eq!(Some(range1), parse_index_range("0..3"));
     assert_eq!(Some(range2), parse_index_range("0...2"));
     assert_eq!(Some(range3), parse_index_range("2...-2"));
     assert_eq!(Some(range4), parse_index_range("0...-1"));
+    assert_eq!(Some(range5), parse_index_range("-3..-1"));
+    assert_eq!(Some(range6), parse_index_range("-3.."));
     assert_eq!(None, parse_index_range("0..A"));
 }
 

--- a/src/parser/shell_expand/ranges.rs
+++ b/src/parser/shell_expand/ranges.rs
@@ -65,7 +65,7 @@ pub fn parse_index_range(input: &str) -> Option<Range> {
     let mut bytes_iterator = input.bytes().enumerate();
     while let Some((id, byte)) = bytes_iterator.next() {
         match byte {
-            b'0'...b'9' => continue,
+            b'0'...b'9' | b'-' => continue,
             b'.' => {
                 let first = &input[..id];
 

--- a/src/parser/shell_expand/ranges.rs
+++ b/src/parser/shell_expand/ranges.rs
@@ -120,19 +120,28 @@ pub fn parse_index_range(input: &str) -> Option<Range> {
 
 #[test]
 fn index_ranges() {
-    let range1 = Range::exclusive(Index::Forward(0), Index::Forward(3));
-    let range2 = Range::inclusive(Index::Forward(0), Index::Forward(2));
-    let range3 = Range::inclusive(Index::Forward(2), Index::Backward(1));
-    let range4 = Range::inclusive(Index::Forward(0), Index::Backward(0));
-    let range5 = Range::exclusive(Index::Backward(2), Index::Backward(0));
-    let range6 = Range::from(Index::Backward(2));
-    assert_eq!(Some(range1), parse_index_range("0..3"));
-    assert_eq!(Some(range2), parse_index_range("0...2"));
-    assert_eq!(Some(range3), parse_index_range("2...-2"));
-    assert_eq!(Some(range4), parse_index_range("0...-1"));
-    assert_eq!(Some(range5), parse_index_range("-3..-1"));
-    assert_eq!(Some(range6), parse_index_range("-3.."));
-    assert_eq!(None, parse_index_range("0..A"));
+    let valid_cases = vec![
+        (Range::exclusive(Index::Forward(0), Index::Forward(3)), "0..3"),
+        (Range::inclusive(Index::Forward(0), Index::Forward(2)), "0...2"),
+        (Range::inclusive(Index::Forward(2), Index::Backward(1)), "2...-2"),
+        (Range::inclusive(Index::Forward(0), Index::Backward(0)), "0...-1"),
+        (Range::exclusive(Index::Backward(2), Index::Backward(0)), "-3..-1"),
+        (Range::from(Index::Backward(2)), "-3.."),
+        (Range::to(Index::Forward(5)), "..5")
+    ];
+    
+    for (range, string) in valid_cases {
+        assert_eq!(Some(range), parse_index_range(string));
+    }
+
+    let invalid_cases = vec![
+        "0..A",
+        "3-3..42"
+    ];
+
+    for range in invalid_cases {
+        assert_eq!(None, parse_index_range(range))
+    }
 }
 
 #[test]

--- a/src/parser/shell_expand/ranges.rs
+++ b/src/parser/shell_expand/ranges.rs
@@ -1,4 +1,4 @@
-use super::words::{IndexStart, IndexEnd};
+use super::words::{Range, Index};
 
 pub fn parse_range(input: &str) -> Option<Vec<String>> {
     let mut bytes_iterator = input.bytes().enumerate();
@@ -61,7 +61,7 @@ pub fn parse_range(input: &str) -> Option<Vec<String>> {
     None
 }
 
-pub fn parse_index_range(input: &str) -> Option<(IndexStart, IndexEnd)> {
+pub fn parse_index_range(input: &str) -> Option<Range> {
     let mut bytes_iterator = input.bytes().enumerate();
     while let Some((id, byte)) = bytes_iterator.next() {
         match byte {
@@ -87,27 +87,24 @@ pub fn parse_index_range(input: &str) -> Option<(IndexStart, IndexEnd)> {
                         None
                     } else {
                         match end.parse::<isize>() {
-                            Ok(end) => Some((IndexStart::new(0), IndexEnd::new(end))),
+                            Ok(end) => Some(Range::to(Index::new(end))),
                             Err(_)  => None
                         }
                     }
                 } else if end.is_empty() {
                     return match first.parse::<isize>() {
-                        Ok(start) => Some((IndexStart::new(start), IndexEnd::CatchAll)),
+                        Ok(start) => Some(Range::from(Index::new(start))),
                         Err(_)    => None
                     }
                 }
 
                 if let Ok(start) = first.parse::<isize>() {
                     if let Ok(end) = end.parse::<isize>() {
-                        return if inclusive {
-                            let start = IndexStart::new(start);
-                            let end = if end == -1 { IndexEnd::FromEnd(0) } 
-                                      else { IndexEnd::new(end + 1) };
-                            Some((start, end))
+                        return Some(if inclusive {
+                            Range::inclusive(Index::new(start), Index::new(end))
                         } else {
-                            Some((IndexStart::new(start), IndexEnd::new(end)))
-                        }
+                            Range::exclusive(Index::new(start), Index::new(end))
+                        });
                     }
                 } else {
                     break
@@ -123,10 +120,14 @@ pub fn parse_index_range(input: &str) -> Option<(IndexStart, IndexEnd)> {
 
 #[test]
 fn index_ranges() {
-    assert_eq!(Some((IndexStart::new(0), IndexEnd::new(3))), parse_index_range("0..3"));
-    assert_eq!(Some((IndexStart::new(0), IndexEnd::new(3))), parse_index_range("0...2"));
-    assert_eq!(Some((IndexStart::new(2), IndexEnd::FromEnd(1))), parse_index_range("2...-2"));
-    assert_eq!(Some((IndexStart::new(0), IndexEnd::FromEnd(0))), parse_index_range("0...-1"));
+    let range1 = Range::exclusive(Index::Forward(0), Index::Forward(3));
+    let range2 = Range::inclusive(Index::Forward(0), Index::Forward(2));
+    let range3 = Range::inclusive(Index::Forward(2), Index::Backward(1));
+    let range4 = Range::inclusive(Index::Forward(0), Index::Backward(0));
+    assert_eq!(Some(range1), parse_index_range("0..3"));
+    assert_eq!(Some(range2), parse_index_range("0...2"));
+    assert_eq!(Some(range3), parse_index_range("2...-2"));
+    assert_eq!(Some(range4), parse_index_range("0...-1"));
     assert_eq!(None, parse_index_range("0..A"));
 }
 

--- a/src/parser/shell_expand/words.rs
+++ b/src/parser/shell_expand/words.rs
@@ -93,15 +93,13 @@ impl Range {
     /// Returns the bounds of this range as a tuple containing:
     /// - The starting point of the range
     /// - The length of the range
-    /// This function is meant to be used in the following pattern:
-    /// ```rust,ignore
-    /// let iter = some_iterator();
-    /// let range = Range { ... };
-    /// let len = length_of_some_iterator();
-    /// if let Some((start, size)) = range.bounds(len) {
-    ///     let res = iter.skip(start).take(len);
-    ///     ...
-    /// }
+    /// ```
+    /// let vec = vec![0, 1, 2, 3, 4, 5, 6, 7, 8];
+    /// let range = Range::exclusive(Index::new(1), Index::new(5));
+    /// let (start, size) = range.bounds(vec.len()).unwrap();
+    /// let expected = vec![1, 2, 3, 4];
+    /// let selection = vec.iter().skip(start).take(size).collect::<Vec<_>>();
+    /// assert_eq!(expected, selection);
     /// ```
     pub fn bounds(&self, vector_length : usize) -> Option<(usize,usize)> {
         if let Some(start) = self.start.resolve(vector_length) {

--- a/src/parser/shell_expand/words.rs
+++ b/src/parser/shell_expand/words.rs
@@ -988,6 +988,17 @@ mod tests {
     }
 
     #[test]
+    fn ranges() {
+        let range1 = Range::exclusive(Index::new(1), Index::new(5));
+        assert_eq!(Some((1, 4)), range1.bounds(42));
+        assert_eq!(Some((1, 4)), range1.bounds(7));
+        let range2 = Range::inclusive(Index::new(2), Index::new(-4));
+        assert_eq!(Some((2, 5)), range2.bounds(10));
+        assert_eq!(None, range2.bounds(3));
+    }
+
+
+    #[test]
     fn string_method() {
         let input = "$join(array, 'pattern') $join(array, 'pattern')";
         let expected = vec![

--- a/src/parser/shell_expand/words.rs
+++ b/src/parser/shell_expand/words.rs
@@ -185,8 +185,8 @@ impl<'a> ArrayMethod<'a> {
                     ),
                     (&Pattern::Whitespace, Select::All) => current.push_str (
                         &variable.split(char::is_whitespace)
-                            .collect::<Vec<&str>>()
-                            .join(" ")
+                                 .collect::<Vec<&str>>()
+                                 .join(" ")
                     ),
                     (_, Select::None) => (),
                     (&Pattern::StringPattern(pattern), Select::Index(Index::Forward(id))) => {
@@ -197,8 +197,8 @@ impl<'a> ArrayMethod<'a> {
                     } ,
                     (&Pattern::Whitespace, Select::Index(Index::Forward(id))) => current.push_str (
                         variable.split(char::is_whitespace)
-                            .nth(id)
-                            .unwrap_or_default()
+                                .nth(id)
+                                .unwrap_or_default()
                     ),
                     (&Pattern::StringPattern(pattern), Select::Index(Index::Backward(id))) => {
                         current.push_str(

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -40,7 +40,7 @@ use parser::{
     ArgumentSplitter,
     QuoteTerminator,
     ExpanderFunctions,
-    Index,
+    Select,
 };
 use parser::peg::Pipeline;
 

--- a/src/shell/variables.rs
+++ b/src/shell/variables.rs
@@ -252,7 +252,7 @@ fn get_user_home(_username: &str) -> Option<String> {
 mod tests {
     use super::*;
     use shell::directory_stack::DirectoryStack;
-    use parser::{expand_string, ExpanderFunctions, Index};
+    use parser::{expand_string, ExpanderFunctions, Select};
 
     fn new_dir_stack() -> DirectoryStack {
         DirectoryStack::new().unwrap()


### PR DESCRIPTION
**Problem**: The extra features introduced in #297 made it clear that `Index` `IndexStart` and `IndexEnd` were confusing to exist all together. 

**Solution**: This PR consolidates and appropriately separates the responisbilities of `Index`, `IndexStart`, and `IndexEnd` into `Select`, `Range`, and `Index.

**Changes introduced by this pull request**:
- Replaced top-level `Index` with `Select` which better captures the meaning of the enumeration: a selection of an array versus an index, which brings to mind a single element within the array.
- Added a separate `Range` struct that encapsulates inclusive vs. exclusive
- Consolidated `Index<blah>` into `Index::Forward` and `Index::Backward` and removed all of the `CatchAll` values. `CatchAll` is now represented by `Forward(0)` or `Backward(0)`.
- Added explicit, versus implicit, failure cases when a range is invalid

**Drawbacks**: 
- `Selection` is a more apt name but I wonder if there's something more precise
- This is mostly due to the features in #297 but there are several places where some logic is repeated

**TODOs**:
- [ ] Move some of the repeated logic and patterns for iterators from their call-sites to `Range`; I would love it if this PR reduced the total line count 
- [x] Add documentation and real examples for `Range` and `Index`
- [x] Add in more regression tests, especially now that `Range` is easily independently testable

**State**: Good to go

**Related**: #297, #263 
