### PR TITLE
Resolve quotes not being an escaped character

### DIFF
--- a/src/shell/completer.rs
+++ b/src/shell/completer.rs
@@ -99,7 +99,8 @@ fn escape(input: &str) -> String {
     for character in input.bytes() {
         match character {
             b'(' | b')' | b'[' | b']' | b'&' | b'$' |
-            b'@' | b'{' | b'}' | b'<' | b'>' | b';' => output.push(b'\\'),
+            b'@' | b'{' | b'}' | b'<' | b'>' | b';' |
+            b'"' | b'\'' => output.push(b'\\'),
             _ => ()
         }
         output.push(character);


### PR DESCRIPTION
**Changes introduced by this pull request**:
- Quotes are now considered escaped characters as per `IonFileCompleter`
- `pipelines::Collector` now respects escaped characters in arguments, such as quotes
- `pipelines::Collector` also will now error if not at the top level of a job, i.e. not inside an array or subshell

**Fixes**: Closes #350 
