### PR TITLE
include whitespace in alias argument

### DIFF
--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -220,7 +220,8 @@ fn builtin_popd(args: &[&str], shell: &mut Shell) -> i32 {
 }
 
 fn builtin_alias(args: &[&str], shell: &mut Shell) -> i32 {
-    alias(&mut shell.variables, args)
+    let args_str = args[1..].join(" ");
+    alias(&mut shell.variables, &args_str)
 }
 
 fn builtin_unalias(args: &[&str], shell: &mut Shell) -> i32 {

--- a/src/builtins/variables.rs
+++ b/src/builtins/variables.rs
@@ -34,12 +34,10 @@ enum Operator {
     Multiply
 }
 
-/// Parses let bindings, `let VAR = KEY`, returning the result as a `(key, value)` tuple.
-fn parse_assignment<'a, S: AsRef<str> + 'a>(args: &[S]) -> Binding {
+/// Parses alias as a `(key, value)` tuple.
+fn parse_alias(args: &str) -> Binding {
     // Write all the arguments into a single `String`
-    let mut char_iter = args.iter().skip(1)
-        .map(|arg| arg.as_ref().chars())
-        .flat_map(|chars| chars);
+    let mut char_iter = args.chars();
 
     // Find the key and advance the iterator until the equals operator is found.
     let mut key = "".to_owned();
@@ -115,8 +113,8 @@ fn parse_assignment<'a, S: AsRef<str> + 'a>(args: &[S]) -> Binding {
 
 /// The `alias` command will define an alias for another command, and thus may be used as a
 /// command itself.
-pub fn alias<'a, S: AsRef<str> + 'a>(vars: &mut Variables, args: &[S]) -> i32 {
-    match parse_assignment(args) {
+pub fn alias(vars: &mut Variables, args: &str) -> i32 {
+    match parse_alias(args) {
         Binding::InvalidKey(key) => {
             let stderr = io::stderr();
             let _ = writeln!(&mut stderr.lock(), "ion: alias name, '{}', is invalid", key);


### PR DESCRIPTION
Fix #453 
The `alias` built-in took an array of arguments so whitespace wasn't included. 
Now the array is joined by whitespace, and given to `alias` as is. 
`parse_assignment` didn't actually parse `let` bindings so I changed the name and documentation to reflect that.
     