### PR TITLE
Read init file only when using interactive shell

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,8 +36,7 @@ use std::thread;
 
 fn inner_main(sigint_rx : mpsc::Receiver<i32>) {
     let builtins = Builtin::map();
-    let mut shell = Shell::new(&builtins, sigint_rx);
-    shell.evaluate_init_file();
+    let shell = Shell::new(&builtins, sigint_rx);
     shell.main();
 }
 

--- a/src/shell/binary.rs
+++ b/src/shell/binary.rs
@@ -248,6 +248,8 @@ impl<'a> Binary for Shell<'a> {
             context
         });
 
+        self.evaluate_init_file();
+
         self.variables.set_array (
             "args",
             iter::once(env::args().next().unwrap()).collect(),


### PR DESCRIPTION
Execute the initrc file only when using ion in interactive mode as it probably makes less sense in the other modes.

Moreover, it fixes modification of the context done in the initrc file which weren't taken into account as the context wasn't initialized at the time of the script execution (e.g.: `set -o vi` in the initrc didn't set the vi editing mode in interactive sessions).