### PR TITLE
Update version_check to 0.1.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ tokio-signal = "0.1"
 [build-dependencies]
 peg = "0.5"
 ansi_term = "0.9"
-version_check = "0.1"
+version_check = "0.1.3"
 
 [profile.release]
 debug = true


### PR DESCRIPTION
**Problem**: There's a bug in version_check < 0.1.3 that lets the check fail on Arch Linux (and possibly other rustc builds)

**Fixes**: #393 