### PR TITLE
Fix issue #419 `echo hello#world`

### DIFF
--- a/examples/comments.ion
+++ b/examples/comments.ion
@@ -1,3 +1,6 @@
 echo Hello world  # End of line comments are ignored
 
 #echo Goodbye world
+	#echo Nada
+echo tabs ok	#comment
+echo not#a#comment

--- a/examples/comments.out
+++ b/examples/comments.out
@@ -1,1 +1,3 @@
 Hello world
+tabs ok
+not#a#comment

--- a/src/parser/statements.rs
+++ b/src/parser/statements.rs
@@ -220,7 +220,15 @@ impl<'a> Iterator for StatementSplitter<'a> {
                         None        => Some(Ok(self.data[start..self.read-1].trim()))
                     };
                 },
-                b'#' if !self.flags.intersects(SQUOTE | DQUOTE) && self.process_level == 0 && self.array_process_level == 0 => {
+                b'#' if self.read == 1 || (
+                        !self.flags.intersects(SQUOTE | DQUOTE) &&
+                        self.process_level == 0 &&
+                        self.array_process_level == 0 &&
+                        match self.data.as_bytes()[self.read - 2] {
+                            b' ' | b'\t' => true,
+                            _ => false
+                        }
+                ) => {
                     let output = self.data[start..self.read-1].trim();
                     self.read = self.data.len();
                     return match error {

--- a/src/parser/statements.rs
+++ b/src/parser/statements.rs
@@ -113,6 +113,7 @@ impl<'a> Iterator for StatementSplitter<'a> {
             self.read += 1;
             match character {
                 _ if self.flags.contains(POST_MATHEXPR) => (),
+                // [^A-Za-z0-9_}]
                 0...47 | 58...64 | 91...94 | 96 | 123...124 | 126...127 if self.flags.contains(VBRACE) => {
                     // If we are just ending the braced section continue as normal
                     if error.is_none() {
@@ -249,6 +250,7 @@ impl<'a> Iterator for StatementSplitter<'a> {
                         }
                     }
                 }
+                // [^A-Za-z0-9_]
                 0...47 | 58...64 | 91...94 | 96 | 123...127 => self.flags -= VARIAB | ARRAY,
                 _ => ()
             }


### PR DESCRIPTION
This should fix issue #419, but I'm not sure if it is exactly how we want to do it. With this change any `#` not at the start of the line (`self.read == 1`) or preceded by an ascii whitespace character (`b' ' | b'\t'`) will be considered part of the token it is inside.