### PR TITLE
Fixed completing executables

### DIFF
--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -78,6 +78,9 @@ impl<'a> Shell<'a> {
         }
     }
 
+    /// Infer if the given filename is actually a partial filename by determining if
+    /// the file exsits in the current directory, or if the parent of the file exists in the
+    /// current directory, and is not the directory itself
     fn is_file_completion(current_dir : PathBuf, filename : String) -> bool {
         let mut file = current_dir.clone();
         file.push(filename);

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -18,7 +18,7 @@ use std::fs::File;
 use std::io::{self, ErrorKind, Read, Write};
 use std::env;
 use std::mem;
-use std::path::Path;
+use std::path::{PathBuf, Path};
 use std::process;
 use std::time::SystemTime;
 use std::iter::FromIterator;
@@ -77,7 +77,19 @@ impl<'a> Shell<'a> {
             sigint_handle: ctrl_c
         }
     }
-    
+
+    fn is_file_completion(current_dir : PathBuf, filename : String) -> bool {
+        let mut file = current_dir.clone();
+        file.push(filename);
+        if file.exists() {
+            true
+        } else if let Some(parent) = file.parent() {
+            parent.exists() && parent != current_dir
+        } else {
+            false
+        }
+    }
+
     fn readln(&mut self) -> Option<String> {
         let vars_ptr = &self.variables as *const Variables;
         let dirs_ptr = &self.directory_stack as *const DirectoryStack;
@@ -105,10 +117,9 @@ impl<'a> Shell<'a> {
                         CursorPosition::OnWordLeftEdge(index) => index >= 1,
                         CursorPosition::OnWordRightEdge(index) => {
                             if let Some((start, end)) = words.into_iter().nth(index) {
-                                if let Ok(mut file) = env::current_dir() {
+                                if let Ok(file) = env::current_dir() {
                                     let filename = editor.current_buffer().range(start, end);
-                                    file.push(filename);
-                                    file.exists() || file.parent().map(Path::exists).unwrap_or(false)
+                                    Shell::is_file_completion(file, filename)
                                 } else {
                                     false
                                 }


### PR DESCRIPTION
The problem was that for any filename "foo", `readln` would check to see if either it exists, or if the parent exists. Which means if you're trying to complete _any_ executable, it thinks its a file because the "parent" is the current directory.

Closes #352.