### PR TITLE
Fix braced variables not parsing correctly

### DIFF
--- a/src/parser/statements.rs
+++ b/src/parser/statements.rs
@@ -327,3 +327,11 @@ fn nested_array_process() {
     assert_eq!(results.len(), 1);
     assert_eq!(results[0], Ok(command));
 }
+
+#[test]
+fn braced_variables() {
+    let command = "echo ${foo}bar ${bar}baz ${baz}quux";
+    let results = StatementSplitter::new(command).collect::<Vec<Result<&str, StatementError>>>();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results, vec![Ok(command)]);
+}


### PR DESCRIPTION
At some point in the history of `StatementSplitter` it started rejecting braced variables such as `${foo}`. While working on #262 I noticed this.

The problem was that the first case, which catches any character that cannot be in a braced variable, also threw an error for a brace, even though that might be the valid end of a braced variable.