### PR TITLE
Replace manual bit flags with auto-generated bit flag construct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,7 @@ name = "ion-shell"
 version = "1.0.3"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "liner 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -18,6 +19,11 @@ dependencies = [
 [[package]]
 name = "ansi_term"
 version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -113,6 +119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
+"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)" = "38f5c2b18a287cf78b4097db62e20f43cace381dc76ae5c0a3073067f78b7ddc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ build = "build.rs"
 name = "ion"
 
 [dependencies]
+bitflags = "0.9.1"
 fnv = "1.0"
 glob = "0.2"
 liner = "0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@
 // #![feature(alloc_system)]
 // extern crate alloc_system;
 
+#[macro_use]
+extern crate bitflags;
 extern crate fnv;
 extern crate glob;
 extern crate liner;

--- a/src/parser/pipelines.rs
+++ b/src/parser/pipelines.rs
@@ -131,9 +131,9 @@ pub fn collect(possible_error: &mut Option<&str>, args: &str) -> Pipeline {
             RedirMode::False => {
                 while let Some(character) = args_iter.next() {
                     match character {
-                        _ if flags.contains(BACKSLASH) => flags.toggle(BACKSLASH),
-                        b'\\'                        => flags.toggle(BACKSLASH),
-                        b'@'                         => {
+                        _ if flags.contains(BACKSLASH) => flags ^= BACKSLASH,
+                        b'\\'                          => flags ^= BACKSLASH,
+                        b'@'                           => {
                             flags_ext |= ARRAY | ARRAY_CHAR_FOUND;
                             index += 1;
                             continue

--- a/src/parser/pipelines.rs
+++ b/src/parser/pipelines.rs
@@ -10,19 +10,25 @@ use parser::peg::{Pipeline, Redirection, RedirectFrom};
 use shell::{Job, JobKind};
 use types::*;
 
-const BACKSLASH:     u8 = 1;
-const SINGLE_QUOTE:  u8 = 2;
-const DOUBLE_QUOTE:  u8 = 4;
-const ARRAY_PROCESS: u8 = 8;
-const METHOD:        u8 = 16;
-const PROCESS_TWO:   u8 = 128;
+bitflags! {
+    pub struct Flags : u16 {
+        const BACKSLASH = 1;
+        const SINGLE_QUOTE = 2;
+        const DOUBLE_QUOTE = 4;
+        const ARRAY_PROCESS = 8;
+        const METHOD = 16;
+        const PROCESS_TWO = 32;
 
-const ARRAY:            u8 = 1;
-const VARIABLE:         u8 = 2;
-const ARRAY_CHAR_FOUND: u8 = 4;
-const VAR_CHAR_FOUND:   u8 = 8;
-
-const IS_VALID: u8 = SINGLE_QUOTE + METHOD + PROCESS_TWO + ARRAY_PROCESS;
+        const ARRAY = 64;
+        const VARIABLE = 128;
+        const ARRAY_CHAR_FOUND = 256;
+        const VAR_CHAR_FOUND = 512;
+        const IS_VALID = SINGLE_QUOTE.bits
+                       | METHOD.bits
+                       | PROCESS_TWO.bits
+                       | ARRAY_PROCESS.bits;
+    }
+}
 
 #[derive(PartialEq)]
 enum RedirMode { False, Stdin, Stdout(RedirectFrom), StdoutAppend(RedirectFrom) }
@@ -51,8 +57,8 @@ pub fn collect(possible_error: &mut Option<&str>, args: &str) -> Pipeline {
     let mut jobs: Vec<Job> = Vec::new();
     let mut args_iter = args.bytes().peekable();
     let (mut index, mut arg_start) = (0, 0);
-    let mut flags = 0u8; // (backslash, single_quote, double_quote, x, x, x, process_one, process_two)
-    let mut flags_ext = 0u8;
+    let mut flags = Flags::empty(); // (backslash, single_quote, double_quote, x, x, x, process_one, process_two)
+    let mut flags_ext = Flags::empty();
 
     let mut arguments = Array::new();
 
@@ -121,43 +127,43 @@ pub fn collect(possible_error: &mut Option<&str>, args: &str) -> Pipeline {
             RedirMode::False => {
                 while let Some(character) = args_iter.next() {
                     match character {
-                        _ if flags & BACKSLASH != 0  => flags ^= BACKSLASH,
-                        b'\\'                        => flags ^= BACKSLASH,
+                        _ if flags.contains(BACKSLASH) => flags.toggle(BACKSLASH),
+                        b'\\'                        => flags.toggle(BACKSLASH),
                         b'@'                         => {
-                            flags_ext |= ARRAY + ARRAY_CHAR_FOUND;
+                            flags_ext |= ARRAY | ARRAY_CHAR_FOUND;
                             index += 1;
                             continue
                         },
-                        b'$' if flags & IS_VALID == 0 => {
-                            flags_ext |= VARIABLE + VAR_CHAR_FOUND;
+                        b'$' if !flags.contains(IS_VALID) => {
+                            flags_ext |= VARIABLE | VAR_CHAR_FOUND;
                             index += 1;
                             continue
                         },
-                        b'[' if flags_ext & ARRAY_CHAR_FOUND != 0 => {
+                        b'[' if flags_ext.contains(ARRAY_CHAR_FOUND) => {
                             array_process_levels += 1;
                             flags |= ARRAY_PROCESS;
                         },
                         b'['                               => array_levels += 1,
                         b']' if array_levels != 0          => array_levels -= 1,
                         b']'                               => array_process_levels -= 1,
-                        b'(' if flags_ext & VAR_CHAR_FOUND != 0 => {
+                        b'(' if flags_ext.contains(VAR_CHAR_FOUND) => {
                             flags |= PROCESS_TWO;
                             levels += 1;
                         },
-                        b'(' if flags_ext & (VARIABLE + ARRAY) != 0 => {
+                        b'(' if flags_ext.intersects(VARIABLE | ARRAY) => {
                             flags |= METHOD;
-                            flags_ext &= 255 ^ (VARIABLE + ARRAY);
+                            flags_ext -= VARIABLE | ARRAY;
                         },
-                        b')' if levels == 0 && flags & METHOD != 0 && flags & SINGLE_QUOTE == 0 => {
-                            flags &= 255 ^ METHOD;
+                        b')' if levels == 0 && flags.contains(METHOD) && !flags.contains(SINGLE_QUOTE) => {
+                            flags.remove(METHOD);
                         }
-                        b')' if flags & PROCESS_TWO != 0 => {
+                        b')' if flags.contains(PROCESS_TWO) => {
                             levels -= 0;
-                            if levels == 0 { flags &= 255 ^ PROCESS_TWO; }
+                            if levels == 0 { flags.remove(PROCESS_TWO); }
                         },
                         b'\'' => flags ^= SINGLE_QUOTE,
                         b'"'  => flags ^= DOUBLE_QUOTE,
-                        b' ' | b'\t' if flags & (DOUBLE_QUOTE + IS_VALID) == 0 && array_levels == 0
+                        b' ' | b'\t' if !flags.intersects(DOUBLE_QUOTE | IS_VALID) && array_levels == 0
                             && array_process_levels == 0 =>
                         {
                             if arg_start != index {
@@ -169,9 +175,9 @@ pub fn collect(possible_error: &mut Option<&str>, args: &str) -> Pipeline {
                                 arg_start += 1;
                             }
                         },
-                        b'|' if flags & (DOUBLE_QUOTE + IS_VALID) == 0 && array_levels == 0
+                        b'|' if !flags.intersects(DOUBLE_QUOTE | IS_VALID) && array_levels == 0
                             && array_process_levels == 0 => job_found!(RedirectFrom::Stdout, true),
-                        b'&' if flags & (DOUBLE_QUOTE + IS_VALID) == 0 && array_levels == 0
+                        b'&' if !flags.intersects(DOUBLE_QUOTE | IS_VALID) && array_levels == 0
                             && array_process_levels == 0 => {
                             match args_iter.peek() {
                                 Some(&b'>') => {
@@ -181,7 +187,7 @@ pub fn collect(possible_error: &mut Option<&str>, args: &str) -> Pipeline {
                                 _ => job_found!(RedirectFrom::Stdout, false)
                             }
                         },
-                        b'^' if flags & (DOUBLE_QUOTE + IS_VALID) == 0 && array_levels == 0
+                        b'^' if !flags.intersects(DOUBLE_QUOTE | IS_VALID) && array_levels == 0
                             && array_process_levels == 0 => {
                             match args_iter.peek() {
                                 Some(&b'>') => {
@@ -195,13 +201,13 @@ pub fn collect(possible_error: &mut Option<&str>, args: &str) -> Pipeline {
                                 _ => ()
                             }
                         },
-                        b'>' if flags & (DOUBLE_QUOTE + IS_VALID) == 0 && array_levels == 0
+                        b'>' if !flags.intersects(DOUBLE_QUOTE | IS_VALID) && array_levels == 0
                             && array_process_levels == 0 => redir_found!(RedirMode::Stdout(RedirectFrom::Stdout)),
-                        b'<' if flags & (DOUBLE_QUOTE + IS_VALID) == 0 && array_levels == 0
+                        b'<' if !flags.intersects(DOUBLE_QUOTE | IS_VALID) && array_levels == 0
                             && array_process_levels == 0 => redir_found!(RedirMode::Stdin),
                         _ => (),
                     }
-                    flags_ext &= 255 ^ (VAR_CHAR_FOUND + ARRAY_CHAR_FOUND);
+                    flags_ext -= VAR_CHAR_FOUND | ARRAY_CHAR_FOUND;
                     index += 1;
                 }
                 break 'outer
@@ -229,7 +235,7 @@ pub fn collect(possible_error: &mut Option<&str>, args: &str) -> Pipeline {
                         }
                     } else {
                         match character {
-                            _ if flags & BACKSLASH != 0 => {
+                            _ if flags.contains(BACKSLASH) => {
                                 stdout_file.push(character);
                                 flags ^= BACKSLASH;
                             }
@@ -291,7 +297,7 @@ pub fn collect(possible_error: &mut Option<&str>, args: &str) -> Pipeline {
                         }
                     } else {
                         match character {
-                            _ if flags & BACKSLASH != 0 => {
+                            _ if flags.intersects(BACKSLASH) => {
                                 stdin_file.push(character);
                                 flags ^= BACKSLASH;
                             }

--- a/src/parser/pipelines.rs
+++ b/src/parser/pipelines.rs
@@ -155,11 +155,11 @@ pub fn collect(possible_error: &mut Option<&str>, args: &str) -> Pipeline {
                             flags_ext -= VARIABLE | ARRAY;
                         },
                         b')' if levels == 0 && flags.contains(METHOD) && !flags.contains(SINGLE_QUOTE) => {
-                            flags.remove(METHOD);
+                            flags -= METHOD;
                         }
                         b')' if flags.contains(PROCESS_TWO) => {
                             levels -= 0;
-                            if levels == 0 { flags.remove(PROCESS_TWO); }
+                            if levels == 0 { flags -= PROCESS_TWO; }
                         },
                         b'\'' => flags ^= SINGLE_QUOTE,
                         b'"'  => flags ^= DOUBLE_QUOTE,

--- a/src/parser/pipelines.rs
+++ b/src/parser/pipelines.rs
@@ -11,22 +11,26 @@ use shell::{Job, JobKind};
 use types::*;
 
 bitflags! {
-    pub struct Flags : u16 {
+    pub struct NormalFlags : u8 {
         const BACKSLASH = 1;
         const SINGLE_QUOTE = 2;
         const DOUBLE_QUOTE = 4;
         const ARRAY_PROCESS = 8;
         const METHOD = 16;
         const PROCESS_TWO = 32;
-
-        const ARRAY = 64;
-        const VARIABLE = 128;
-        const ARRAY_CHAR_FOUND = 256;
-        const VAR_CHAR_FOUND = 512;
         const IS_VALID = SINGLE_QUOTE.bits
                        | METHOD.bits
                        | PROCESS_TWO.bits
                        | ARRAY_PROCESS.bits;
+    }
+}
+
+bitflags! {
+    pub struct VariableFlags : u8 {
+        const ARRAY = 1;
+        const VARIABLE = 2;
+        const ARRAY_CHAR_FOUND = 4;
+        const VAR_CHAR_FOUND = 8;
     }
 }
 
@@ -57,8 +61,8 @@ pub fn collect(possible_error: &mut Option<&str>, args: &str) -> Pipeline {
     let mut jobs: Vec<Job> = Vec::new();
     let mut args_iter = args.bytes().peekable();
     let (mut index, mut arg_start) = (0, 0);
-    let mut flags = Flags::empty(); // (backslash, single_quote, double_quote, x, x, x, process_one, process_two)
-    let mut flags_ext = Flags::empty();
+    let mut flags = NormalFlags::empty(); // (backslash, single_quote, double_quote, x, x, x, process_one, process_two)
+    let mut flags_ext = VariableFlags::empty();
 
     let mut arguments = Array::new();
 

--- a/src/parser/shell_expand/words.rs
+++ b/src/parser/shell_expand/words.rs
@@ -595,7 +595,7 @@ impl<'a> WordIterator<'a> {
                 b'[' => {
                     let result = WordToken::ArrayVariable (
                         &self.data[start..self.read],
-                        self.flags & DQUOTE != 0,
+                        self.flags.contains(DQUOTE),
                         self.read_selection(iterator)
                     );
                     self.read += 1;
@@ -612,14 +612,14 @@ impl<'a> WordIterator<'a> {
                 // Only alphanumerical and underscores are allowed in variable names
                 0...47 | 58...64 | 91...94 | 96 | 123...127 => {
                     return WordToken::ArrayVariable(&self.data[start..self.read],
-                                                    self.flags & DQUOTE != 0,
+                                                    self.flags.contains(DQUOTE),
                                                     Select::All);
                 },
                 _ => (),
             }
             self.read += 1;
         }
-        WordToken::ArrayVariable(&self.data[start..], self.flags & DQUOTE != 0, Select::All)
+        WordToken::ArrayVariable(&self.data[start..], self.flags.contains(DQUOTE), Select::All)
     }
 
     /// Contains the logic for parsing subshell syntax.

--- a/src/parser/statements.rs
+++ b/src/parser/statements.rs
@@ -7,15 +7,19 @@ use std::io::{self, Write};
 use shell::flow_control::Statement;
 use super::peg::parse;
 
-const SQUOTE: u16 = 1;
-const DQUOTE: u16 = 2;
-const BACKSL: u16 = 4;
-const COMM_1: u16 = 8;
-const COMM_2: u16 = 16;
-const VBRACE: u16 = 32;
-const ARRAY:  u16 = 64;
-const VARIAB: u16 = 128;
-const METHOD: u16 = 256;
+bitflags! {
+    pub struct Flags : u16 {
+        const SQUOTE = 1;
+        const DQUOTE = 2;
+        const BACKSL = 4;
+        const COMM_1 = 8;
+        const COMM_2 = 16;
+        const VBRACE = 32;
+        const ARRAY  = 64;
+        const VARIAB = 128;
+        const METHOD = 256;
+    }
+}
 
 
 #[derive(Debug, PartialEq)]
@@ -67,7 +71,7 @@ pub fn check_statement<'a>(statement: Result<&str, StatementError<'a>>) -> State
 pub struct StatementSplitter<'a> {
     data:  &'a str,
     read:  usize,
-    flags: u16,
+    flags: Flags,
     array_level: u8,
     array_process_level: u8,
     process_level: u8,
@@ -79,7 +83,7 @@ impl<'a> StatementSplitter<'a> {
         StatementSplitter {
             data: data,
             read: 0,
-            flags: 0,
+            flags: Flags::empty(),
             array_level: 0,
             array_process_level: 0,
             process_level: 0,
@@ -99,30 +103,30 @@ impl<'a> Iterator for StatementSplitter<'a> {
         for character in self.data.bytes().skip(self.read) {
             self.read += 1;
             match character {
-                0...47 | 58...64 | 91...94 | 96 | 123...124 | 126...127 if self.flags & VBRACE != 0 => {
+                0...47 | 58...64 | 91...94 | 96 | 123...124 | 126...127 if self.flags.contains(VBRACE) => {
                     // If we are just ending the braced section continue as normal
                     if error.is_none() {
                         error = Some(StatementError::InvalidCharacter(character as char, self.read))
                     }
                 },
-                _ if self.flags & BACKSL != 0     => self.flags ^= BACKSL,
-                b'\\'                             => self.flags ^= BACKSL,
-                b'\'' if self.flags & DQUOTE == 0 => self.flags ^= SQUOTE,
-                b'"'  if self.flags & SQUOTE == 0 => self.flags ^= DQUOTE,
-                b'@'  if self.flags & SQUOTE == 0 => {
-                    self.flags &= u16::MAX ^ COMM_1;
-                    self.flags |= COMM_2 + ARRAY;
+                _ if self.flags.contains(BACKSL)      => self.flags.toggle(BACKSL),
+                b'\\'                                 => self.flags.toggle(BACKSL),
+                b'\'' if !self.flags.contains(DQUOTE) => self.flags.toggle(SQUOTE),
+                b'"'  if !self.flags.contains(SQUOTE) => self.flags.toggle(DQUOTE),
+                b'@'  if !self.flags.contains(SQUOTE) => {
+                    self.flags -= COMM_1;
+                    self.flags |= COMM_2 | ARRAY;
                     continue
                 }
-                b'$'  if self.flags & SQUOTE == 0 => {
-                    self.flags &= u16::MAX ^ COMM_2;
-                    self.flags |= COMM_1 + VARIAB;
+                b'$' if !self.flags.contains(SQUOTE) => {
+                    self.flags -= COMM_2;
+                    self.flags |= COMM_1 | VARIAB;
                     continue
                 },
-                b'{'  if self.flags & COMM_1 != 0 => self.flags |= VBRACE,
-                b'{'  if self.flags & (SQUOTE + DQUOTE) == 0 => self.brace_level += 1,
-                b'}'  if self.flags & VBRACE != 0 => self.flags ^= VBRACE,
-                b'}'  if self.flags & (SQUOTE + DQUOTE) == 0 => {
+                b'{' if self.flags.contains(COMM_1) => self.flags |= VBRACE,
+                b'{' if !self.flags.intersects(SQUOTE | DQUOTE) => self.brace_level += 1,
+                b'}' if self.flags.contains(VBRACE) => self.flags.toggle(VBRACE),
+                b'}' if !self.flags.intersects(SQUOTE | DQUOTE) => {
                     if self.brace_level == 0 {
                         if error.is_none() {
                             error = Some(StatementError::InvalidCharacter(character as char, self.read))
@@ -131,46 +135,46 @@ impl<'a> Iterator for StatementSplitter<'a> {
                         self.brace_level -= 1;
                     }
                 },
-                b'('  if self.flags & (COMM_1 + VARIAB + ARRAY) == 0 => {
-                    if error.is_none() && self.flags & (SQUOTE + DQUOTE) == 0 {
+                b'('  if !self.flags.intersects(COMM_1 | VARIAB | ARRAY) => {
+                    if error.is_none() && !self.flags.intersects(SQUOTE | DQUOTE) {
                         error = Some(StatementError::InvalidCharacter(character as char, self.read))
                     }
                 },
-                b'(' if self.flags & COMM_1 != 0 => {
+                b'(' if self.flags.contains(COMM_1) => {
                     self.process_level += 1;
-                    self.flags &= u16::MAX ^ (VARIAB + ARRAY);
+                    self.flags -= VARIAB | ARRAY;
                 },
-                b'(' if self.flags & (VARIAB + ARRAY) != 0 => {
-                    self.flags &= u16::MAX ^ (VARIAB + ARRAY);
+                b'(' if self.flags.intersects(VARIAB | ARRAY) => {
+                    self.flags -= VARIAB | ARRAY;
                     self.flags |= METHOD;
                 },
-                b'[' if self.flags & COMM_2 != 0 => {
+                b'[' if self.flags.contains(COMM_2) => {
                     self.array_process_level += 1;
                 },
-                b'[' if self.flags & SQUOTE == 0 => self.array_level += 1,
-                b']' if self.array_process_level == 0 && self.array_level == 0 && self.flags & SQUOTE == 0 => {
+                b'[' if !self.flags.contains(SQUOTE) => self.array_level += 1,
+                b']' if self.array_process_level == 0 && self.array_level == 0 && !self.flags.contains(SQUOTE) => {
                     if error.is_none() {
                         error = Some(StatementError::InvalidCharacter(character as char, self.read))
                     }
                 },
-                b']' if self.flags & SQUOTE == 0 && self.array_level != 0 => self.array_level -= 1,
-                b']' if self.flags & SQUOTE == 0 => self.array_process_level -= 1,
-                b')' if self.flags & SQUOTE == 0 && self.flags & METHOD != 0 => {
+                b']' if !self.flags.contains(SQUOTE) && self.array_level != 0 => self.array_level -= 1,
+                b']' if !self.flags.contains(SQUOTE) => self.array_process_level -= 1,
+                b')' if !self.flags.contains(SQUOTE) && self.flags.contains(METHOD) => {
                     self.flags ^= METHOD;
                 },
-                b')' if self.process_level == 0 && self.array_level == 0 && self.flags & SQUOTE == 0 => {
-                    if error.is_none() && self.flags & (SQUOTE + DQUOTE) == 0 {
+                b')' if self.process_level == 0 && self.array_level == 0 && !self.flags.contains(SQUOTE) => {
+                    if error.is_none() && !self.flags.intersects(SQUOTE | DQUOTE) {
                         error = Some(StatementError::InvalidCharacter(character as char, self.read))
                     }
                 },
-                b')' if self.flags & SQUOTE == 0 => self.process_level -= 1,
-                b';'  if (self.flags & (SQUOTE + DQUOTE) == 0) && self.process_level == 0 && self.array_process_level == 0 => {
+                b')' if !self.flags.contains(SQUOTE) => self.process_level -= 1,
+                b';' if !self.flags.intersects(SQUOTE | DQUOTE) && self.process_level == 0 && self.array_process_level == 0 => {
                     return match error {
                         Some(error) => Some(Err(error)),
                         None        => Some(Ok(self.data[start..self.read-1].trim()))
                     };
                 },
-                b'#' if self.flags & (SQUOTE + DQUOTE) == 0 && self.process_level == 0 && self.array_process_level == 0 => {
+                b'#' if !self.flags.intersects(SQUOTE | DQUOTE) && self.process_level == 0 && self.array_process_level == 0 => {
                     let output = self.data[start..self.read-1].trim();
                     self.read = self.data.len();
                     return match error {
@@ -202,7 +206,7 @@ impl<'a> Iterator for StatementSplitter<'a> {
                 }
                 _ => ()
             }
-            self.flags &= u16::MAX ^ (COMM_1 + COMM_2);
+            self.flags -= COMM_1 | COMM_2;
         }
 
         if start == self.read {
@@ -216,8 +220,8 @@ impl<'a> Iterator for StatementSplitter<'a> {
                 {
                     Some(Err(StatementError::UnterminatedSubshell))
                 },
-                None if self.flags & METHOD != 0 => Some(Err(StatementError::UnterminatedMethod)),
-                None if self.flags & VBRACE != 0 => Some(Err(StatementError::UnterminatedBracedVar)),
+                None if self.flags.contains(METHOD) => Some(Err(StatementError::UnterminatedMethod)),
+                None if self.flags.contains(VBRACE) => Some(Err(StatementError::UnterminatedBracedVar)),
                 None if self.brace_level != 0    => Some(Err(StatementError::UnterminatedBrace)),
                 None => {
                     let output = self.data[start..].trim();


### PR DESCRIPTION
**Problem**: There are small ergonomics issues with using hand-rolled bit flags as described in #308.

**Solution**: Replace the use of the hand-rolled flags with auto-generated `bitflags` structures that provide nice mnemonics for membership while being mostly compatible with the old syntax.

**Changes introduced by this pull request**:
- Bitflags have been replaced with `bitflag!` equivalents as per the [bitflag crate](https://docs.rs/bitflags/0.9.1/bitflags/)

**Drawbacks**: 
- I'm not entirely sure if this is any more readable than before: part of the problem is `contains` versus `intersects`, where `foo.contains(bar)` is `foo & bar == bar` and `foo.intersects(bar)` is `foo & bar != 0`. These names are non-intuitive.
- In addition to the above, the operators tended to be much more concise so for the most part I tried to not replace them with the mnemonics. 
- There is a _slight_ chance that this is overall less efficient (more function calls) but I highly doubt it; the `bitflags` crate essentially has `#[inline]` on every function

**Fixes**: Closes #308.

**State**: I'm on the fence on whether or not this is a worthwhile addition, but I have nothing else to add.