### PR TITLE
Updat README.md to add vi/emacs keybindings as a feature and fix a typo in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ They may also be optionally defined using a braced syntax, which is useful in th
 integrated alongside other characters that do not terminate the variable parsing.
 
 ```ion
-let a = one
-let b = two
+let A = one
+let B = two
 echo $A:$B
 echo ${A}s and ${B}s
 ```

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Ion is a shell for UNIX platforms, and is the default shell in Redox. It is stil
 - [x] Background Jobs
 - [x] Multiline Comments and Commands
 - [x] Tab Completion (Needs Improvements)
+- [x] vi and emacs keybindings (`set -o (vi|emacs)`)
 
 ## Unimplemented Features
 


### PR DESCRIPTION
**Problem**: vi and emacs keybindings are now supported, but missing from the feature list.

**Solution**: I added the fact that `set -o (vi|emacs)` is now supported by ion.

**State**: Ready

**Blocking/related**: Issue #289 fixed by commit [ce0a196](https://github.com/redox-os/ion/commit/ce0a19672e7d76c4ff431bffa2731852a893157e)