### PR TITLE
Simplify cross platform functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,6 @@ dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "calculate 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -19,8 +18,6 @@ dependencies = [
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallstring 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-signal 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "users 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -66,20 +63,6 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "byteorder"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "bytes"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "calculate"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,41 +78,13 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "futures"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "glob"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "iovec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "lazy_static"
 version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "lazycell"
-version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -148,64 +103,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "log"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "memchr"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "mio"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "mio-uds"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "miow"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "net2"
-version = "0.2.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -269,11 +171,6 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "scoped-tls"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "shell32-sys"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,11 +178,6 @@ dependencies = [
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "slab"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "smallstring"
@@ -320,45 +212,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-core"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytes 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-io"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytes 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-signal"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio-uds 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -413,15 +266,6 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "xdg"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,25 +277,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bytecount 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "4bbeb7c30341fce29f6078b4bdf876ea4779600866e98f5b2d203a534f195050"
-"checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
-"checksum bytes 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8b24f16593f445422331a5eed46b72f7f171f910fead4f2ea8f17e727e9c5c14"
 "checksum calculate 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1b593017444d7b7d0d1cacfea9dd28a507e42cfd30c5366130d14e1e16eb33e0"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
-"checksum futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4b63a4792d4f8f686defe3b39b92127fea6344de5d38202b2ee5a11bbbf29d6a"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29d062ee61fccdf25be172e70f34c9f6efc597e1fb8f6526e8437b2046ab26be"
-"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
-"checksum lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce12306c4739d86ee97c23139f3a34ddf0387bbf181bc7929d287025a8c3ef6b"
 "checksum libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)" = "30885bcb161cf67054244d10d4a7f4835ffd58773bc72e07d35fecf472295503"
 "checksum liner 0.4.0 (git+https://github.com/MovingtoMars/liner/)" = "<none>"
-"checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
 "checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
-"checksum mio 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9e965267d4d58496fc4f740e9861118367f13570cadf66316ed2c3f2f14d87c7"
-"checksum mio-uds 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1731a873077147b626d89cc6c2a0db6288d607496c5d10c0cfcf3adc697ec673"
-"checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum net2 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)" = "94101fd932816f97eb9a5116f6c1a11511a1fed7db21c5ccd823b2dc11abf566"
 "checksum nix 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "47e49f6982987135c5e9620ab317623e723bd06738fd85377e8d55f57c8b6487"
 "checksum ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2c49021782e5233cd243168edfa8037574afed4eba4bbaf538b3d8d1789d8c"
 "checksum peg 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "36a474cba42744afe0f223e9d4263594b3387f172e512259c72d2011e477c4fb"
@@ -460,17 +293,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum redox_syscall 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "9df6a71a1e67be2104410736b2389fb8e383c1d7e9e792d629ff13c02867147a"
 "checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
-"checksum scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f417c22df063e9450888a7561788e9bd46d3bb3c1466435b4eccb903807f147d"
 "checksum shell32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72f20b8f3c060374edb8046591ba28f62448c369ccbdc7b02075103fb3a9e38d"
-"checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
 "checksum smallstring 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "30950abdb5b38f56a0e181ae56ed64a539b64fa77ea6325147203dc7faeb087f"
 "checksum smallvec 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4f8266519bc1d17d0b5b16f6c21295625d562841c708f6376f49028a43e9c11e"
 "checksum smallvec 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "26aa2afb825226fa29f0315de04d5a4af5fd44adadf837296accc01a49929724"
 "checksum termion 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9105678ba52491a8e38e67be7842435ac44d7797b9b05bcdad370b0c84559615"
 "checksum thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1697c4b57aeeb7a536b647165a2825faddffb1d3bad386d507709bd51a90bb14"
-"checksum tokio-core 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6a20ba4738d283cac7495ca36e045c80c2a8df3e05dd0909b17a06646af5a7ed"
-"checksum tokio-io 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c2c3ce9739f7387a0fa65b5421e81feae92e04d603f008898f4257790ce8c2db"
-"checksum tokio-signal 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3d121715f6917878a0df69f39365d01dd66c4463e4ba19efdcddcdfeb1bcb2bc"
 "checksum unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8083c594e02b8ae1654ae26f0ade5158b119bd88ad0e8227a5d8fcd72407946"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
@@ -480,5 +308,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
-"checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a66b7c2281ebde13cf4391d70d4c7e5946c3c25e72a7b859ca8f677dcd0b0c61"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,16 +56,10 @@ redox_syscall = "0.1"
 ## *nix Dependencies (Linux, Mac OS, BSDs)
 
 [target.'cfg(all(unix, not(target_os = "redox")))'.dependencies]
-# Used by `tokio-signal`/`tokio-core` for creating zero-allocation streams of future data.
-futures = "0.1"
 # Required to access some *nix-specific syscalls for signals/job control.
 libc = "0.2"
 # A higher level abstraction of libc-acquired syscalls for signals/job control.
 nix = "0.8"
-# Provides the core event loop for a tokio solution.
-tokio-core = "0.1"
-# Provides a high level abstraction to watching signals with tokio.
-tokio-signal = "0.1"
 # Obtains user directories
 users = "0.5.1"
 

--- a/src/shell/fork.rs
+++ b/src/shell/fork.rs
@@ -1,53 +1,8 @@
-#[cfg(target_os = "redox")]
-pub use self::redox::*;
-#[cfg(all(unix, not(target_os = "redox")))]
-pub use self::unix::*;
+use sys;
 
-pub enum Fork {
-    Parent(u32),
-    Child
-}
-
-#[cfg(target_os = "redox")]
-mod redox {
-    use syscall;
-    use super::Fork;
-
-    /// Forks the shell Redox's `clone(0)` syscall.
-    pub fn ion_fork() -> syscall::error::Result<Fork> {
-        use syscall::call::clone;
-        unsafe {
-            clone(0).map(|pid| {
-                if pid == 0 { Fork::Child } else { Fork::Parent(pid as u32) }
-            })
-        }
-    }
-
-    /// Ensures that the forked child is given a unique process ID.
-    pub fn create_process_group(pgid: u32) {
-
-    }
-}
-
-
-#[cfg(all(unix, not(target_os = "redox")))]
-mod unix {
-    use nix::Error as NixError;
-    use nix::unistd::{fork, ForkResult, setpgid};
-    use super::Fork;
-
-    /// Forks the shell using the *nix `fork()` syscall.
-    pub fn ion_fork() -> Result<Fork, NixError> {
-        match fork()? {
-            ForkResult::Parent{ child: pid } => Ok(Fork::Parent(pid as u32)),
-            ForkResult::Child                => Ok(Fork::Child)
-        }
-    }
-
-    /// Ensures that the forked child is given a unique process ID.
-    pub fn create_process_group(pgid: u32) {
-        let _ = setpgid(0, pgid as i32);
-    }
+/// Ensures that the forked child is given a unique process ID.
+pub fn create_process_group(pgid: u32) {
+    let _ = sys::setpgid(0, pgid);
 }
 
 use std::process::{Command, exit};
@@ -65,19 +20,19 @@ pub fn fork_pipe (
     commands: Vec<(Command, JobKind)>,
     command_name: String
 ) -> i32 {
-    match ion_fork() {
-        Ok(Fork::Parent(pid)) => {
-            // The parent process should add the child fork's PID to the background.
-            shell.send_to_background(pid, ProcessState::Running, command_name);
-            SUCCESS
-        },
-        Ok(Fork::Child) => {
+    match unsafe { sys::fork() } {
+        Ok(0) => {
             // The child fork should not have any signals blocked, so the shell can control it.
             signals::unblock();
             // This ensures that the child fork has a unique PGID.
             create_process_group(0);
             // After execution of it's commands, exit with the last command's status.
             exit(pipe(shell, commands, false));
+        },
+        Ok(pid) => {
+            // The parent process should add the child fork's PID to the background.
+            shell.send_to_background(pid, ProcessState::Running, command_name);
+            SUCCESS
         },
         Err(why) => {
             eprintln!("ion: background fork failed: {}", why);

--- a/src/shell/job_control.rs
+++ b/src/shell/job_control.rs
@@ -1,6 +1,4 @@
-#[cfg(all(unix, not(target_os = "redox")))] use libc::{self, pid_t, c_int};
-#[cfg(all(unix, not(target_os = "redox")))] use nix::sys::signal::{self, Signal};
-#[cfg(all(unix, not(target_os = "redox")))] use nix::unistd;
+#[cfg(all(unix, not(target_os = "redox")))] use libc::{self, pid_t};
 use std::fmt;
 use std::thread::{sleep, spawn};
 use std::time::Duration;
@@ -9,19 +7,13 @@ use super::foreground::{ForegroundSignals, BackgroundResult};
 use super::signals;
 use super::status::*;
 use super::Shell;
-use super::pipe::crossplat::get_pid;
+use sys;
 
-#[cfg(all(unix, not(target_os = "redox")))]
 /// When given a process ID, that process's group will be assigned as the foreground process group.
 pub fn set_foreground_as(pid: u32) {
     signals::block();
-    let _ = unistd::tcsetpgrp(0, pid as i32);
+    let _ = sys::tcsetpgrp(0, pid);
     signals::unblock();
-}
-
-#[cfg(target_os = "redox")]
-pub fn set_foreground_as(pid: u32) {
-    // TODO
 }
 
 pub trait JobControl {
@@ -192,11 +184,10 @@ impl<'a> JobControl for Shell<'a> {
             }
         };
         // Have the shell reclaim the TTY
-        set_foreground_as(get_pid());
+        set_foreground_as(sys::getpid().unwrap());
         status
     }
 
-    #[cfg(all(unix, not(target_os = "redox")))]
     /// Waits until all running background tasks have completed, and listens for signals in the
     /// event that a signal is sent to kill the running tasks.
     fn wait_for_background(&mut self) {
@@ -204,7 +195,7 @@ impl<'a> JobControl for Shell<'a> {
             for process in self.background.lock().unwrap().iter() {
                 if let ProcessState::Running = process.state {
                     if let Ok(signal) = self.signals.try_recv() {
-                        if signal != libc::SIGTSTP {
+                        if signal != sys::SIGTSTP {
                             self.background_send(signal);
                             break 'event
                         }
@@ -216,11 +207,6 @@ impl<'a> JobControl for Shell<'a> {
             return
         }
         self.exit(TERMINATED);
-    }
-
-    #[cfg(target_os = "redox")]
-    fn wait_for_background(&mut self) {
-        // TODO: Redox doesn't support signals yet.
     }
 
     #[cfg(all(unix, not(target_os = "redox")))]
@@ -287,7 +273,6 @@ impl<'a> JobControl for Shell<'a> {
         use std::os::unix::process::ExitStatusExt;
         use std::process::ExitStatus;
         use syscall;
-        use syscall::flag::WNOHANG;
 
         loop {
             let mut status_raw = 0;
@@ -314,40 +299,28 @@ impl<'a> JobControl for Shell<'a> {
         }
     }
 
-    #[cfg(all(unix, not(target_os = "redox")))]
     /// Send a kill signal to all running foreground tasks.
     fn foreground_send(&self, signal: i32) {
-        for process in self.foreground.iter() {
-            let _ = signal::kill(-(*process as pid_t), Signal::from_c_int(signal as c_int).ok());
+        for &process in self.foreground.iter() {
+            let _ = sys::killpg(process, signal);
         }
     }
 
-    #[cfg(target_os = "redox")]
-    fn foreground_send(&self, _: i32) {
-        // TODO: Redox doesn't support signals yet
-    }
-
-    #[cfg(all(unix, not(target_os = "redox")))]
     /// Send a kill signal to all running background tasks.
     fn background_send(&self, signal: i32) {
-        if signal == libc::SIGHUP {
+        if signal == sys::SIGHUP {
             for process in self.background.lock().unwrap().iter() {
                 if !process.ignore_sighup {
-                    let _ = signal::kill(-(process.pid as pid_t), Signal::from_c_int(signal as c_int).ok());
+                    let _ = sys::killpg(process.pid, signal);
                 }
             }
         } else {
             for process in self.background.lock().unwrap().iter() {
                 if let ProcessState::Running = process.state {
-                    let _ = signal::kill(-(process.pid as pid_t), Signal::from_c_int(signal as c_int).ok());
+                    let _ = sys::killpg(process.pid, signal);
                 }
             }
         }
-    }
-
-    #[cfg(target_os = "redox")]
-    fn background_send(&self, _: i32) {
-        // TODO: Redox doesn't support signals yet
     }
 
     fn send_to_background(&mut self, pid: u32, state: ProcessState, command: String) {
@@ -372,17 +345,10 @@ impl<'a> JobControl for Shell<'a> {
 
     /// If a SIGTERM is received, a SIGTERM will be sent to all background processes
     /// before the shell terminates itself.
-    #[cfg(all(unix, not(target_os = "redox")))]
     fn handle_signal(&self, signal: i32) -> bool {
-        if signal == libc::SIGTERM || signal == libc::SIGHUP {
+        if signal == sys::SIGTERM || signal == sys::SIGHUP {
             self.background_send(signal);
             true
         } else { false }
-    }
-
-    #[cfg(target_os = "redox")]
-    fn handle_signal(&self, _: i32) -> bool {
-        // TODO: Redox doesn't support signals yet;
-        false
     }
 }

--- a/src/shell/signals.rs
+++ b/src/shell/signals.rs
@@ -1,6 +1,8 @@
 //! This module contains all of the code that manages signal handling in the shell. Primarily, this will be used to
 //! block signals in the shell at startup, and unblock signals for each of the forked children of the shell.
 
+use sys;
+
 #[cfg(all(unix, not(target_os = "redox")))]
 pub use self::unix::*;
 
@@ -9,12 +11,6 @@ pub use self::redox::*;
 
 #[cfg(all(unix, not(target_os = "redox")))]
 mod unix {
-    use futures::{Future, Stream};
-    use nix::sys::signal::{kill, Signal};
-    use std::sync::mpsc::Sender;
-    use tokio_core::reactor::Core;
-    use tokio_signal::unix::{self as unix_signal, Signal as TokioSignal};
-
     /// Blocks the SIGTSTP/SIGTTOU/SIGTTIN/SIGCHLD signals so that the shell never receives them.
     pub fn block() {
         unsafe {
@@ -46,55 +42,24 @@ mod unix {
             sigprocmask(SIG_UNBLOCK, &sigset as *const sigset_t, ptr::null_mut() as *mut sigset_t);
         }
     }
-
-    /// Suspends a given process by it's process ID.
-    pub fn suspend(pid: u32) {
-        let _ = kill(-(pid as i32), Some(Signal::SIGSTOP));
-    }
-
-    /// Resumes a given process by it's process ID.
-    pub fn resume(pid: u32) {
-        let _ = kill(-(pid as i32), Some(Signal::SIGCONT));
-    }
-
-
-    /// Execute the event loop that will listen for and transmit received signals to the shell.
-    pub fn event_loop(signals_tx: Sender<i32>) {
-        let mut core = Core::new().unwrap();
-        let handle = core.handle();
-
-        // Block the SIGTSTP signal -- prevents the shell from being stopped
-        // when the foreground group is changed during command execution.
-        block();
-
-        // Create a stream that will select over SIGINT, SIGTERM, and SIGHUP signals.
-        let signals = TokioSignal::new(unix_signal::SIGINT, &handle).flatten_stream()
-            .select(TokioSignal::new(unix_signal::SIGTERM, &handle).flatten_stream())
-            .select(TokioSignal::new(unix_signal::SIGHUP, &handle).flatten_stream());
-
-        core.run(signals.for_each(|signal| {
-            let _ = signals_tx.send(signal);
-            Ok(())
-        })).unwrap();
-    }
 }
 
 // TODO
 #[cfg(target_os = "redox")]
 mod redox {
-    use syscall;
-
     pub fn block() { }
 
     pub fn unblock() { }
+}
 
-    pub fn suspend(pid: u32) {
-        let _ = syscall::kill(pid as usize, syscall::SIGSTOP);
-    }
+/// Suspends a given process by it's process ID.
+pub fn suspend(pid: u32) {
+    let _ = sys::killpg(pid, sys::SIGSTOP);
+}
 
-    pub fn resume(pid: u32) {
-        let _ = syscall::kill(pid as usize, syscall::SIGCONT);
-    }
+/// Resumes a given process by it's process ID.
+pub fn resume(pid: u32) {
+    let _ = sys::killpg(pid, sys::SIGCONT);
 }
 
 /// The purpose of the signal handler is to ignore signals when it is active, and then continue

--- a/src/sys/redox.rs
+++ b/src/sys/redox.rs
@@ -1,0 +1,61 @@
+extern crate syscall;
+
+use std::{io, mem};
+use std::os::unix::io::RawFd;
+
+use syscall::SigAction;
+
+pub const O_CLOEXEC: usize = syscall::O_CLOEXEC;
+pub const SIGHUP: i32 = syscall::SIGHUP as i32;
+pub const SIGINT: i32 = syscall::SIGINT as i32;
+pub const SIGTERM: i32 = syscall::SIGTERM as i32;
+pub const SIGCONT: i32 = syscall::SIGCONT as i32;
+pub const SIGSTOP: i32 = syscall::SIGSTOP as i32;
+pub const SIGTSTP: i32 = syscall::SIGTSTP as i32;
+
+pub unsafe fn fork() -> io::Result<u32> {
+    cvt(syscall::clone(0)).map(|pid| pid as u32)
+}
+
+pub fn getpid() -> io::Result<u32> {
+    cvt(syscall::getpid()).map(|pid| pid as u32)
+}
+
+pub fn kill(pid: u32, signal: i32) -> io::Result<()> {
+    cvt(syscall::kill(pid as usize, signal as usize)).and(Ok(()))
+}
+
+pub fn killpg(pgid: u32, signal: i32) -> io::Result<()> {
+    cvt(syscall::kill(!(pgid as usize), signal as usize)).and(Ok(()))
+}
+
+pub fn pipe2(flags: usize) -> io::Result<(RawFd, RawFd)> {
+    let mut fds = [0; 2];
+    cvt(syscall::pipe2(&mut fds, flags))?;
+    Ok((fds[0], fds[1]))
+}
+
+pub fn setpgid(_pid: u32, _pgid: u32) -> io::Result<()> {
+    //TODO: Add setpgid syscall
+    Ok(())
+}
+
+pub fn signal(signal: i32, handler: extern "C" fn(i32)) -> io::Result<()> {
+    let new = SigAction {
+        sa_handler: unsafe { mem::transmute(handler) },
+        sa_mask: [0; 2],
+        sa_flags: 0
+    };
+    let mut old = SigAction::default();
+    cvt(syscall::sigaction(signal as usize, &new, &mut old)).and(Ok(()))
+}
+
+pub fn tcsetpgrp(_fd: RawFd, _pgid: u32) -> io::Result<()> {
+    //TODO: Add tcsetpgrp implementation
+    Ok(())
+}
+
+// Support function for converting syscall error to io error
+fn cvt(result: Result<usize, syscall::Error>) -> io::Result<usize> {
+    result.map_err(|err| io::Error::from_raw_os_error(err.errno))
+}

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1,0 +1,79 @@
+extern crate libc;
+
+use libc::{
+    c_int,
+    pid_t,
+    sighandler_t
+};
+use std::io;
+use std::os::unix::io::RawFd;
+
+pub const O_CLOEXEC: usize = libc::O_CLOEXEC as usize;
+pub const SIGHUP: i32 = libc::SIGHUP;
+pub const SIGINT: i32 = libc::SIGINT;
+pub const SIGTERM: i32 = libc::SIGTERM;
+pub const SIGCONT: i32 = libc::SIGCONT;
+pub const SIGSTOP: i32 = libc::SIGSTOP;
+pub const SIGTSTP: i32 = libc::SIGTSTP;
+
+pub unsafe fn fork() -> io::Result<u32> {
+    cvt(libc::fork()).map(|pid| pid as u32)
+}
+
+pub fn getpid() -> io::Result<u32> {
+    cvt(unsafe { libc::getpid() }).map(|pid| pid as u32)
+}
+
+pub fn kill(pid: u32, signal: i32) -> io::Result<()> {
+    cvt(unsafe { libc::kill(pid as pid_t, signal as c_int) }).and(Ok(()))
+}
+
+pub fn killpg(pgid: u32, signal: i32) -> io::Result<()> {
+    cvt(unsafe { libc::kill(-(pgid as pid_t), signal as c_int) }).and(Ok(()))
+}
+
+pub fn pipe2(flags: usize) -> io::Result<(RawFd, RawFd)> {
+    let mut fds = [0; 2];
+    cvt(unsafe { libc::pipe2(fds.as_mut_ptr(), flags as c_int) })?;
+    Ok((fds[0], fds[1]))
+}
+
+pub fn setpgid(pid: u32, pgid: u32) -> io::Result<()> {
+    cvt(unsafe { libc::setpgid(pid as pid_t, pgid as pid_t) }).and(Ok(()))
+}
+
+pub fn signal(signal: i32, handler: extern "C" fn(i32)) -> io::Result<()> {
+    if unsafe { libc::signal(signal as c_int, handler as sighandler_t) } == libc::SIG_ERR {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+pub fn tcsetpgrp(fd: RawFd, pgrp: u32) -> io::Result<()> {
+    cvt(unsafe { libc::tcsetpgrp(fd as c_int, pgrp as pid_t) }).and(Ok(()))
+}
+
+// Support functions for converting libc return values to io errors {
+    trait IsMinusOne {
+        fn is_minus_one(&self) -> bool;
+    }
+
+    macro_rules! impl_is_minus_one {
+        ($($t:ident)*) => ($(impl IsMinusOne for $t {
+            fn is_minus_one(&self) -> bool {
+                *self == -1
+            }
+        })*)
+    }
+
+    impl_is_minus_one! { i8 i16 i32 i64 isize }
+
+    fn cvt<T: IsMinusOne>(t: T) -> io::Result<T> {
+        if t.is_minus_one() {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(t)
+        }
+    }
+// } End of support functions


### PR DESCRIPTION
This set of changes moves most platform support into two simple files, `sys/redox.rs` and `sys/unix.rs`.

It also adjusts signal handling to use `signal` for compatibility with both Redox and Linux.

For the reviewer, probably @mmstick, I would like to know if signal behavior on Linux is the same as before this modification.