### PR TITLE
`expand_process` changed to not strip newlines for quoted instances

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -46,7 +46,7 @@ macro_rules! get_expanders {
                         .map(|x| x.ascii_replace('\n', ' ').into())
                 }
             },
-            command: &|command: &str, quoted: bool| $vars.command_expansion(command, quoted),
+            command: &|command: &str| $vars.command_expansion(command),
         }
     }
 }

--- a/src/parser/shell_expand/words.rs
+++ b/src/parser/shell_expand/words.rs
@@ -1263,7 +1263,7 @@ mod tests {
                 tilde:    &|_| None,
                 array:    &|_, _| None,
                 variable: &|_, _| None,
-                command:  &|_, _| None
+                command:  &|_| None
             }
         }
     }
@@ -1497,7 +1497,7 @@ mod tests {
                     "pkmn2" => "Poke\u{0301}mon".to_owned().into(),
                     _ => None
                 },
-                command: &|_, _| None,
+                command: &|_| None,
             }
         }
     }

--- a/src/shell/variables.rs
+++ b/src/shell/variables.rs
@@ -202,9 +202,7 @@ impl Variables {
         None
     }
 
-    pub fn command_expansion(&self, command: &str, quoted: bool) -> Option<Value> {
-        use ascii_helpers::AsciiReplace;
-
+    pub fn command_expansion(&self, command: &str) -> Option<Value> {
         if let Ok(exe) = env::current_exe() {
             if let Ok(output) = process::Command::new(exe).arg("-c").arg(command).output() {
                 if let Ok(mut stdout) = String::from_utf8(output.stdout) {
@@ -212,11 +210,7 @@ impl Variables {
                         stdout.pop();
                     }
 
-                    return if quoted {
-                        Some(stdout.into())
-                    } else {
-                        Some(stdout.ascii_replace('\n', ' ').into())
-                    };
+                    return Some(stdout.into());
                 }
             }
         }


### PR DESCRIPTION
**Fixes**: Closes #410 

**Drawbacks**: If a user wants the specific behavior of capturing a process and stripping newlines, it is slightly more cumbersome to do so (as `tr "\n" " "` doesn't work as expected).