### PR TITLE
Fix redox build

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ extern crate smallstring;
 #[cfg(all(unix, not(target_os = "redox")))] extern crate tokio_core;
 #[cfg(all(unix, not(target_os = "redox")))] extern crate tokio_signal;
 #[cfg(all(unix, not(target_os = "redox")))] extern crate users as users_unix;
-#[cfg(target_os = "redox")] extern crate redox_syscall;
+#[cfg(target_os = "redox")] extern crate syscall;
 
 #[macro_use] mod parser;
 mod builtins;

--- a/src/shell/flow.rs
+++ b/src/shell/flow.rs
@@ -10,7 +10,6 @@ use parser::{ForExpression, StatementSplitter, check_statement, expand_string, S
 use parser::peg::Pipeline;
 use super::assignments::{let_assignment, export_variable};
 use types::Array;
-#[cfg(all(unix, not(target_os = "redox")))] use libc;
 
 pub enum Condition {
     Continue,

--- a/src/shell/flow.rs
+++ b/src/shell/flow.rs
@@ -284,9 +284,7 @@ impl<'a> FlowLogic for Shell<'a> {
                 _ => {}
             }
             if let Ok(signal) = self.signals.try_recv() {
-                if cfg!(not(target_os = "redox")) && signal != libc::SIGTSTP {
-                    self.handle_signal(signal);
-                }
+                self.handle_signal(signal);
                 return Condition::SigInt;
             } else if self.received_sigtstp {
                 self.received_sigtstp = false;

--- a/src/shell/job_control.rs
+++ b/src/shell/job_control.rs
@@ -194,10 +194,16 @@ impl<'a> JobControl for Shell<'a> {
 
     /// If a SIGTERM is received, a SIGTERM will be sent to all background processes
     /// before the shell terminates itself.
+    #[cfg(all(unix, not(target_os = "redox")))]
     fn handle_signal(&self, signal: i32) {
         if signal == libc::SIGTERM {
             self.background_send(libc::SIGTERM);
             process::exit(TERMINATED);
         }
+    }
+
+    #[cfg(target_os = "redox")]
+    fn handle_signal(&self, _: i32) {
+        // TODO: Redox doesn't support signals yet;
     }
 }

--- a/src/shell/job_control.rs
+++ b/src/shell/job_control.rs
@@ -36,7 +36,7 @@ impl fmt::Display for ProcessState {
 }
 
 #[cfg(target_os = "redox")]
-pub fn watch_pid(processes: Arc<Mutex<Vec<BackgroundProcess>>>, pid: u32) {
+pub fn watch_pid(processes: Arc<Mutex<Vec<BackgroundProcess>>>, pid: u32, njob: usize) {
     // TODO: Implement this using syscall::call::waitpid
 }
 

--- a/src/shell/pipe.rs
+++ b/src/shell/pipe.rs
@@ -238,13 +238,14 @@ fn terminate_fg(shell: &mut Shell) {
 }
 
 #[cfg(all(unix, not(target_os = "redox")))]
-fn is_sigtstp(signal: i32) {
+fn is_sigtstp(signal: i32) -> bool {
     signal == libc::SIGTSTP
 }
 
 #[cfg(target_os = "redox")]
-fn is_sigtstp(_: i32) {
+fn is_sigtstp(_: i32) -> bool {
     // TODO: Redox does not support signals
+    false
 }
 
 fn execute_command(shell: &mut Shell, command: &mut Command) -> i32 {

--- a/src/shell/pipe.rs
+++ b/src/shell/pipe.rs
@@ -87,7 +87,7 @@ enum Fork {
 
 #[cfg(target_os = "redox")]
 fn ion_fork() -> Result<Fork, Error> {
-    use redox_syscall::call::clone;
+    use syscall::call::clone;
     unsafe {
         clone(0).map(|pid| if pid == 0 { Fork::Child } else { Fork::Parent(pid as u32)})?
     }

--- a/src/shell/pipe.rs
+++ b/src/shell/pipe.rs
@@ -89,7 +89,7 @@ enum Fork {
 fn ion_fork() -> Result<Fork, Error> {
     use syscall::call::clone;
     unsafe {
-        clone(0).map(|pid| if pid == 0 { Fork::Child } else { Fork::Parent(pid as u32)})?
+        clone(0).map(|pid| if pid == 0 { Fork::Child } else { Fork::Parent(pid as u32)})
     }
 }
 
@@ -213,7 +213,7 @@ fn pipe(shell: &mut Shell, commands: &mut [(Command, JobKind)]) -> i32 {
                 }
                 previous_status = wait(shell, &mut children);
                 if previous_status == TERMINATED {
-                    shell.foreground_send(libc::SIGTERM);
+                    terminate_fg(shell);
                     return previous_status;
                 }
             }
@@ -225,6 +225,26 @@ fn pipe(shell: &mut Shell, commands: &mut [(Command, JobKind)]) -> i32 {
     }
 
     previous_status
+}
+
+#[cfg(all(unix, not(target_os = "redox")))]
+fn terminate_fg(shell: &mut Shell) {
+    shell.foreground_send(libc::SIGTERM);
+}
+
+#[cfg(target_os = "redox")]
+fn terminate_fg(shell: &mut Shell) {
+    // TODO: Redox does not support signals
+}
+
+#[cfg(all(unix, not(target_os = "redox")))]
+fn is_sigtstp(signal: i32) {
+    signal == libc::SIGTSTP
+}
+
+#[cfg(target_os = "redox")]
+fn is_sigtstp(_: i32) {
+    // TODO: Redox does not support signals
 }
 
 fn execute_command(shell: &mut Shell, command: &mut Command) -> i32 {
@@ -254,7 +274,7 @@ fn wait_on_child(shell: &mut Shell, mut child: Child) -> i32 {
             },
             Ok(None) => {
                 if let Ok(signal) = shell.signals.try_recv() {
-                    if signal == libc::SIGTSTP {
+                    if is_sigtstp(signal) {
                         shell.received_sigtstp = true;
                         let pid = child.id();
                         shell.suspend(pid);
@@ -343,7 +363,7 @@ fn wait(shell: &mut Shell, children: &mut Vec<Option<Child>>) -> i32 {
                 },
                 Ok(None) => {
                     if let Ok(signal) = shell.signals.try_recv() {
-                        if signal == libc::SIGTSTP {
+                        if is_sigtstp(signal) {
                             shell.received_sigtstp = true;
                             let pid = child.id();
                             shell.suspend(pid);


### PR DESCRIPTION
Redox build was breaking for a number of reasons:

- Apparently the crate for Redox syscalls is just `syscall`, which is news to me
- `libc` is only imported for Unix and non-redox, which means any case where we refer to a `libc` constant needs to be behind a `cfg`
- The Redox version of `watch_pid` had a different number of arguments