### PR TITLE
Move OS #[cfg] functions to sys

### DIFF
--- a/src/shell/binary.rs
+++ b/src/shell/binary.rs
@@ -11,6 +11,7 @@ use std::io::{self, Write, Read, ErrorKind};
 use std::iter::{self, FromIterator};
 use std::mem;
 use std::path::{Path, PathBuf};
+use sys;
 use super::completer::*;
 use super::flow_control::Statement;
 use super::status::*;
@@ -115,7 +116,7 @@ impl<'a> Binary for Shell<'a> {
                             // Creates completers containing definitions from all directories listed
                             // in the environment's **$PATH** variable.
                             let mut file_completers = if let Ok(val) = env::var("PATH") {
-                                val.split(if cfg!(unix) { ':' } else { ';' })
+                                val.split(sys::PATH_SEPARATOR)
                                     .map(|s| IonFileCompleter::new(Some(s), dirs_ptr, vars_ptr))
                                     .collect()
                             } else {

--- a/src/shell/job_control.rs
+++ b/src/shell/job_control.rs
@@ -1,13 +1,15 @@
-#[cfg(all(unix, not(target_os = "redox")))] use libc::{self, pid_t};
 use std::fmt;
 use std::thread::{sleep, spawn};
 use std::time::Duration;
 use std::sync::{Arc, Mutex};
-use super::foreground::{ForegroundSignals, BackgroundResult};
+use super::foreground::BackgroundResult;
 use super::signals;
 use super::status::*;
 use super::Shell;
 use sys;
+
+pub use sys::job_control::watch_background;
+use sys::job_control as self_sys;
 
 /// When given a process ID, that process's group will be assigned as the foreground process group.
 pub fn set_foreground_as(pid: u32) {
@@ -26,14 +28,16 @@ pub trait JobControl {
     fn handle_signal(&self, signal: i32) -> bool;
     fn foreground_send(&self, signal: i32);
     fn background_send(&self, signal: i32);
-    fn watch_foreground <F, D> (
+    fn watch_foreground<F, D>(
         &mut self,
         pid: u32,
         last_pid: u32,
         get_command: F,
-        drop_command: D
-        ) -> i32 where F: FnOnce() -> String,
-                       D: FnMut(i32);
+        drop_command: D,
+    ) -> i32
+    where
+        F: FnOnce() -> String,
+        D: FnMut(i32);
     fn send_to_background(&mut self, child: u32, state: ProcessState, command: String);
 }
 
@@ -42,7 +46,7 @@ pub trait JobControl {
 pub enum ProcessState {
     Running,
     Stopped,
-    Empty
+    Empty,
 }
 
 impl fmt::Display for ProcessState {
@@ -50,103 +54,38 @@ impl fmt::Display for ProcessState {
         match *self {
             ProcessState::Running => write!(f, "Running"),
             ProcessState::Stopped => write!(f, "Stopped"),
-            ProcessState::Empty   => write!(f, "Empty"),
+            ProcessState::Empty => write!(f, "Empty"),
         }
     }
 }
 
-#[cfg(target_os = "redox")]
-pub fn watch_background (
-    fg: Arc<ForegroundSignals>,
-    processes: Arc<Mutex<Vec<BackgroundProcess>>>,
-    pid: u32,
-    njob: usize
-) {
-    // TODO: Implement this using syscall::call::waitpid
-}
-
-#[cfg(all(unix, not(target_os = "redox")))]
-pub fn watch_background (
-    fg: Arc<ForegroundSignals>,
-    processes: Arc<Mutex<Vec<BackgroundProcess>>>,
-    pid: u32,
-    njob: usize
-) {
-    use nix::sys::wait::*;
-    let mut fg_was_grabbed = false;
-    loop {
-        if !fg_was_grabbed {
-            if fg.was_grabbed(pid) { fg_was_grabbed = true; }
-        }
-        match waitpid(-(pid as pid_t), Some(WUNTRACED | WCONTINUED | WNOHANG)) {
-            Ok(WaitStatus::Exited(_, status)) => {
-                if !fg_was_grabbed {
-                    eprintln!("ion: ([{}] {}) exited with {}", njob, pid, status);
-                }
-                let mut processes = processes.lock().unwrap();
-                let process = &mut processes.iter_mut().nth(njob).unwrap();
-                process.state = ProcessState::Empty;
-                if fg_was_grabbed { fg.reply_with(status); }
-                break
-            },
-            Ok(WaitStatus::Stopped(pid, _)) => {
-                if !fg_was_grabbed {
-                    eprintln!("ion: ([{}] {}) Stopped", njob, pid);
-                }
-                let mut processes = processes.lock().unwrap();
-                let process = &mut processes.iter_mut().nth(njob).unwrap();
-                if fg_was_grabbed {
-                    fg.reply_with(TERMINATED as i8);
-                    fg_was_grabbed = false;
-                }
-                process.state = ProcessState::Stopped;
-            },
-            Ok(WaitStatus::Continued(pid)) => {
-                if !fg_was_grabbed {
-                    eprintln!("ion: ([{}] {}) Running", njob, pid);
-                }
-                let mut processes = processes.lock().unwrap();
-                let process = &mut processes.iter_mut().nth(njob).unwrap();
-                process.state = ProcessState::Running;
-            },
-            Ok(_) => (),
-            Err(why) => {
-                eprintln!("ion: ([{}] {}) errored: {}", njob, pid, why);
-                let mut processes = processes.lock().unwrap();
-                let process = &mut processes.iter_mut().nth(njob).unwrap();
-                process.state = ProcessState::Empty;
-                if fg_was_grabbed { fg.errored(); }
-                break
-            }
-        }
-        sleep(Duration::from_millis(100));
-    }
-}
-
-pub fn add_to_background (
+pub fn add_to_background(
     processes: Arc<Mutex<Vec<BackgroundProcess>>>,
     pid: u32,
     state: ProcessState,
-    command: String
+    command: String,
 ) -> u32 {
     let mut processes = processes.lock().unwrap();
-    match (*processes).iter().position(|x| x.state == ProcessState::Empty) {
+    match (*processes)
+        .iter()
+        .position(|x| x.state == ProcessState::Empty)
+    {
         Some(id) => {
             (*processes)[id] = BackgroundProcess {
                 pid: pid,
                 ignore_sighup: false,
                 state: state,
-                name: command
+                name: command,
             };
             id as u32
-        },
+        }
         None => {
             let njobs = (*processes).len();
             (*processes).push(BackgroundProcess {
                 pid: pid,
                 ignore_sighup: false,
                 state: state,
-                name: command
+                name: command,
             });
             njobs as u32
         }
@@ -162,13 +101,15 @@ pub struct BackgroundProcess {
     pub pid: u32,
     pub ignore_sighup: bool,
     pub state: ProcessState,
-    pub name: String
+    pub name: String,
 }
 
 impl<'a> JobControl for Shell<'a> {
     fn set_bg_task_in_foreground(&self, pid: u32, cont: bool) -> i32 {
         // Resume the background task, if needed.
-        if cont { signals::resume(pid); }
+        if cont {
+            signals::resume(pid);
+        }
         // Pass the TTY to the background job
         set_foreground_as(pid);
         // Signal the background thread that is waiting on this process to stop waiting.
@@ -180,7 +121,7 @@ impl<'a> JobControl for Shell<'a> {
             match self.foreground_signals.was_processed() {
                 Some(BackgroundResult::Status(stat)) => break stat as i32,
                 Some(BackgroundResult::Errored) => break TERMINATED,
-                None => sleep(Duration::from_millis(25))
+                None => sleep(Duration::from_millis(25)),
             }
         };
         // Have the shell reclaim the TTY
@@ -197,106 +138,30 @@ impl<'a> JobControl for Shell<'a> {
                     while let Some(signal) = self.next_signal() {
                         if signal != sys::SIGTSTP {
                             self.background_send(signal);
-                            break 'event
+                            break 'event;
                         }
                     }
                     sleep(Duration::from_millis(100));
-                    continue 'event
+                    continue 'event;
                 }
             }
-            return
+            return;
         }
         self.exit(TERMINATED);
     }
 
-    #[cfg(all(unix, not(target_os = "redox")))]
-    fn watch_foreground <F: FnOnce() -> String, D: FnMut(i32)> (
+    fn watch_foreground<F, D>(
         &mut self,
         pid: u32,
         last_pid: u32,
         get_command: F,
-        mut drop_command: D,
-    ) -> i32 {
-        use nix::sys::wait::{waitpid, WaitStatus, WUNTRACED};
-        use nix::sys::signal::Signal;
-        use nix::{Error, Errno};
-        let mut exit_status = 0;
-        loop {
-            match waitpid(-(pid as pid_t), Some(WUNTRACED)) {
-                Ok(WaitStatus::Exited(pid, status)) => {
-                    if pid == (last_pid as i32) {
-                        break status as i32
-                    } else {
-                        drop_command(pid);
-                        exit_status = status;
-                    }
-                }
-                Ok(WaitStatus::Signaled(_, signal, _)) => {
-                    eprintln!("ion: process ended by signal");
-                    if signal == Signal::SIGTERM {
-                        self.handle_signal(libc::SIGTERM);
-                        self.exit(TERMINATED);
-                    } else if signal == Signal::SIGHUP {
-                        self.handle_signal(libc::SIGHUP);
-                        self.exit(TERMINATED);
-                    } else if signal == Signal::SIGINT {
-                        self.foreground_send(libc::SIGINT as i32);
-                        self.break_flow = true;
-                    }
-                    break TERMINATED;
-                },
-                Ok(WaitStatus::Stopped(pid, _)) => {
-                    self.send_to_background(pid as u32, ProcessState::Stopped, get_command());
-                    self.break_flow = true;
-                    break TERMINATED
-                },
-                Ok(_) => (),
-                // ECHILD signifies that all children have exited
-                Err(Error::Sys(Errno::ECHILD)) => break exit_status as i32,
-                Err(why) => {
-                    eprintln!("ion: process doesn't exist: {}", why);
-                    break FAILURE
-                }
-            }
-        }
-    }
-
-    #[cfg(target_os = "redox")]
-    fn watch_foreground <F: FnOnce() -> String, D: FnMut(i32)> (
-        &mut self,
-        pid: u32,
-        _last_pid: u32,
-        _get_command: F,
-        mut drop_command: D,
-    ) -> i32 {
-        use std::io::{self, Write};
-        use std::os::unix::process::ExitStatusExt;
-        use std::process::ExitStatus;
-        use syscall;
-
-        loop {
-            let mut status_raw = 0;
-            match syscall::waitpid(pid as usize, &mut status_raw, 0) {
-                Ok(0) => (),
-                Ok(_pid) => {
-                    let status = ExitStatus::from_raw(status_raw as i32);
-                    if let Some(code) = status.code() {
-                        break code
-                    } else {
-                        let stderr = io::stderr();
-                        let mut stderr = stderr.lock();
-                        let _ = stderr.write_all(b"ion: child ended by signal\n");
-                        break TERMINATED
-                    }
-                },
-                Err(err) => {
-                    let stderr = io::stderr();
-                    let mut stderr = stderr.lock();
-                    let _ = writeln!(stderr, "ion: failed to wait: {}", err);
-                    break 100 // TODO what should we return here?
-                }
-            }
-        }
+        drop_command: D,
+    ) -> i32
+    where
+        F: FnOnce() -> String,
+        D: FnMut(i32),
+    {
+        self_sys::watch_foreground(self, pid, last_pid, get_command, drop_command)
     }
 
     /// Send a kill signal to all running foreground tasks.
@@ -349,6 +214,8 @@ impl<'a> JobControl for Shell<'a> {
         if signal == sys::SIGTERM || signal == sys::SIGHUP {
             self.background_send(signal);
             true
-        } else { false }
+        } else {
+            false
+        }
     }
 }

--- a/src/shell/signals.rs
+++ b/src/shell/signals.rs
@@ -1,60 +1,14 @@
-//! This module contains all of the code that manages signal handling in the shell. Primarily, this will be used to
-//! block signals in the shell at startup, and unblock signals for each of the forked children of the shell.
+//! This module contains all of the code that manages signal handling in the shell. Primarily, this
+//! will be used to block signals in the shell at startup, and unblock signals for each of the forked
+//! children of the shell.
 
 use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
 
 use sys;
 
-#[cfg(all(unix, not(target_os = "redox")))]
-pub use self::unix::*;
-
-#[cfg(target_os = "redox")]
-pub use self::redox::*;
+pub use sys::signals::{block, unblock};
 
 pub static PENDING: AtomicUsize = ATOMIC_USIZE_INIT;
-
-#[cfg(all(unix, not(target_os = "redox")))]
-mod unix {
-    /// Blocks the SIGTSTP/SIGTTOU/SIGTTIN/SIGCHLD signals so that the shell never receives them.
-    pub fn block() {
-        unsafe {
-            use libc::*;
-            use std::mem;
-            use std::ptr;
-            let mut sigset = mem::uninitialized::<sigset_t>();
-            sigemptyset(&mut sigset as *mut sigset_t);
-            sigaddset(&mut sigset as *mut sigset_t, SIGTSTP);
-            sigaddset(&mut sigset as *mut sigset_t, SIGTTOU);
-            sigaddset(&mut sigset as *mut sigset_t, SIGTTIN);
-            sigaddset(&mut sigset as *mut sigset_t, SIGCHLD);
-            sigprocmask(SIG_BLOCK, &sigset as *const sigset_t, ptr::null_mut() as *mut sigset_t);
-        }
-    }
-
-    /// Unblocks the SIGTSTP/SIGTTOU/SIGTTIN/SIGCHLD signals so children processes can be controlled by the shell.
-    pub fn unblock() {
-        unsafe {
-            use libc::*;
-            use std::mem;
-            use std::ptr;
-            let mut sigset = mem::uninitialized::<sigset_t>();
-            sigemptyset(&mut sigset as *mut sigset_t);
-            sigaddset(&mut sigset as *mut sigset_t, SIGTSTP);
-            sigaddset(&mut sigset as *mut sigset_t, SIGTTOU);
-            sigaddset(&mut sigset as *mut sigset_t, SIGTTIN);
-            sigaddset(&mut sigset as *mut sigset_t, SIGCHLD);
-            sigprocmask(SIG_UNBLOCK, &sigset as *const sigset_t, ptr::null_mut() as *mut sigset_t);
-        }
-    }
-}
-
-// TODO
-#[cfg(target_os = "redox")]
-mod redox {
-    pub fn block() { }
-
-    pub fn unblock() { }
-}
 
 /// Suspends a given process by it's process ID.
 pub fn suspend(pid: u32) {

--- a/src/shell/variables.rs
+++ b/src/shell/variables.rs
@@ -14,6 +14,8 @@ use types::{
     Array,
 };
 
+use ::sys::variables as self_sys;
+
 #[derive(Debug)]
 pub struct Variables {
     pub arrays:    ArrayVariableContext,
@@ -196,7 +198,7 @@ impl Variables {
                         }
                     }
                     Err(_) => {
-                        if let Some(home) = get_user_home(tilde_prefix) {
+                        if let Some(home) = self_sys::get_user_home(tilde_prefix) {
                             return Some(home + remainder);
                         }
                     }
@@ -221,29 +223,6 @@ impl Variables {
 
         None
     }
-}
-
-#[cfg(all(unix, not(target_os = "redox")))]
-fn get_user_home(username: &str) -> Option<String> {
-    use users_unix::get_user_by_name;
-    use users_unix::os::unix::UserExt;
-
-    match get_user_by_name(username) {
-        Some(user) => Some(user.home_dir().to_string_lossy().into_owned()),
-        None => None,
-    }
-}
-
-#[cfg(target_os = "redox")]
-fn get_user_home(_username: &str) -> Option<String> {
-    // TODO
-    None
-}
-
-#[cfg(not(any(unix, target_os = "redox")))]
-fn get_user_home(_username: &str) -> Option<String> {
-    // TODO
-    None
 }
 
 #[cfg(test)]

--- a/src/sys/redox.rs
+++ b/src/sys/redox.rs
@@ -5,6 +5,8 @@ use std::os::unix::io::RawFd;
 
 use syscall::SigAction;
 
+pub const PATH_SEPARATOR: &str = ";";
+
 pub const O_CLOEXEC: usize = syscall::O_CLOEXEC;
 pub const SIGHUP: i32 = syscall::SIGHUP as i32;
 pub const SIGINT: i32 = syscall::SIGINT as i32;

--- a/src/sys/redox.rs
+++ b/src/sys/redox.rs
@@ -43,7 +43,7 @@ pub fn signal(signal: i32, handler: extern "C" fn(i32)) -> io::Result<()> {
     let new = SigAction {
         sa_handler: unsafe { mem::transmute(handler) },
         sa_mask: [0; 2],
-        sa_flags: 0
+        sa_flags: 0,
     };
     cvt(syscall::sigaction(signal as usize, Some(&new), None)).and(Ok(()))
 }
@@ -55,7 +55,7 @@ pub fn tcsetpgrp(tty_fd: RawFd, pgid: u32) -> io::Result<()> {
     let res = syscall::write(fd, unsafe {
         slice::from_raw_parts(
             &pgid_usize as *const usize as *const u8,
-            mem::size_of::<usize>()
+            mem::size_of::<usize>(),
         )
     });
 
@@ -67,4 +67,77 @@ pub fn tcsetpgrp(tty_fd: RawFd, pgid: u32) -> io::Result<()> {
 // Support function for converting syscall error to io error
 fn cvt(result: Result<usize, syscall::Error>) -> io::Result<usize> {
     result.map_err(|err| io::Error::from_raw_os_error(err.errno))
+}
+
+// TODO
+pub mod signals {
+    pub fn block() {}
+
+    /// Unblocks the SIGTSTP/SIGTTOU/SIGTTIN/SIGCHLD signals so children processes can be controlled
+    /// by the shell.
+    pub fn unblock() {}
+}
+
+pub mod job_control {
+    use shell::job_control::*;
+
+    use std::io::{self, Write};
+    use std::os::unix::process::ExitStatusExt;
+    use std::process::ExitStatus;
+    use std::sync::{Arc, Mutex};
+    use syscall;
+    use shell::foreground::ForegroundSignals;
+
+    pub fn watch_background(
+        fg: Arc<ForegroundSignals>,
+        processes: Arc<Mutex<Vec<BackgroundProcess>>>,
+        pid: u32,
+        njob: usize,
+    ) {
+        // TODO: Implement this using syscall::call::waitpid
+    }
+
+
+    pub fn watch_foreground<'a, F, D>(
+        _shell: &mut Shell<'a>,
+        pid: u32,
+        _last_pid: u32,
+        _get_command: F,
+        mut drop_command: D,
+    ) -> i32
+    where
+        F: FnOnce() -> String,
+        D: FnMut(i32),
+    {
+        loop {
+            let mut status_raw = 0;
+            match syscall::waitpid(pid as usize, &mut status_raw, 0) {
+                Ok(0) => (),
+                Ok(_pid) => {
+                    let status = ExitStatus::from_raw(status_raw as i32);
+                    if let Some(code) = status.code() {
+                        break code;
+                    } else {
+                        let stderr = io::stderr();
+                        let mut stderr = stderr.lock();
+                        let _ = stderr.write_all(b"ion: child ended by signal\n");
+                        break TERMINATED;
+                    }
+                }
+                Err(err) => {
+                    let stderr = io::stderr();
+                    let mut stderr = stderr.lock();
+                    let _ = writeln!(stderr, "ion: failed to wait: {}", err);
+                    break 100; // TODO what should we return here?
+                }
+            }
+        }
+    }
+}
+
+pub mod variables {
+    pub fn get_user_home(_username: &str) -> Option<String> {
+        // TODO
+        None
+    }
 }

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1,10 +1,6 @@
 extern crate libc;
 
-use libc::{
-    c_int,
-    pid_t,
-    sighandler_t
-};
+use libc::{c_int, pid_t, sighandler_t};
 use std::io;
 use std::os::unix::io::RawFd;
 
@@ -55,11 +51,11 @@ pub fn tcsetpgrp(fd: RawFd, pgrp: u32) -> io::Result<()> {
 }
 
 // Support functions for converting libc return values to io errors {
-    trait IsMinusOne {
-        fn is_minus_one(&self) -> bool;
-    }
+trait IsMinusOne {
+    fn is_minus_one(&self) -> bool;
+}
 
-    macro_rules! impl_is_minus_one {
+macro_rules! impl_is_minus_one {
         ($($t:ident)*) => ($(impl IsMinusOne for $t {
             fn is_minus_one(&self) -> bool {
                 *self == -1
@@ -67,13 +63,195 @@ pub fn tcsetpgrp(fd: RawFd, pgrp: u32) -> io::Result<()> {
         })*)
     }
 
-    impl_is_minus_one! { i8 i16 i32 i64 isize }
+impl_is_minus_one! { i8 i16 i32 i64 isize }
 
-    fn cvt<T: IsMinusOne>(t: T) -> io::Result<T> {
-        if t.is_minus_one() {
-            Err(io::Error::last_os_error())
-        } else {
-            Ok(t)
+fn cvt<T: IsMinusOne>(t: T) -> io::Result<T> {
+    if t.is_minus_one() {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(t)
+    }
+}
+// } End of support functions
+
+pub mod signals {
+    /// Blocks the SIGTSTP/SIGTTOU/SIGTTIN/SIGCHLD signals so that the shell never receives them.
+    pub fn block() {
+        unsafe {
+            use libc::*;
+            use std::mem;
+            use std::ptr;
+            let mut sigset = mem::uninitialized::<sigset_t>();
+            sigemptyset(&mut sigset as *mut sigset_t);
+            sigaddset(&mut sigset as *mut sigset_t, SIGTSTP);
+            sigaddset(&mut sigset as *mut sigset_t, SIGTTOU);
+            sigaddset(&mut sigset as *mut sigset_t, SIGTTIN);
+            sigaddset(&mut sigset as *mut sigset_t, SIGCHLD);
+            sigprocmask(
+                SIG_BLOCK,
+                &sigset as *const sigset_t,
+                ptr::null_mut() as *mut sigset_t,
+            );
         }
     }
-// } End of support functions
+
+    /// Unblocks the SIGTSTP/SIGTTOU/SIGTTIN/SIGCHLD signals so children processes can be controlled
+    /// by the shell.
+    pub fn unblock() {
+        unsafe {
+            use libc::*;
+            use std::mem;
+            use std::ptr;
+            let mut sigset = mem::uninitialized::<sigset_t>();
+            sigemptyset(&mut sigset as *mut sigset_t);
+            sigaddset(&mut sigset as *mut sigset_t, SIGTSTP);
+            sigaddset(&mut sigset as *mut sigset_t, SIGTTOU);
+            sigaddset(&mut sigset as *mut sigset_t, SIGTTIN);
+            sigaddset(&mut sigset as *mut sigset_t, SIGCHLD);
+            sigprocmask(
+                SIG_UNBLOCK,
+                &sigset as *const sigset_t,
+                ptr::null_mut() as *mut sigset_t,
+            );
+        }
+    }
+}
+
+pub mod job_control {
+    use shell::job_control::*;
+
+    use std::thread::sleep;
+    use std::time::Duration;
+    use std::sync::{Arc, Mutex};
+    use shell::foreground::ForegroundSignals;
+    use shell::status::{FAILURE, TERMINATED};
+    use shell::Shell;
+    use libc::{self, pid_t};
+    use nix::sys::wait::{waitpid, WaitStatus, WCONTINUED, WNOHANG, WUNTRACED};
+    use nix::sys::signal::Signal;
+    use nix::{Errno, Error};
+
+    pub fn watch_background(
+        fg: Arc<ForegroundSignals>,
+        processes: Arc<Mutex<Vec<BackgroundProcess>>>,
+        pid: u32,
+        njob: usize,
+    ) {
+        let mut fg_was_grabbed = false;
+        loop {
+            if !fg_was_grabbed {
+                if fg.was_grabbed(pid) {
+                    fg_was_grabbed = true;
+                }
+            }
+            match waitpid(-(pid as pid_t), Some(WUNTRACED | WCONTINUED | WNOHANG)) {
+                Ok(WaitStatus::Exited(_, status)) => {
+                    if !fg_was_grabbed {
+                        eprintln!("ion: ([{}] {}) exited with {}", njob, pid, status);
+                    }
+                    let mut processes = processes.lock().unwrap();
+                    let process = &mut processes.iter_mut().nth(njob).unwrap();
+                    process.state = ProcessState::Empty;
+                    if fg_was_grabbed {
+                        fg.reply_with(status);
+                    }
+                    break;
+                }
+                Ok(WaitStatus::Stopped(pid, _)) => {
+                    if !fg_was_grabbed {
+                        eprintln!("ion: ([{}] {}) Stopped", njob, pid);
+                    }
+                    let mut processes = processes.lock().unwrap();
+                    let process = &mut processes.iter_mut().nth(njob).unwrap();
+                    if fg_was_grabbed {
+                        fg.reply_with(TERMINATED as i8);
+                        fg_was_grabbed = false;
+                    }
+                    process.state = ProcessState::Stopped;
+                }
+                Ok(WaitStatus::Continued(pid)) => {
+                    if !fg_was_grabbed {
+                        eprintln!("ion: ([{}] {}) Running", njob, pid);
+                    }
+                    let mut processes = processes.lock().unwrap();
+                    let process = &mut processes.iter_mut().nth(njob).unwrap();
+                    process.state = ProcessState::Running;
+                }
+                Ok(_) => (),
+                Err(why) => {
+                    eprintln!("ion: ([{}] {}) errored: {}", njob, pid, why);
+                    let mut processes = processes.lock().unwrap();
+                    let process = &mut processes.iter_mut().nth(njob).unwrap();
+                    process.state = ProcessState::Empty;
+                    if fg_was_grabbed {
+                        fg.errored();
+                    }
+                    break;
+                }
+            }
+            sleep(Duration::from_millis(100));
+        }
+    }
+
+    pub fn watch_foreground<'a, F, D>(
+        shell: &mut Shell<'a>,
+        pid: u32,
+        last_pid: u32,
+        get_command: F,
+        mut drop_command: D,
+    ) -> i32
+    where
+        F: FnOnce() -> String,
+        D: FnMut(i32),
+    {
+        let mut exit_status = 0;
+        loop {
+            match waitpid(-(pid as pid_t), Some(WUNTRACED)) {
+                Ok(WaitStatus::Exited(pid, status)) => if pid == (last_pid as i32) {
+                    break status as i32;
+                } else {
+                    drop_command(pid);
+                    exit_status = status;
+                },
+                Ok(WaitStatus::Signaled(_, signal, _)) => {
+                    eprintln!("ion: process ended by signal");
+                    if signal == Signal::SIGTERM {
+                        shell.handle_signal(libc::SIGTERM);
+                        shell.exit(TERMINATED);
+                    } else if signal == Signal::SIGHUP {
+                        shell.handle_signal(libc::SIGHUP);
+                        shell.exit(TERMINATED);
+                    } else if signal == Signal::SIGINT {
+                        shell.foreground_send(libc::SIGINT as i32);
+                        shell.break_flow = true;
+                    }
+                    break TERMINATED;
+                }
+                Ok(WaitStatus::Stopped(pid, _)) => {
+                    shell.send_to_background(pid as u32, ProcessState::Stopped, get_command());
+                    shell.break_flow = true;
+                    break TERMINATED;
+                }
+                Ok(_) => (),
+                // ECHILD signifies that all children have exited
+                Err(Error::Sys(Errno::ECHILD)) => break exit_status as i32,
+                Err(why) => {
+                    eprintln!("ion: process doesn't exist: {}", why);
+                    break FAILURE;
+                }
+            }
+        }
+    }
+}
+
+pub mod variables {
+    use users_unix::get_user_by_name;
+    use users_unix::os::unix::UserExt;
+
+    pub fn get_user_home(username: &str) -> Option<String> {
+        match get_user_by_name(username) {
+            Some(user) => Some(user.home_dir().to_string_lossy().into_owned()),
+            None => None,
+        }
+    }
+}

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -4,6 +4,8 @@ use libc::{c_int, pid_t, sighandler_t};
 use std::io;
 use std::os::unix::io::RawFd;
 
+pub const PATH_SEPARATOR: &str = ":";
+
 pub const O_CLOEXEC: usize = libc::O_CLOEXEC as usize;
 pub const SIGHUP: i32 = libc::SIGHUP;
 pub const SIGINT: i32 = libc::SIGINT;


### PR DESCRIPTION
Resolves #463. A non-flat replica of the module structure may be wanted in the future if `sys` grows, but I think this works fine for now.