### PR TITLE
Added not builtin

### DIFF
--- a/examples/not.ion
+++ b/examples/not.ion
@@ -1,0 +1,6 @@
+not true || echo not true
+not false && echo not false
+true && not false && echo true and not false 
+not test -z "a" && echo not test
+not echo hello
+echo $?

--- a/examples/not.out
+++ b/examples/not.out
@@ -1,0 +1,6 @@
+not true
+not false
+true and not false
+not test
+hello
+-1

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -193,6 +193,20 @@ impl Builtin {
                         });
 
         /* Misc */
+        commands.insert("not",
+            Builtin {
+                name: "not",
+                help: "Reverses the exit status value of the given command.",
+                main: Box::new(|args: &[&str], shell: &mut Shell| -> i32 {
+                    let cmd = args[1..].join(" ");
+                    shell.on_command(&cmd);
+                    match shell.previous_status {
+                        SUCCESS => FAILURE,
+                        FAILURE => SUCCESS,
+                        _ => shell.previous_status
+                    }
+                }),
+            });
         commands.insert("set",
             Builtin {
                 name: "set",


### PR DESCRIPTION
`not` will run the command after it and flip any nonerror status code. 0 -> -1 and -1 -> 0.