### PR TITLE
[WIP] Add support for herestrings

### DIFF
--- a/examples/herestring.ion
+++ b/examples/herestring.ion
@@ -1,0 +1,14 @@
+echo $(tr '[a-z]' '[A-Z]' <<< foo)
+
+let output = [foo bar baz bing]
+
+fn find elem array
+  if grep -q $elem <<< $array
+    echo "true"
+  else
+    echo "false"
+  end
+end
+
+find "bar" "@output"
+find "zar" "@output"

--- a/examples/herestring.out
+++ b/examples/herestring.out
@@ -1,0 +1,3 @@
+FOO
+true
+false

--- a/src/parser/peg.rs
+++ b/src/parser/peg.rs
@@ -18,9 +18,12 @@ pub struct Redirection {
     pub append: bool
 }
 
+/// Represents input that a process could initially receive from `stdin`
 #[derive(Debug, PartialEq, Clone)]
 pub enum Input {
+    /// A file; the contents of said file will be written to the `stdin` of a process
     File(String),
+    /// A string literal that is written to the `stdin` of a process
     HereString(String),
 }
 

--- a/src/parser/peg.rs
+++ b/src/parser/peg.rs
@@ -50,7 +50,7 @@ impl Pipeline {
                 Some(Input::File(expand_string(s, &expanders, false).join(" ")))
             },
             Some(Input::HereString(ref s)) => {
-                Some(Input::HereString(expand_string(s, &expanders, false).join(" ")))
+                Some(Input::HereString(expand_string(s, &expanders, true).join(" ")))
             },
             None => None
         };

--- a/src/shell/pipe.rs
+++ b/src/shell/pipe.rs
@@ -201,15 +201,10 @@ impl<'a> PipelineExecution for Shell<'a> {
                     }
                 }
             },
-            Some(Input::HereString(ref string)) => {
+            Some(Input::HereString(ref mut string)) => {
                 if let Some(command) = piped_commands.first_mut() {
-                    let result = if string.ends_with('\n') {
-                        unsafe { crossplat::stdin_of(string) }
-                    } else {
-                        let string = [string, "\n"].concat();
-                        unsafe { crossplat::stdin_of(string) }
-                    };
-                    match result {
+                    if !string.ends_with('\n') { string.push('\n'); }
+                    match unsafe { crossplat::stdin_of(string) } {
                         Ok(stdio) => {
                             command.0.stdin(stdio);
                         },

--- a/src/shell/pipe.rs
+++ b/src/shell/pipe.rs
@@ -43,6 +43,7 @@ pub mod crossplat {
         // Write the contents; make sure to use write_all so that we block until
         // the entire string is written
         infile.write_all(input.as_ref())?;
+        infile.flush()?;
         // `infile` currently owns the writer end RawFd. If we just return the reader end
         // and let `infile` go out of scope, it will be closed, sending EOF to the reader!
         Ok(Stdio::from_raw_fd(reader))
@@ -186,7 +187,6 @@ impl<'a> PipelineExecution for Shell<'a> {
             .drain(..).map(|mut job| {
                 (job.build_command(), job.kind)
             }).collect();
-
         match pipeline.stdin {
             None => (),
             Some(Input::File(ref filename)) => {

--- a/src/shell/pipe.rs
+++ b/src/shell/pipe.rs
@@ -11,7 +11,7 @@ use super::job_control::JobControl;
 use super::{JobKind, Shell};
 use super::status::*;
 use super::signals::{self, SignalHandler};
-use parser::peg::{Pipeline, RedirectFrom};
+use parser::peg::{Pipeline, Input, RedirectFrom};
 use self::crossplat::*;
 
 /// The `crossplat` module contains components that are meant to be abstracted across
@@ -21,7 +21,7 @@ pub mod crossplat {
     use nix::{fcntl, unistd};
     use parser::peg::{RedirectFrom};
     use std::fs::File;
-    use std::io::Error;
+    use std::io::{Write, Error};
     use std::os::unix::io::{IntoRawFd, FromRawFd};
     use std::process::{Stdio, Command};
 
@@ -32,6 +32,20 @@ pub mod crossplat {
 
     pub fn get_pid() -> u32 {
         unistd::getpid() as u32
+    }
+
+    /// Create an instance of Stdio from a byte slice that will echo the
+    /// contents of the slice when read. This can be called with owned or
+    /// borrowed strings
+    pub unsafe fn stdin_of<T: AsRef<[u8]>>(input: T) -> Result<Stdio, Error> {
+        let (reader, writer) = unistd::pipe2(fcntl::O_CLOEXEC)?;
+        let mut infile = File::from_raw_fd(writer);
+        // Write the contents; make sure to use write_all so that we block until
+        // the entire string is written
+        infile.write_all(input.as_ref())?;
+        // `infile` currently owns the writer end RawFd. If we just return the reader end
+        // and let `infile` go out of scope, it will be closed, sending EOF to the reader!
+        Ok(Stdio::from_raw_fd(reader))
     }
 
     /// Set up pipes such that the relevant output of parent is sent to the stdin of child.
@@ -68,7 +82,7 @@ pub mod crossplat {
 pub mod crossplat {
     use parser::peg::{RedirectFrom};
     use std::fs::File;
-    use std::io;
+    use std::io::{self, Write};
     use std::os::unix::io::{IntoRawFd, FromRawFd};
     use std::process::{Stdio, Command};
     use syscall;
@@ -93,6 +107,19 @@ pub mod crossplat {
 
     impl From<syscall::Error> for Error {
         fn from(data: syscall::Error) -> Error { Error::Sys(data) }
+    }
+
+    pub unsafe fn stdin_of<T: AsRef<[u8]>>(input: T) -> Result<Stdio, Error> {
+        let mut fds: [usize; 2] = [0; 2];
+        syscall::call::pipe2(&mut fds, syscall::flag::O_CLOEXEC)?;
+        let (reader, writer) = (fds[0], fds[1]);
+        let infile = File::from_raw_fd(writer);
+        // Write the contents; make sure to use write_all so that we block until
+        // the entire string is written
+        infile.write_all(input.as_ref())?;
+        // `infile` currently owns the writer end RawFd. If we just return the reader end
+        // and let `infile` go out of scope, it will be closed, sending EOF to the reader!
+        Ok(Stdio::from_raw_fd(reader))
     }
 
     /// Set up pipes such that the relevant output of parent is sent to the stdin of child.
@@ -160,14 +187,30 @@ impl<'a> PipelineExecution for Shell<'a> {
                 (job.build_command(), job.kind)
             }).collect();
 
-        if let Some(ref stdin) = pipeline.stdin {
-            if let Some(command) = piped_commands.first_mut() {
-                match File::open(&stdin.file) {
-                    Ok(file) => unsafe { command.0.stdin(Stdio::from_raw_fd(file.into_raw_fd())); },
-                    Err(err) => {
-                        let stderr = io::stderr();
-                        let mut stderr = stderr.lock();
-                        let _ = writeln!(stderr, "ion: failed to redirect stdin into {}: {}", stdin.file, err);
+        match pipeline.stdin {
+            None => (),
+            Some(Input::File(ref filename)) => {
+                if let Some(command) = piped_commands.first_mut() {
+                    match File::open(filename) {
+                        Ok(file) => unsafe {
+                            command.0.stdin(Stdio::from_raw_fd(file.into_raw_fd()));
+                        },
+                        Err(e) => {
+                            eprintln!("ion: failed to redirect '{}' into stdin: {}", filename, e);
+                        }
+                    }
+                }
+            },
+            Some(Input::HereString(ref string)) => {
+                if let Some(command) = piped_commands.first_mut() {
+                    match unsafe { crossplat::stdin_of(string) } {
+                        Ok(stdio) => {
+                            command.0.stdin(stdio);
+                        },
+                        Err(e) => {
+                            eprintln!("ion: failed to redirect herestring '{}' into stdin: {}",
+                                      string, e);
+                        }
                     }
                 }
             }

--- a/src/shell/pipe.rs
+++ b/src/shell/pipe.rs
@@ -204,7 +204,7 @@ impl<'a> PipelineExecution for Shell<'a> {
             Some(Input::HereString(ref mut string)) => {
                 if let Some(command) = piped_commands.first_mut() {
                     if !string.ends_with('\n') { string.push('\n'); }
-                    match unsafe { crossplat::stdin_of(string) } {
+                    match unsafe { crossplat::stdin_of(&string) } {
                         Ok(stdio) => {
                             command.0.stdin(stdio);
                         },

--- a/src/shell/pipe.rs
+++ b/src/shell/pipe.rs
@@ -203,7 +203,13 @@ impl<'a> PipelineExecution for Shell<'a> {
             },
             Some(Input::HereString(ref string)) => {
                 if let Some(command) = piped_commands.first_mut() {
-                    match unsafe { crossplat::stdin_of(string) } {
+                    let result = if string.ends_with('\n') {
+                        unsafe { crossplat::stdin_of(string) }
+                    } else {
+                        let string = [string, "\n"].concat();
+                        unsafe { crossplat::stdin_of(string) }
+                    };
+                    match result {
                         Ok(stdio) => {
                             command.0.stdin(stdio);
                         },


### PR DESCRIPTION
**Changes introduced by this pull request**:
- Modified `Pipeline::stdin`'s type to be a union of either a filename or a string input
- Added support in `pipelines::Collector` for recognizing herestrings
- Added required functionality in `Shell::execute_pipeline`

**TODOs**:
- [ ] **Outstanding Bug**: running `tr '[a-z]' '[A-Z]' <<< "foo"` produces no output
- [x] Add doc comments for the `peg::Input` enum
- [x] Add regression tests in `pipelines.rs` and integration tests in `examples/` for herestrings

**Fixes**: Closes #133

**State**: WIP; see TODOs. 

**Other**: This PR ended up being slightly different than #200; instead of holding onto the string and writing to `stdin` once the command had been spawned, this takes a cue from the implementation of `&|`: write the herestring to a pipe, close the writer end, and pass the reader end to the first command in the pipeline.