### PR TITLE
Fix autocomplete for partially escaped filenames

### DIFF
--- a/src/shell/completer.rs
+++ b/src/shell/completer.rs
@@ -86,7 +86,7 @@ impl Completer for IonFileCompleter {
             }
         }
 
-        self.inner.completions(start).iter().map(|x| escape(x.as_str())).collect()
+        self.inner.completions(&unescape(start)).iter().map(|x| escape(x.as_str())).collect()
     }
 }
 
@@ -103,6 +103,25 @@ fn escape(input: &str) -> String {
             _ => ()
         }
         output.push(character);
+    }
+    unsafe { String::from_utf8_unchecked(output) }
+}
+
+/// Unescapes filenames to be passed into the completer
+fn unescape(input: &str) -> String {
+    let mut output = Vec::with_capacity(input.len());
+    let mut bytes = input.bytes();
+    while let Some(b) = bytes.next() {
+        match b {
+            b'\\' => {
+                if let Some(next) = bytes.next() {
+                    output.push(next);
+                } else {
+                    output.push(b'\\')
+                }
+            }
+            _ => output.push(b),
+        }
     }
     unsafe { String::from_utf8_unchecked(output) }
 }


### PR DESCRIPTION
**Fixes**: Closes #348.

**Changes introduced by this pull request**:
- Add `unescape` which maps from escaped strings to their raw counterparts
- Add custom logic for determining word boundaries for `liner` completions; this is based off the default completer with some adjustments for backslash.

**Drawbacks**: 
- I can't remember who, but someone mentioned that we ought to have some central list of what should get escaped / un-escaped; this builds on the problem without fixing it. Additionally this does not allow something like:
```
$ touch "foo(bar)"
$ rm "foo(<Tab>
```
to autocomplete `"foo(` to `"foo(bar)"`.

**State**: Ready to go!