### PR TITLE
Implement simple form of associative arrays

### DIFF
--- a/src/parser/assignments.rs
+++ b/src/parser/assignments.rs
@@ -1,11 +1,11 @@
 use shell::variables::Variables;
-use types::{Identifier, Value as VString, Array};
+use types::{Identifier, Value as VString, Array, Key};
 
 #[derive(Debug, PartialEq, Clone)]
 // TODO: Have the expand_string function return the `Value` type.
 pub enum Value {
     String(VString),
-    Array(Array)
+    Array(Array),
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -14,6 +14,7 @@ pub enum Binding {
     ListEntries,
     KeyOnly(Identifier),
     KeyValue(Identifier, VString),
+    MapKeyValue(Identifier, Key, VString),
     Math(Identifier, Operator, VString),
     MultipleKeys(Vec<Identifier>, VString)
 }
@@ -108,6 +109,8 @@ pub fn parse_assignment(arguments: &str) -> Binding {
         let value = char_iter.skip_while(|&x| x == ' ').collect::<VString>();
         if value.is_empty() {
             Binding::KeyOnly(key.into())
+        } else if let Some((key, inner_key)) = Variables::is_hashmap_reference(&key) {
+            Binding::MapKeyValue(key.into(), inner_key.into(), value)
         } else if !Variables::is_valid_variable_name(&key) {
             Binding::InvalidKey(key.into())
         } else {

--- a/src/parser/shell_expand/words.rs
+++ b/src/parser/shell_expand/words.rs
@@ -131,8 +131,19 @@ impl Range {
     }
 }
 
+#[derive(Debug, PartialEq, Clone)]
+pub struct Key {
+    key : ::types::Key
+}
+
+impl Key {
+    pub fn get(&self) -> &::types::Key {
+        return &self.key
+    }
+}
+
 /// Represents a filter on a vector-like object
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Select {
     /// Select no elements
     None,
@@ -141,7 +152,9 @@ pub enum Select {
     /// Select a single element based on its index
     Index(Index),
     /// Select a range of elements
-    Range(Range)
+    Range(Range),
+    /// Select an element by mapped key
+    Key(Key),
 }
 
 pub trait SelectWithSize {
@@ -168,19 +181,18 @@ impl<I, T> SelectWithSize for I where I : Iterator<Item=T> {
                 } else {
                     empty().collect()
                 }
+            },
+            Select::Key(_) => {
+                empty().collect()
             }
         }
     }
 
 }
 
-pub enum SelectError {
-    Invalid
-}
-
 impl FromStr for Select {
-    type Err = SelectError;
-    fn from_str(data: &str) -> Result<Select, SelectError> {
+    type Err = ();
+    fn from_str(data: &str) -> Result<Select, ()> {
         if ".." == data {
             return Ok(Select::All)
         }
@@ -193,10 +205,7 @@ impl FromStr for Select {
             return Ok(Select::Range(range));
         }
 
-        let stderr = io::stderr();
-        let _ = writeln!(stderr.lock(), "ion: supplied selector, '{}', for array is invalid", data);
-
-        Err(SelectError::Invalid)
+        Ok(Select::Key(Key{ key: data.into() }))
     }
 }
 
@@ -244,7 +253,7 @@ impl<'a> ArrayMethod<'a> {
                 } else {
                     return;
                 };
-                match (&self.pattern, self.selection) {
+                match (&self.pattern, self.selection.clone()) {
                     (&Pattern::StringPattern(pattern), Select::All) => current.push_str (
                         &variable.split(&expand_string(pattern, expand_func, false).join(" "))
                             .collect::<Vec<&str>>()
@@ -301,6 +310,7 @@ impl<'a> ArrayMethod<'a> {
                         }
 
                     },
+                    (_, Select::Key(_)) => ()
                 }
             },
             _ => {
@@ -328,7 +338,7 @@ impl<'a> ArrayMethod<'a> {
         match self.method {
             "split" => {
                 let variable = resolve_var!();
-                return match (&self.pattern, self.selection) {
+                return match (&self.pattern, self.selection.clone()) {
                     (_, Select::None) => Some("".into()).into_iter().collect(),
                     (&Pattern::StringPattern(pattern), Select::All) => variable
                         .split(&expand_string(pattern, expand_func, false).join(" "))
@@ -386,6 +396,9 @@ impl<'a> ArrayMethod<'a> {
                             Array::new()
                         }
                     },
+                    (_, Select::Key(_)) => {
+                        Some("".into()).into_iter().collect()
+                    }
                 }
             },
             "graphemes" => {
@@ -393,21 +406,21 @@ impl<'a> ArrayMethod<'a> {
                 let graphemes = UnicodeSegmentation::graphemes(variable.as_str(), true);
                 let len = graphemes.clone().count();
                 return graphemes.map(From::from)
-                                .select(self.selection, len);
+                                .select(self.selection.clone(), len);
             },
             "bytes" => {
                 let variable = resolve_var!();
                 let len = variable.as_bytes().len();
                 return variable.bytes()
                                .map(|b| b.to_string())
-                               .select(self.selection, len);
+                               .select(self.selection.clone(), len);
             },
             "chars" => {
                 let variable = resolve_var!();
                 let len = variable.chars().count();
                 return variable.chars()
                                .map(|c| c.to_string())
-                               .select(self.selection, len);
+                               .select(self.selection.clone(), len);
             },
             _ => {
                 let stderr = io::stderr();
@@ -443,9 +456,9 @@ impl<'a> StringMethod<'a> {
             "join" => {
                 let pattern = expand_string(self.pattern, expand, false).join(" ");
                 if let Some(array) = (expand.array)(self.variable, Select::All) {
-                    slice(output, array.join(&pattern), self.selection);
+                    slice(output, array.join(&pattern), self.selection.clone());
                 } else if is_expression(self.variable) {
-                    slice(output, expand_string(self.variable, expand, false).join(&pattern), self.selection);
+                    slice(output, expand_string(self.variable, expand, false).join(&pattern), self.selection.clone());
                 }
             },
             "len" => {
@@ -1436,11 +1449,24 @@ mod tests {
             WordToken::ArrayVariable("array", false, Select::Range(Range::inclusive(Index::new(0),
                                                                                     Index::new(3)))),
             WordToken::Whitespace(" "),
-            WordToken::ArrayVariable("array", false, Select::None),
+            WordToken::ArrayVariable("array", false, Select::Key(Key{key: "abc".into()})),
             WordToken::Whitespace(" "),
             WordToken::ArrayVariable("array", false, Select::Range(Range::to(Index::new(3)))),
             WordToken::Whitespace(" "),
             WordToken::ArrayVariable("array", false, Select::Range(Range::from(Index::new(3)))),
+        ];
+        compare(input, expected);
+    }
+
+    #[test]
+    fn string_keys() {
+        let input = "@array['key'] @array[key] @array[]";
+        let expected = vec![
+            WordToken::ArrayVariable("array", false, Select::Key(Key{key: "key".into()})),
+            WordToken::Whitespace(" "),
+            WordToken::ArrayVariable("array", false, Select::Key(Key{key: "key".into()})),
+            WordToken::Whitespace(" "),
+            WordToken::ArrayVariable("array", false, Select::Key(Key{key: "".into()})),
         ];
         compare(input, expected);
     }

--- a/src/shell/variables.rs
+++ b/src/shell/variables.rs
@@ -7,15 +7,19 @@ use super::directory_stack::DirectoryStack;
 use liner::Context;
 use super::status::{SUCCESS, FAILURE};
 use types::{
+    HashMapVariableContext,
     ArrayVariableContext,
     VariableContext,
     Identifier,
+    Key,
     Value,
     Array,
+    HashMap,
 };
 
 #[derive(Debug)]
 pub struct Variables {
+    pub hashmaps:  HashMapVariableContext,
     pub arrays:    ArrayVariableContext,
     pub variables: VariableContext,
     pub aliases:   VariableContext,
@@ -45,6 +49,10 @@ impl Default for Variables {
         // Initialize the HOME variable
         env::home_dir().map_or_else(|| env::set_var("HOME", "?"), |path| env::set_var("HOME", path.to_str().unwrap_or("?")));
         Variables {
+            hashmaps: FnvHashMap::with_capacity_and_hasher(
+                64,
+                Default::default(),
+            ),
             arrays: FnvHashMap::with_capacity_and_hasher(
                 64,
                 Default::default(),
@@ -93,6 +101,26 @@ impl Variables {
                 self.arrays.insert(name.into(), value);
             }
         }
+    }
+
+    pub fn set_hashmap_value(&mut self, name: &str, key: &str, value: &str) {
+        if !name.is_empty() {
+            if let Some(map) = self.hashmaps.get_mut(name) {
+                map.insert(key.into(), value.into());
+                return
+            }
+
+            let mut map = HashMap::with_capacity_and_hasher(
+                4,
+                Default::default()
+            );
+            map.insert(key.into(), value.into());
+            self.hashmaps.insert(name.into(), map);
+        }
+    }
+
+    pub fn get_map(&self, name: &str) -> Option<&HashMap>{
+        self.hashmaps.get(name)
     }
 
     pub fn get_array(&self, name: &str) -> Option<&Array> {
@@ -221,6 +249,23 @@ impl Variables {
 
         None
     }
+
+    pub fn is_hashmap_reference(key: &str) -> Option<(Identifier, Key)> {
+        let mut key_iter = key.split('[');
+
+        if let Some(map_name) = key_iter.next() {
+            if Variables::is_valid_variable_name(map_name) {
+                if let Some(mut inner_key) = key_iter.next() {
+                    if inner_key.ends_with(']') {
+                        inner_key = inner_key.split(']').next().unwrap_or("");
+                        inner_key = inner_key.trim_matches(|c| c == '\'' || c == '\"');
+                        return Some((map_name.into(), inner_key.into()))
+                    }
+                }
+            }
+        }
+        None
+    }
 }
 
 #[cfg(all(unix, not(target_os = "redox")))]
@@ -273,5 +318,15 @@ mod tests {
             false
         ).join("");
         assert_eq!("BAR", &expanded);
+    }
+
+    #[test]
+    fn decompose_map_reference() {
+        if let Some((map_name, inner_key)) = Variables::is_hashmap_reference("map[\'key\']") {
+            assert!(map_name == "map".into());
+            assert!(inner_key == "key".into());
+        } else {
+            assert!(false);
+        }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,10 +3,13 @@ use fnv::FnvHashMap;
 use smallstring::SmallString;
 
 pub type Array = SmallVec<[Value; 4]>;
+pub type HashMap = FnvHashMap<Key, Value>;
 pub type Identifier = SmallString;
+pub type Key = SmallString;
 pub type Value = String;
 pub type VariableContext = FnvHashMap<Identifier, Value>;
 pub type ArrayVariableContext = FnvHashMap<Identifier, Array>;
+pub type HashMapVariableContext = FnvHashMap<Identifier, HashMap>;
 
 /// Construct a new Array containing the given arguments
 ///


### PR DESCRIPTION
**Problem**: No map-like data structures yet exist in ion.

**Solution**: Allow simple associative arrays with string keys

**Changes introduced by this pull request**:

- Create hashmap context in shell::variables to store named hashmaps
- Create "Key" selector to represent string keys
- Instances of "Select" objects must now be cloned; remove Copy trait
      (This was needed to support a select type based on string keys)

**Drawbacks**: Select objects no longer implement Copy

**TODOs**: Does not yet have an initializer syntax for associative arrays 

**Fixes**: Addresses #246 

**State**: Needs review