### PR TITLE
Some more consistency changes to builtins

### DIFF
--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -27,20 +27,10 @@ use shell::status::*;
 /// Structure which represents a Terminal's command.
 /// This command structure contains a name, and the code which run the
 /// functionnality associated to this one, with zero, one or several argument(s).
-/// # Example
-/// ```
-/// let my_command = Builtin {
-///     name: "my_command",
-///     help: "Describe what my_command does followed by a newline showing usage",
-///     main: box|args: &[&str], &mut Shell| -> i32 {
-///         println!("Say 'hello' to my command! :-D");
-///     }
-/// }
-/// ```
 pub struct Builtin {
     pub name: &'static str,
     pub help: &'static str,
-    pub main: Box<Fn(&[&str], &mut Shell) -> i32>,
+    pub main: fn(&[&str], &mut Shell) -> i32,
 }
 
 impl Builtin {
@@ -72,7 +62,7 @@ impl Builtin {
                     Builtin {
                         name: $name,
                         help: $help,
-                        main: Box::new($func),
+                        main: $func,
                     }
                 ); 
             }

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -182,7 +182,7 @@ impl<'a> Shell<'a> {
                 let small: SmallVec<[&str; 4]> = borrowed.iter()
                     .map(|x| x as &str)
                     .collect();
-                Some((*command.main)(&small, self))
+                Some((command.main)(&small, self))
             } else {
                 Some(self.execute_pipeline(pipeline))
             }
@@ -268,7 +268,7 @@ impl<'a> Shell<'a> {
             let mut new_args: SmallVec<[&str; 4]> = SmallVec::new();
             new_args.push("cd");
             new_args.extend(pipeline.jobs[0].args.iter().map(|x| x as &str));
-            Some((*builtins.get("cd").unwrap().main)(&new_args, self))
+            Some((builtins.get("cd").unwrap().main)(&new_args, self))
         } else {
             Some(self.execute_pipeline(pipeline))
         };


### PR DESCRIPTION
We don't need the `Box<Fn(...)>` anymore in the builtins. The only thing this new `Builtin` doesn't allow is closures that capture an environment.

I'm going to start working on changing builtins to accept stdin, stdout, and stderr as parameters now.