### PR TITLE
Add `@graphemes(..)`, `@bytes(..)` and `@chars(..)`

### DIFF
--- a/src/parser/shell_expand/words.rs
+++ b/src/parser/shell_expand/words.rs
@@ -1324,4 +1324,49 @@ mod tests {
         compare(input, expected);
     }
 
+    macro_rules! functions_with_vars {
+        () => {
+            ExpanderFunctions {
+                vars:     &Variables::default(),
+                tilde:    &|_| None,
+                array:    &|_, _| None,
+                variable:  &|var : &str, _| match var {
+                    "pkmn1" => "Pokémon".to_owned().into(),
+                    "pkmn2" => "Poke\u{0301}mon".to_owned().into(),
+                    _ => None
+                },
+                command: &|_, _| None,
+            }
+        }
+    }
+
+    #[test]
+    fn array_methods() {
+        let expanders = functions_with_vars!();
+        let method = ArrayMethod {
+            method: "graphemes",
+            variable: "pkmn1",
+            pattern: Pattern::Whitespace,
+            selection: Select::Index(Index::Forward(3))
+        };
+        let expected = Array::from_vec(vec!["é".into()]);
+        assert_eq!(method.handle_as_array(&expanders), expected);
+        let method = ArrayMethod {
+            method: "chars",
+            variable: "pkmn2",
+            pattern: Pattern::Whitespace,
+            selection: Select::Index(Index::Forward(3))
+        };
+        let expected = Array::from_vec(vec!["e".into()]);
+        assert_eq!(method.handle_as_array(&expanders), expected);
+        let method = ArrayMethod {
+            method: "bytes",
+            variable: "pkmn2",
+            pattern: Pattern::Whitespace,
+            selection: Select::Index(Index::Forward(1))
+        };
+        let expected = Array::from_vec(vec!["111".into()]);
+        assert_eq!(method.handle_as_array(&expanders), expected);
+    }
+
 }

--- a/src/parser/shell_expand/words.rs
+++ b/src/parser/shell_expand/words.rs
@@ -1,6 +1,10 @@
 use std::io::{self, Write};
 use std::char;
 use std::str::FromStr;
+use std::iter::{empty, FromIterator};
+
+use super::unicode_segmentation::UnicodeSegmentation;
+
 use super::{ExpanderFunctions, expand_string};
 use super::ranges::parse_index_range;
 
@@ -138,6 +142,36 @@ pub enum Select {
     Range(Range)
 }
 
+pub trait SelectWithSize {
+    type Item;
+    fn select<O>(&mut self, Select, usize) -> O where O : FromIterator<Self::Item>;
+}
+
+impl<I, T> SelectWithSize for I where I : Iterator<Item=T> {
+    type Item = T;
+    fn select<O>(&mut self, s : Select, size : usize) -> O where O : FromIterator<Self::Item> {
+        match s {
+            Select::None => empty().collect(),
+            Select::All => self.collect(),
+            Select::Index(idx) =>
+                idx.resolve(size)
+                   .and_then(|idx| self.nth(idx))
+                   .into_iter()
+                   .collect(),
+            Select::Range(range) => {
+                if let Some((start, length)) = range.bounds(size) {
+                    self.skip(start)
+                        .take(length)
+                        .collect()
+                } else {
+                    empty().collect()
+                }
+            }
+        }
+    }
+
+}
+
 pub enum SelectError {
     Invalid
 }
@@ -170,6 +204,7 @@ enum Pattern<'a> {
     Whitespace,
 }
 
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct ArrayMethod<'a> {
     method: &'a str,
@@ -179,9 +214,14 @@ pub struct ArrayMethod<'a> {
 }
 
 impl<'a> ArrayMethod<'a> {
+
     pub fn returns_array(&self) -> bool {
-        self.method == "split"
+        match self.method {
+            "split" | "chars" | "bytes" | "graphemes" => true,
+            _ => false
+        }
     }
+
     pub fn handle(&self, current: &mut String, expand_func: &ExpanderFunctions) {
         match self.method {
             "len" => match expand_func.vars.get_array(self.variable) {
@@ -318,6 +358,24 @@ impl<'a> ArrayMethod<'a> {
                         }
                     },
                 }
+            },
+            "graphemes" => if let Some(variable) = (expand_func.variable)(self.variable, false) {
+                let graphemes = UnicodeSegmentation::graphemes(variable.as_str(), true);
+                let len = graphemes.clone().count();
+                return graphemes.map(From::from)
+                                .select(self.selection, len);
+            },
+            "bytes" => if let Some(variable) = (expand_func.variable)(self.variable, false) {
+                let len = variable.as_bytes().len();
+                return variable.bytes()
+                               .map(|b| b.to_string())
+                               .select(self.selection, len);
+            },
+            "chars" => if let Some(variable) = (expand_func.variable)(self.variable, false) {
+                let len = variable.chars().count();
+                return variable.chars()
+                               .map(|c| c.to_string())
+                               .select(self.selection, len);
             },
             _ => {
                 let stderr = io::stderr();


### PR DESCRIPTION
**Problem**: Users cannot iterate over the contents of a string easily.

**Solution**: Add in three new `ArrayMethod`s that map from string variables to arrays:
- `@graphemes(..)` iterates over the unicode graphemes of the string as per [this crate](https://github.com/unicode-rs/unicode-segmentation)
- `@bytes(..)` iterates over the UTF-8 byte sequence that corresponds to the given string
- `@chars(..)` iterates over the unicode scalars of the byte sequence as per [`String::chars`](https://doc.rust-lang.org/std/string/struct.String.html#method.chars)

**Changes introduced by this pull request**:
- Add the three above methods to `parser::shell_expand::words`
- Introduce a new trait for applying a `Select` variant to an iterator DRYer

**Drawbacks**: 
- The `SelectWithSize` trait is not optimal as it always requires the size of the iterator that is passed in; in most cases we are not dealing with `ExactSizeIterator` so this requires making a copy of the iterator and using `Iterator::count()`.
- Having `SelectWithSize::select` work like `collect` means that it is costly to map / filter / reduce after calling `select`, but I don't think this will be an issue.

**Fixes**: Closes #316 

**State**: WIP: I'm not quite sure if `SelectWithSize` is the right approach. Any and all thoughts are appreciated.

**Other**: 
- Depending on how we feel about `SelectWithSize` I want to start refactoring code that can be replaced with a similar pattern.
- The alternative for `SelectWithSize` is a `Select<I>` iterator; we could implement `From<I>` for other iterators, which would allow us to specialize the logic more efficiently (versus having a catch-all solution that).
