### PR TITLE
Test can now interpret the empty string + fresh coat of paint

### DIFF
--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -341,7 +341,11 @@ impl<'a> Shell<'a> {
                 if let Some(mut arg) = args.next() {
                     for argument in args {
                         arg.push(' ');
-                        arg.push_str(&argument);
+                        if argument == "" {
+                            arg.push_str("''");
+                        } else {
+                            arg.push_str(&argument);
+                        }
                     }
                     self.on_command(&arg);
                 } else {
@@ -467,7 +471,6 @@ impl<'a> Shell<'a> {
 
         pipeline.expand(&self.variables, &self.directory_stack);
         // Branch if -> input == shell command i.e. echo
-
         let exit_status = if let Some(command) = {
             let key: &str = pipeline.jobs[0].command.as_ref();
             builtins.get(key)


### PR DESCRIPTION
**Changes introduced by this pull request**:
- `tests.rs` now avoids the use of `unwrap` and is more generic on the output buffer.
- When Ion is invoked as `-c`, forward the empty string appropriately if given as an arg in `args()`

**Fixes**: Closes #387 
