### PR TITLE
Case statements are now implicitly ended

### DIFF
--- a/examples/match.ion
+++ b/examples/match.ion
@@ -1,7 +1,7 @@
 for i in [1 2 3 4 5 6]
   match $((i % 2))
-    case 0; echo "Even!"; end
-    case 1; echo "Odd!" ; end
+    case 0; echo "Even!"
+    case 1; echo "Odd!" 
   end
 end
 
@@ -10,8 +10,8 @@ let out2 = "/foo/bar/baz.quxx: application/quxx-archive";
 
 fn analyze output
   match @split(output)[1]
-    case application/x-gzip; echo "Use tar -xzf"; end
-    case _ ; echo "Unknown file type"; end
+    case application/x-gzip; echo "Use tar -xzf"
+    case _ ; echo "Unknown file type"
   end
 end
 
@@ -20,8 +20,8 @@ analyze $out2
 
 fn wildcard input
   match $input
-    case _; echo "WILDCARD!"; end
-    case huh; echo "U N R E A C H A B L E"; end
+    case _; echo "WILDCARD!"
+    case huh; echo "U N R E A C H A B L E"
   end
 end
 
@@ -30,11 +30,11 @@ wildcard "huh"
 
 fn report usage
   match $usage
-    case @(seq 0 25); echo "Plenty of space my guy"; end
-    case @(seq 26 50); echo "Almost half full (or half empty)"; end
-    case @(seq 51 75); echo "Getting close to full :O"; end
-    case @(seq 76 99); echo "Time for spring cleaning, almost full!"; end
-    case _; echo "How did you even do this..."; end
+    case @(seq 0 25); echo "Plenty of space my guy"
+    case @(seq 26 50); echo "Almost half full (or half empty)"
+    case @(seq 51 75); echo "Getting close to full :O"
+    case @(seq 76 99); echo "Time for spring cleaning, almost full!"
+    case _; echo "How did you even do this..."
   end
 end
 
@@ -47,10 +47,8 @@ fn animated filetype
   match $filetype
     case ["image/jpeg" "image/png"]
       echo "Static :("
-    end
     case "image/gif"
       echo "Animated :D"
-    end
   end
 end
 


### PR DESCRIPTION
**Changes introduced by this pull request**:
- Instead of using `end` to signal the end of a case, case blocks are implicitly ended by either another `case` statement or the end of the `match` block.

**Fixes**: Closes #414 

**State**: Good to go!

**Other**: The description of #414 was "make end optional" but I figure we can just remove it altogether; thoughts?