### PR TITLE
Handle unusual errors during process spawning

### DIFF
--- a/src/shell/pipe.rs
+++ b/src/shell/pipe.rs
@@ -378,10 +378,14 @@ fn execute_command(shell: &mut Shell, command: &mut Command, foreground: bool) -
             if foreground { set_foreground(child.id()); }
             shell.watch_foreground(child.id(), child.id(), || get_full_command(command), |_| ())
         },
-        Err(_) => {
+        Err(e) => {
             let stderr = io::stderr();
             let mut stderr = stderr.lock();
-            let _ = writeln!(stderr, "ion: command not found: {}", get_command_name(command));
+            let _ = if e.kind() == io::ErrorKind::NotFound {
+                writeln!(stderr, "ion: Command not found: {}", get_command_name(command))
+            } else {
+                writeln!(stderr, "ion: Error spawning process: {}", e)
+            };
             FAILURE
         }
     }


### PR DESCRIPTION

**Problem**: I found that while trying to echo to the example scheme (:vec) I was getting
EBADF which caused "command not found: /bin/ion" to be printed.

**Solution**: Only print "Command not found: ...", if the error is actually that the command
is not found. Otherwise print a general error description from the system. 

