### PR TITLE
Shell::readln now completes to a filename if the last word is a file 

### DIFF
--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -77,7 +77,7 @@ impl<'a> Shell<'a> {
             sigint_handle: ctrl_c
         }
     }
-
+    
     fn readln(&mut self) -> Option<String> {
         let vars_ptr = &self.variables as *const Variables;
         let dirs_ptr = &self.directory_stack as *const DirectoryStack;

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -77,6 +77,7 @@ impl<'a> Shell<'a> {
             sigint_handle: ctrl_c
         }
     }
+
     fn readln(&mut self) -> Option<String> {
         let vars_ptr = &self.variables as *const Variables;
         let dirs_ptr = &self.directory_stack as *const DirectoryStack;
@@ -103,13 +104,17 @@ impl<'a> Shell<'a> {
                         CursorPosition::InSpace(None, _) => false,
                         CursorPosition::OnWordLeftEdge(index) => index >= 1,
                         CursorPosition::OnWordRightEdge(index) => {
-                            words.into_iter()
-                                 .nth(index)
-                                 .map(|(start, end)|{
+                            if let Some((start, end)) = words.into_iter().nth(index) {
+                                if let Ok(mut file) = env::current_dir() {
                                     let filename = editor.current_buffer().range(start, end);
-                                    let file = Path::new(&filename);
-                                    file.exists() || file.parent().map(|p| p.exists()).unwrap_or(false)
-                                 }).unwrap_or(false)
+                                    file.push(filename);
+                                    file.exists() || file.parent().map(Path::exists).unwrap_or(false)
+                                } else {
+                                    false
+                                }
+                            } else {
+                                false
+                            }
                         }
                     };
 

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -103,10 +103,13 @@ impl<'a> Shell<'a> {
                         CursorPosition::InSpace(None, _) => false,
                         CursorPosition::OnWordLeftEdge(index) => index >= 1,
                         CursorPosition::OnWordRightEdge(index) => {
-                            index >= 1 && !words.into_iter().nth(index).map(|(start, end)| {
-                                let buf = editor.current_buffer();
-                                buf.range(start, end).trim().starts_with('$')
-                            }).unwrap_or(false)
+                            words.into_iter()
+                                 .nth(index)
+                                 .map(|(start, end)|{
+                                    let filename = editor.current_buffer().range(start, end);
+                                    let file = Path::new(&filename);
+                                    file.exists() || file.parent().map(|p| p.exists()).unwrap_or(false)
+                                 }).unwrap_or(false)
                         }
                     };
 


### PR DESCRIPTION
**Related Issues**: Closes #321 

**Changes introduced in this pull request**:
- `Shell::readln` now determines if the first word is either an existing directory, or is potentially a directory (i.e. if the parent exists as a folder)

**TODO**:
- [x] Use `DirectoryStack` instead of getting the current directory from the environment
- [x] How does this react if the user types a completely wrong directory?
