### PR TITLE
Job control: libc constants, pid fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Below is an overview of features that Ion has either already implemented, or aim
 - [x] Background Jobs
 - [ ] Piping Functions
 - [ ] Redirecting Functions
-- [ ] Background Job Control
+- [x] Background Job Control
 - [ ] XDG App Dirs
 - [ ] Plugins Support
     - [ ] Builtins

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,10 +73,10 @@ fn main() {
     let mut core = Core::new().unwrap();
     let handle = core.handle();
 
-    // Create a stream that will select over SIGINT and SIGTERM signals.
+    // Create a stream that will select over SIGINT, SIGTERM and SIGTSTP signals.
     let signal_stream = Signal::new(unix_signal::SIGINT, &handle).flatten_stream()
         .select(Signal::new(unix_signal::SIGTERM, &handle).flatten_stream())
-        .select(Signal::new(20i32, &handle).flatten_stream()); // SIGTSTP
+        .select(Signal::new(libc::SIGTSTP, &handle).flatten_stream());
 
     // Execute the event loop that will listen for and transmit received
     // signals to the shell.

--- a/src/shell/flow.rs
+++ b/src/shell/flow.rs
@@ -10,6 +10,8 @@ use parser::{ForExpression, StatementSplitter, check_statement, expand_string, S
 use parser::peg::Pipeline;
 use super::assignments::{let_assignment, export_variable};
 use types::Array;
+#[cfg(not(target_os = "redox"))]
+use libc;
 
 pub enum Condition {
     Continue,
@@ -283,7 +285,7 @@ impl<'a> FlowLogic for Shell<'a> {
                 _ => {}
             }
             if let Ok(signal) = self.signals.try_recv() {
-                if signal != 20 {
+                if cfg!(not(target_os = "redox")) && signal != libc::SIGTSTP {
                     self.handle_signal(signal);
                 }
                 return Condition::SigInt;

--- a/src/shell/job_control.rs
+++ b/src/shell/job_control.rs
@@ -14,7 +14,7 @@ pub trait JobControl {
     fn handle_signal(&self, signal: i32);
     fn foreground_send(&self, signal: i32);
     fn background_send(&self, signal: i32);
-    fn send_child_to_background(&mut self, child: Child, state: ProcessState, offset: u32);
+    fn send_child_to_background(&mut self, child: Child, state: ProcessState);
 }
 
 #[derive(Clone)]
@@ -113,11 +113,8 @@ impl<'a> JobControl for Shell<'a> {
         // TODO: Redox doesn't support signals yet
     }
 
-    fn send_child_to_background(&mut self, mut child: Child, state: ProcessState, offset: u32) {
-        // NOTE: Why is this always off?
-        // command args + Ctrl + Z: off by 1
-        // commands args &: off by 2
-        let pid = child.id() + offset;
+    fn send_child_to_background(&mut self, mut child: Child, state: ProcessState) {
+        let pid = child.id();
         let processes = self.background.clone();
         let _ = spawn(move || {
             let njob;

--- a/src/shell/pipe.rs
+++ b/src/shell/pipe.rs
@@ -92,7 +92,7 @@ fn pipe(shell: &mut Shell, commands: &mut [(Command, JobKind)]) -> i32 {
         match kind {
             JobKind::Background => {
                 if let Err(_) = command.spawn()
-                    .map(|child| shell.send_child_to_background(child, ProcessState::Running, 2))
+                    .map(|child| shell.send_child_to_background(child, ProcessState::Running))
                 {
                     let stderr = io::stderr();
                     let mut stderr = stderr.lock();
@@ -218,7 +218,7 @@ fn wait_on_child(shell: &mut Shell, mut child: Child) -> i32 {
                     if signal == libc::SIGTSTP {
                         shell.received_sigtstp = true;
                         shell.suspend(child.id());
-                        shell.send_child_to_background(child, ProcessState::Stopped, 1);
+                        shell.send_child_to_background(child, ProcessState::Stopped);
                         break SUCCESS
                     } else {
                         if let Err(why) = child.kill() {
@@ -264,7 +264,7 @@ fn wait(shell: &mut Shell, children: &mut Vec<Option<Child>>) -> i32 {
                             if signal == libc::SIGTSTP {
                                 shell.received_sigtstp = true;
                                 shell.suspend(child.id());
-                                shell.send_child_to_background(child, ProcessState::Stopped, 1);
+                                shell.send_child_to_background(child, ProcessState::Stopped);
                                 break SUCCESS
                             }
                             shell.foreground_send(signal);
@@ -305,7 +305,7 @@ fn wait(shell: &mut Shell, children: &mut Vec<Option<Child>>) -> i32 {
                         if signal == libc::SIGTSTP {
                             shell.received_sigtstp = true;
                             shell.suspend(child.id());
-                            shell.send_child_to_background(child, ProcessState::Stopped, 1);
+                            shell.send_child_to_background(child, ProcessState::Stopped);
                             break SUCCESS
                         }
                         shell.foreground_send(signal);


### PR DESCRIPTION
This PR removes hardcoded signal numbers and adds `-1` to the PID when sending SIGCONT. #29

Tested on FreeBSD, Arch Linux and the Windows Subsystem for Linux. Redox might be even more broken though.