### PR TITLE
Force run_examples.sh to use project root as working directory

### DIFF
--- a/examples/run_examples.sh
+++ b/examples/run_examples.sh
@@ -11,6 +11,10 @@ PROJECT_DIR=$(dirname $(cargo locate-project | awk -F\" '{print $4}'))
 
 EXIT_VAL=0
 
+# Some of the examples assume that the working directory is the project root
+# and it never hurts to force consistency regardless
+cd $PROJECT_DIR
+
 function check_return_value {
 
     # Check number of parameters passed into the check function


### PR DESCRIPTION
In particular, `glob.ion` was failing if I ran `run_examples.sh` in the examples folder.