### PR TITLE
Empty string can now be passed in as an argument to a function / command / etc.

### DIFF
--- a/src/parser/shell_expand/words.rs
+++ b/src/parser/shell_expand/words.rs
@@ -923,10 +923,6 @@ impl<'a> WordIterator<'a> {
     }
 }
 
-fn filter_empty<'a>(input : &'a str) -> Option<&'a str> {
-    if input == "" { None } else { Some(input) }
-}
-
 impl<'a> Iterator for WordIterator<'a> {
     type Item = WordToken<'a>;
 
@@ -1085,8 +1081,9 @@ impl<'a> Iterator for WordIterator<'a> {
                     return Some(WordToken::Normal(&self.data[start..self.read],glob));
                 },
                 b'$' | b'@' if !self.flags.contains(SQUOTE) => {
-                    if let Some(s) = filter_empty(&self.data[start..self.read]) {
-                        return Some(WordToken::Normal(s, glob));
+                    let output = &self.data[start..self.read];
+                    if output != "" {
+                        return Some(WordToken::Normal(output, glob));
                     } else {
                         return self.next();
                     };

--- a/src/parser/shell_expand/words.rs
+++ b/src/parser/shell_expand/words.rs
@@ -957,6 +957,7 @@ impl<'a> Iterator for WordIterator<'a> {
                         if !self.flags.contains(EXPAND_PROCESSES) {
                             return Some(WordToken::Normal("'",glob));
                         }
+                        break;
                     },
                     b'"' if !self.flags.contains(SQUOTE) => {
                         start += 1;
@@ -965,6 +966,7 @@ impl<'a> Iterator for WordIterator<'a> {
                         if !self.flags.contains(EXPAND_PROCESSES) {
                             return Some(WordToken::Normal("\"",glob));
                         }
+                        break;
                     }
                     b' ' if !self.flags.intersects(DQUOTE | SQUOTE) => {
                         return Some(self.whitespaces(&mut iterator));
@@ -1305,6 +1307,23 @@ mod tests {
             WordToken::Normal("barbaz*", true),
             WordToken::Whitespace(" "),
             WordToken::Normal("bingcrosb*", true)
+        ];
+        compare(input, expected);
+    }
+
+    #[test]
+    fn test_empty_strings() {
+        let input = "rename '' 0 a \"\"";
+        let expected = vec![
+            WordToken::Normal("rename", false),
+            WordToken::Whitespace(" "),
+            WordToken::Normal("", false),
+            WordToken::Whitespace(" "),
+            WordToken::Normal("0", false),
+            WordToken::Whitespace(" "),
+            WordToken::Normal("a", false),
+            WordToken::Whitespace(" "),
+            WordToken::Normal("", false)
         ];
         compare(input, expected);
     }


### PR DESCRIPTION
**Changes introduced by this pull request**:
- Allow the empty string to be parsed as `WordToken::Normal("")` by allowing a double quote to be the first char of a `WordToken::Normal` sequence
- Added a case where if a `WordToken::Normal` would be the empty string, replace it with whatever the next token would be
  - This prevents cases like `"$FOO"` from generating empty tokens due to having a quote immediately before a `$`
- Added a regression test for this behavior

**Fixes**: Closes #345.

**State**: Good to go!