### PR TITLE
Simplify signal logic so that it is safe and single-threaded

### DIFF
--- a/src/shell/flow.rs
+++ b/src/shell/flow.rs
@@ -282,7 +282,7 @@ impl<'a> FlowLogic for Shell<'a> {
                 }
                 _ => {}
             }
-            if let Ok(signal) = self.signals.try_recv() {
+            if let Some(signal) = self.next_signal() {
                 if self.handle_signal(signal) {
                     self.exit(TERMINATED);
                 }

--- a/src/shell/job_control.rs
+++ b/src/shell/job_control.rs
@@ -194,7 +194,7 @@ impl<'a> JobControl for Shell<'a> {
         'event: loop {
             for process in self.background.lock().unwrap().iter() {
                 if let ProcessState::Running = process.state {
-                    if let Ok(signal) = self.signals.try_recv() {
+                    while let Some(signal) = self.next_signal() {
                         if signal != sys::SIGTSTP {
                             self.background_send(signal);
                             break 'event

--- a/src/shell/signals.rs
+++ b/src/shell/signals.rs
@@ -1,6 +1,8 @@
 //! This module contains all of the code that manages signal handling in the shell. Primarily, this will be used to
 //! block signals in the shell at startup, and unblock signals for each of the forked children of the shell.
 
+use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
+
 use sys;
 
 #[cfg(all(unix, not(target_os = "redox")))]
@@ -8,6 +10,8 @@ pub use self::unix::*;
 
 #[cfg(target_os = "redox")]
 pub use self::redox::*;
+
+pub static PENDING: AtomicUsize = ATOMIC_USIZE_INIT;
 
 #[cfg(all(unix, not(target_os = "redox")))]
 mod unix {


### PR DESCRIPTION
This creates an atomic bitmask of pending signals, and removes the extra signal handling thread. When a signal arrives, an atomic operation flips a bit in the bitmask. The handling code unflips the bit when it checks for signals, in the main thread.