### PR TITLE
Conditionals && and || weren't working as expected

### DIFF
--- a/examples/conditionals.ion
+++ b/examples/conditionals.ion
@@ -1,0 +1,9 @@
+true && echo and || echo or
+false && echo and || echo or
+false || echo false
+true && echo true
+true || echo cant get here
+false && echo cant get here
+false || false || echo double or
+true && true && echo double and
+false || true && echo or and

--- a/examples/conditionals.out
+++ b/examples/conditionals.out
@@ -1,0 +1,7 @@
+and
+or
+false
+true
+double or
+double and
+or and

--- a/src/shell/pipe.rs
+++ b/src/shell/pipe.rs
@@ -273,12 +273,10 @@ pub fn pipe (
             match previous_kind {
                 JobKind::And => if previous_status != SUCCESS {
                     if let JobKind::Or = kind { previous_kind = kind }
-                    commands.next();
                     continue
                 },
                 JobKind::Or => if previous_status == SUCCESS {
                     if let JobKind::And = kind { previous_kind = kind }
-                    commands.next();
                     continue
                 },
                 _ => ()


### PR DESCRIPTION
If you ran `false && echo and || echo or` you should have gotten "or" echoed, but instead nothing was coming out. It was caused by advancing these iterators. It looks like those lines were added [here](https://github.com/redox-os/ion/commit/9d5cb19d26d0744c9de48983d981b4d0da4984b7#diff-cc20bc374fba8d873a99948f7710250eL127), but I'm not exactly sure why. It references `&|`, but that seems to work fine without them.

Also added that examples script to help make sure they're still working in the future.