### PR TITLE
Remove extra read increment in glob branch

### DIFF
--- a/src/parser/shell_expand/words.rs
+++ b/src/parser/shell_expand/words.rs
@@ -1255,4 +1255,15 @@ mod tests {
         compare(input, expected);
     }
 
+    #[test]
+    fn test_globbing() {
+        let input = "barbaz* bingcrosb*";
+        let expected = vec![
+            WordToken::Normal("barbaz*", true),
+            WordToken::Whitespace(" "),
+            WordToken::Normal("bingcrosb*", true)
+        ];
+        compare(input, expected);
+    }
+
 }

--- a/src/parser/shell_expand/words.rs
+++ b/src/parser/shell_expand/words.rs
@@ -1042,7 +1042,6 @@ impl<'a> Iterator for WordIterator<'a> {
                     }
                 },
                 b'*'|b'?' if !self.flags.contains(SQUOTE) => {
-                    self.read += 1;
                     glob = true;
                 },
                 _ => (),


### PR DESCRIPTION
**Fixes**: Closes #324. 

The glob match case incremented `self.read` in addition to the increment that occurs after the match statement. This caused `self.read` to be larger than the length of the input string.
