### PR TITLE
Jobs no longer use a separate list of builtins to determine the command type

### DIFF
--- a/src/shell/job.rs
+++ b/src/shell/job.rs
@@ -44,40 +44,23 @@ impl Job {
         self.command = self.args.first().map_or("".into(), |c| c.clone().into());
     }
 
-    pub fn build_command(&mut self) -> Command {
-        match CommandType::from(self.command.as_ref()) {
-            CommandType::Builtin => {
-                use std::env;
-                let process = env::current_exe().unwrap();
-                let mut command = Command::new(process);
-                command.arg("-c");
-                command.arg(&self.command);
-                for arg in self.args.drain().skip(1) {
-                    command.arg(arg);
-                }
-                command
-            },
-            CommandType::External => {
-                let mut command = Command::new(&self.command);
-                for arg in self.args.drain().skip(1) {
-                    command.arg(arg);
-                }
-                command
-            }
+    pub fn build_command_external(&mut self) -> Command {
+        let mut command = Command::new(&self.command);
+        for arg in self.args.drain().skip(1) {
+            command.arg(arg);
         }
+        command
     }
-}
 
-enum CommandType {
-    Builtin,
-    External
-}
-
-impl<'a> From<&'a str> for CommandType {
-    fn from(command: &'a str) -> CommandType {
-        match command {
-            "help" | "history" | "echo" | "test" | "calc" => CommandType::Builtin,
-            _ => CommandType::External
+    pub fn build_command_builtin(&mut self) -> Command {
+        use std::env;
+        let process = env::current_exe().unwrap();
+        let mut command = Command::new(process);
+        command.arg("-c");
+        command.arg(&self.command);
+        for arg in self.args.drain().skip(1) {
+            command.arg(arg);
         }
+        command
     }
 }

--- a/src/shell/pipe.rs
+++ b/src/shell/pipe.rs
@@ -174,7 +174,11 @@ impl<'a> PipelineExecution for Shell<'a> {
         // Generate a list of commands from the given pipeline
         let mut piped_commands: Vec<(Command, JobKind)> = pipeline.jobs
             .drain(..).map(|mut job| {
-                (job.build_command(), job.kind)
+                if self.builtins.contains_key(&job.command.as_ref()) {
+                    (job.build_command_builtin(), job.kind)
+                } else {
+                    (job.build_command_external(), job.kind)
+                }
             }).collect();
         match pipeline.stdin {
             None => (),


### PR DESCRIPTION
Before when determining how to create the command the code would look at a hand maintained list which had to be updated whenever a new builtin was added. It looked like that was fairly out of date and caused some odd behavior. For example `true` and `false` weren't in the list so `true && false` wouldn't be using the builtins, but just `true` or `false` alone would be. Since the shell has the builtins hash I figured we can just check if it is in there or not by checking the keys and then call the appropriate method to create the command.