### PR TITLE
Move `export` into the grammar

### DIFF
--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -8,7 +8,7 @@ mod echo;
 mod calc;
 mod set;
 
-use self::variables::{alias, drop_alias, drop_variable, export_variable};
+use self::variables::{alias, drop_alias, drop_variable};
 use self::functions::fn_;
 use self::source::source;
 use self::echo::echo;
@@ -129,15 +129,6 @@ impl Builtin {
                         });
 
         /* Variables */
-        commands.insert("export",
-                        Builtin {
-                            name: "export",
-                            help: "Set an environment variable",
-                            main: Box::new(|args: &[&str], shell: &mut Shell| -> i32 {
-                                export_variable(&mut shell.variables, args)
-                            })
-                        });
-
         commands.insert("fn",
                         Builtin {
                             name: "fn",

--- a/src/parser/grammar.rustpeg
+++ b/src/parser/grammar.rustpeg
@@ -5,6 +5,7 @@ use shell::flow_control::{ElseIf, Statement};
 #[pub]
 parse_ -> Statement
       = let_
+      / export_
       / if_
       / else_if_
       / else_
@@ -20,6 +21,12 @@ parse_ -> Statement
 let_ -> Statement
     = whitespace* "let" whitespace? value:$(.*) {
         Statement::Let { expression: parse_assignment(value) }
+    }
+
+#[pub]
+export_ -> Statement
+    = whitespace* "export" whitespace? value:$(.*) {
+        Statement::Export(parse_assignment(value))
     }
 
 #[pub]

--- a/src/shell/flow.rs
+++ b/src/shell/flow.rs
@@ -7,7 +7,7 @@ use super::flags::*;
 use super::flow_control::{ElseIf, Function, Statement, collect_loops, collect_if};
 use parser::{ForExpression, StatementSplitter, check_statement};
 use parser::peg::Pipeline;
-use super::assignments::let_assignment;
+use super::assignments::{let_assignment, export_variable};
 
 //use glob::glob;
 
@@ -105,6 +105,9 @@ impl<'a> FlowLogic for Shell<'a> {
                     Statement::Let { expression } => {
                         self.previous_status = let_assignment(expression, &mut self.variables, &self.directory_stack);
                     },
+                    Statement::Export(expression) => {
+                        self.previous_status = export_variable(expression, &mut self.variables, &self.directory_stack);
+                    }
                     Statement::While { expression, statements } => {
                         self.execute_while(expression, statements);
                     },
@@ -148,6 +151,9 @@ impl<'a> FlowLogic for Shell<'a> {
                 Statement::Let { expression } => {
                     self.previous_status = let_assignment(expression, &mut self.variables, &self.directory_stack);
                 },
+                Statement::Export(expression) => {
+                    self.previous_status = export_variable(expression, &mut self.variables, &self.directory_stack);
+                }
                 Statement::While { expression, mut statements } => {
                     self.flow_control.level += 1;
                     collect_loops(&mut iterator, &mut statements, &mut self.flow_control.level);
@@ -288,6 +294,9 @@ impl<'a> FlowLogic for Shell<'a> {
             Statement::Let { expression } => {
                 self.previous_status = let_assignment(expression, &mut self.variables, &self.directory_stack);
             },
+            Statement::Export(expression) => {
+               self.previous_status = export_variable(expression, &mut self.variables, &self.directory_stack);
+            }
             // Collect the statements for the while loop, and if the loop is complete,
             // execute the while loop with the provided expression.
             Statement::While { expression, mut statements } => {

--- a/src/shell/flow_control.rs
+++ b/src/shell/flow_control.rs
@@ -13,6 +13,7 @@ pub enum Statement {
     Let {
         expression: Binding,
     },
+    Export(Binding),
     If {
         expression: Pipeline,
         success: Vec<Statement>,


### PR DESCRIPTION
**Problem**: `export` not being in the grammar meant that the RHS was eagerly expanded.

**Solution**: `export` now has the same semantics as `let` but instead of storing the variable locally, it is written to the OS environment.

**Changes introduced by this pull request**:
- `export` is now in the PEG grammar and has an associated `Statement` enumeration
- `export` and `let` now have the same logic except, as mentioned, `export` writes to the OS environment
- DRYed up the logic, including replacing a custom made `ExpanderFunctions with `get_expanders!`

**Drawbacks**: Nothing off the top of my head 

**Fixes**: Related to #255

**State**: Ready!