### PR TITLE
Allow builtins to be executed as part of pipelines

### DIFF
--- a/examples/builtin_piping.ion
+++ b/examples/builtin_piping.ion
@@ -1,0 +1,6 @@
+matches Foo '([A-Z])\w+' && echo true
+matches foo '([A-Z])\w+' || echo false
+
+fn foobar x; end
+
+fn | tr '[a-z]' '[A-Z]'

--- a/examples/builtin_piping.out
+++ b/examples/builtin_piping.out
@@ -1,0 +1,4 @@
+true
+false
+# FUNCTIONS
+    FOOBAR

--- a/src/shell/fork.rs
+++ b/src/shell/fork.rs
@@ -51,7 +51,7 @@ mod unix {
 }
 
 use std::process::{Command, exit};
-use super::job::JobKind;
+use super::job::{RefinedJob, JobKind};
 use super::job_control::{JobControl, ProcessState};
 use super::Shell;
 use super::signals;
@@ -62,7 +62,7 @@ use super::pipe::pipe;
 /// the given commands in the child fork.
 pub fn fork_pipe (
     shell: &mut Shell,
-    commands: Vec<(Command, JobKind)>,
+    commands: Vec<(RefinedJob, JobKind)>,
     command_name: String
 ) -> i32 {
     match ion_fork() {

--- a/src/shell/fork.rs
+++ b/src/shell/fork.rs
@@ -5,7 +5,7 @@ pub fn create_process_group(pgid: u32) {
     let _ = sys::setpgid(0, pgid);
 }
 
-use std::process::{Command, exit};
+use std::process::exit;
 use super::job::{RefinedJob, JobKind};
 use super::job_control::{JobControl, ProcessState};
 use super::Shell;

--- a/src/shell/job.rs
+++ b/src/shell/job.rs
@@ -137,6 +137,10 @@ impl RefinedJob {
 
 impl Drop for RefinedJob {
 
+    // This is needed in order to ensure that the parent instance of RefinedJob
+    // cleans up after its own `RawFd`s; otherwise these would never be properly
+    // closed, never sending EOF, causing any process reading from these
+    // `RawFd`s to halt indefinitely.
     fn drop(&mut self) {
         match *self {
             RefinedJob::External(ref mut cmd) => {

--- a/src/shell/job.rs
+++ b/src/shell/job.rs
@@ -126,8 +126,8 @@ impl RefinedJob {
                 }
                 output
             },
-            RefinedJob::Builtin { ref name, ref args, .. } => {
-                format!("{} {}", name, args.join(" "))
+            RefinedJob::Builtin { ref args, .. } => {
+                format!("{}", args.join(" "))
             }
         }
     }

--- a/src/shell/job.rs
+++ b/src/shell/job.rs
@@ -66,27 +66,27 @@ impl RefinedJob {
         }
     }
 
-    pub fn stdin<T: IntoRawFd>(&mut self, fd: T) {
-        set_field!(self, stdin, fd.into_raw_fd());
+    pub fn stdin(&mut self, fd: RawFd) {
+        set_field!(self, stdin, fd);
     }
 
-    pub fn stdout<T: IntoRawFd>(&mut self, fd: T) {
-        set_field!(self, stdout, fd.into_raw_fd());
+    pub fn stdout(&mut self, fd: RawFd) {
+        set_field!(self, stdout, fd);
     }
 
-    pub fn stderr<T: IntoRawFd>(&mut self, fd: T) {
-        set_field!(self, stderr, fd.into_raw_fd());
+    pub fn stderr(&mut self, fd: RawFd) {
+        set_field!(self, stderr, fd);
     }
 
     /// Returns a short description of this job: often just the command
     /// or builtin name
     pub fn short(&self) -> String {
         match *self {
-            RefinedJob::External(cmd) => {
+            RefinedJob::External(ref cmd) => {
                 format!("{:?}", cmd).split('"').nth(1).unwrap_or("").to_string()
             },
-            RefinedJob::Builtin { name, .. } => {
-                name.into()
+            RefinedJob::Builtin { ref name, .. } => {
+                name.to_string()
             }
         }
     }
@@ -94,7 +94,7 @@ impl RefinedJob {
     /// Returns a long description of this job: the commands and arguments
     pub fn long(&self) -> String {
         match *self {
-            RefinedJob::External(cmd) => {
+            RefinedJob::External(ref cmd) => {
                 let command = format!("{:?}", cmd);
                 let mut arg_iter = command.split_whitespace();
                 let command = arg_iter.next().unwrap();
@@ -109,7 +109,7 @@ impl RefinedJob {
                 }
                 output
             },
-            RefinedJob::Builtin { name, args, .. } => {
+            RefinedJob::Builtin { ref name, ref args, .. } => {
                 format!("{} {}", name, args.join(" "))
             }
         }

--- a/src/shell/job_control.rs
+++ b/src/shell/job_control.rs
@@ -28,7 +28,6 @@ pub trait JobControl {
     fn background_send(&self, signal: i32);
     fn watch_foreground <F, D> (
         &mut self,
-        pid: u32,
         last_pid: u32,
         get_command: F,
         drop_command: D
@@ -212,7 +211,6 @@ impl<'a> JobControl for Shell<'a> {
     #[cfg(all(unix, not(target_os = "redox")))]
     fn watch_foreground <F: FnOnce() -> String, D: FnMut(i32)> (
         &mut self,
-        pid: u32,
         last_pid: u32,
         get_command: F,
         mut drop_command: D,

--- a/src/shell/job_control.rs
+++ b/src/shell/job_control.rs
@@ -217,12 +217,13 @@ impl<'a> JobControl for Shell<'a> {
         get_command: F,
         mut drop_command: D,
     ) -> i32 {
-        use nix::sys::wait::{waitpid, WaitStatus, WUNTRACED};
+        use nix::sys::wait::{wait, WaitStatus};
         use nix::sys::signal::Signal;
         use nix::{Error, Errno};
         let mut exit_status = 0;
         loop {
-            match waitpid(-(pid as pid_t), Some(WUNTRACED)) {
+            // match waitpid(-(pid as pid_t), Some(WUNTRACED)) {
+            match wait() {
                 Ok(WaitStatus::Exited(pid, status)) => {
                     if pid == (last_pid as i32) {
                         break status as i32
@@ -252,7 +253,9 @@ impl<'a> JobControl for Shell<'a> {
                 },
                 Ok(_) => (),
                 // ECHILD signifies that all children have exited
-                Err(Error::Sys(Errno::ECHILD)) => break exit_status as i32,
+                Err(Error::Sys(Errno::ECHILD)) => {
+                    break exit_status as i32;
+                }
                 Err(why) => {
                     eprintln!("ion: process doesn't exist: {}", why);
                     break FAILURE

--- a/src/shell/job_control.rs
+++ b/src/shell/job_control.rs
@@ -30,6 +30,7 @@ pub trait JobControl {
     fn background_send(&self, signal: i32);
     fn watch_foreground<F, D>(
         &mut self,
+        pid: u32,
         last_pid: u32,
         get_command: F,
         drop_command: D,
@@ -151,6 +152,7 @@ impl<'a> JobControl for Shell<'a> {
 
     fn watch_foreground<F, D>(
         &mut self,
+        pid: u32,
         last_pid: u32,
         get_command: F,
         drop_command: D,

--- a/src/shell/pipe.rs
+++ b/src/shell/pipe.rs
@@ -356,7 +356,7 @@ fn execute(shell: &mut Shell, job: &mut RefinedJob, foreground: bool) -> i32 {
                     if foreground {
                         let _ = sys::tcsetpgrp(0, child.id());
                     }
-                    shell.watch_foreground(child.id(), move || long, |_| ())
+                    shell.watch_foreground(child.id(), child.id(), move || long, |_| ())
                 },
                 Err(e) => {
                     if e.kind() == io::ErrorKind::NotFound {
@@ -380,7 +380,7 @@ fn execute(shell: &mut Shell, job: &mut RefinedJob, foreground: bool) -> i32 {
                     if foreground {
                         let _ = sys::tcsetpgrp(0, pid);
                     }
-                    shell.watch_foreground(pid, move || long, |_| ())
+                    shell.watch_foreground(pid, pid, move || long, |_| ())
                 },
                 Err(e) => {
                     eprintln!("ion: fork error for '{}': {}", short, e);
@@ -404,11 +404,14 @@ fn wait (
         .collect::<Vec<String>>()
         .join(" | ");
 
+    // Each process in the pipe has the same PGID, which is the first process's PID.
+    let pgid = children[0];
+
     // If the last process exits, we know that all processes should exit.
     let last_pid = children[children.len()-1];
 
     // Watch the foreground group, dropping all commands that exit as they exit.
-    shell.watch_foreground(last_pid, move || as_string, move |pid| {
+    shell.watch_foreground(pgid, last_pid, move || as_string, move |pid| {
         if let Some(id) = children.iter().position(|&x| x as i32 == pid) {
             commands.remove(id);
             children.remove(id);

--- a/src/shell/pipe.rs
+++ b/src/shell/pipe.rs
@@ -53,8 +53,6 @@ impl<'a> PipelineExecution for Shell<'a> {
     fn execute_pipeline(&mut self, pipeline: &mut Pipeline) -> i32 {
         let background_string = check_if_background_job(&pipeline, self.flags & PRINT_COMMS != 0);
 
-        println!("Pipeline: {:?}", pipeline);
-
         let mut piped_commands: Vec<(RefinedJob, JobKind)> = {
             pipeline.jobs
                 .drain(..)

--- a/src/shell/pipe.rs
+++ b/src/shell/pipe.rs
@@ -6,12 +6,14 @@ use std::os::unix::io::{FromRawFd, IntoRawFd};
 use std::os::unix::process::CommandExt;
 use std::fs::{File, OpenOptions};
 use super::flags::*;
-use super::fork::{fork_pipe, create_process_group};
+use super::fork::{fork_pipe, ion_fork, Fork, create_process_group};
 use super::job_control::JobControl;
 use super::{JobKind, Shell};
+use super::job::RefinedJob;
 use super::status::*;
 use super::signals::{self, SignalHandler};
 use parser::peg::{Pipeline, Input, RedirectFrom};
+use sys;
 use self::crossplat::*;
 
 /// The `crossplat` module contains components that are meant to be abstracted across
@@ -34,10 +36,9 @@ pub mod crossplat {
         unistd::getpid() as u32
     }
 
-    /// Create an instance of Stdio from a byte slice that will echo the
-    /// contents of the slice when read. This can be called with owned or
-    /// borrowed strings
-    pub unsafe fn stdin_of<T: AsRef<[u8]>>(input: T) -> Result<Stdio, Error> {
+    /// Create a File from a byte slice that will echo the contents of the slice
+    /// when read. This can be called with owned or borrowed strings
+    pub unsafe fn stdin_of<T: AsRef<[u8]>>(input: T) -> Result<File, Error> {
         let (reader, writer) = unistd::pipe2(fcntl::O_CLOEXEC)?;
         let mut infile = File::from_raw_fd(writer);
         // Write the contents; make sure to use write_all so that we block until
@@ -46,37 +47,9 @@ pub mod crossplat {
         infile.flush()?;
         // `infile` currently owns the writer end RawFd. If we just return the reader end
         // and let `infile` go out of scope, it will be closed, sending EOF to the reader!
-        Ok(Stdio::from_raw_fd(reader))
+        Ok(File::from_raw_fd(reader))
     }
 
-    /// Set up pipes such that the relevant output of parent is sent to the stdin of child.
-    /// The content that is sent depends on `mode`
-    pub unsafe fn create_pipe (
-        parent: &mut Command,
-        child: &mut Command,
-        mode: RedirectFrom
-    ) -> Result<(), Error> {
-        let (reader, writer) = unistd::pipe2(fcntl::O_CLOEXEC)?;
-        match mode {
-            RedirectFrom::Stdout => {
-                parent.stdout(Stdio::from_raw_fd(writer));
-            },
-            RedirectFrom::Stderr => {
-                parent.stderr(Stdio::from_raw_fd(writer));
-            },
-            RedirectFrom::Both => {
-                let temp_file = File::from_raw_fd(writer);
-                let clone = temp_file.try_clone()?;
-                // We want to make sure that the temp file we created no longer has ownership
-                // over the raw file descriptor otherwise it gets closed
-                temp_file.into_raw_fd();
-                parent.stdout(Stdio::from_raw_fd(writer));
-                parent.stderr(Stdio::from_raw_fd(clone.into_raw_fd()));
-            }
-        }
-        child.stdin(Stdio::from_raw_fd(reader));
-        Ok(())
-    }
 }
 
 #[cfg(target_os = "redox")]
@@ -96,7 +69,7 @@ pub mod crossplat {
         syscall::getpid().unwrap() as u32
     }
 
-    pub unsafe fn stdin_of<T: AsRef<[u8]>>(input: T) -> Result<Stdio, Error> {
+    pub unsafe fn stdin_of<T: AsRef<[u8]>>(input: T) -> Result<File, Error> {
         let mut fds: [usize; 2] = [0; 2];
         syscall::call::pipe2(&mut fds, syscall::flag::O_CLOEXEC)
                       .map_err(|e| Error::from_raw_os_error(e.errno))?;
@@ -108,42 +81,9 @@ pub mod crossplat {
         infile.flush()?;
         // `infile` currently owns the writer end RawFd. If we just return the reader end
         // and let `infile` go out of scope, it will be closed, sending EOF to the reader!
-        Ok(Stdio::from_raw_fd(reader))
+        Ok(File::from_raw_fd(reader))
     }
 
-    /// Set up pipes such that the relevant output of parent is sent to the stdin of child.
-    /// The content that is sent depends on `mode`
-    pub unsafe fn create_pipe (
-        parent: &mut Command,
-        child: &mut Command,
-        mode: RedirectFrom
-    ) -> Result<(), Error> {
-        // XXX: Zero probably is a bad default for this, but `pipe2` will error if it fails, so
-        // one could reason that it isn't dangerous.
-        let mut fds: [usize; 2] = [0; 2];
-        syscall::call::pipe2(&mut fds, syscall::flag::O_CLOEXEC)
-                      .map_err(|e| Error::from_raw_os_error(e.errno))?;
-        let (reader, writer) = (fds[0], fds[1]);
-        match mode {
-            RedirectFrom::Stdout => {
-                parent.stdout(Stdio::from_raw_fd(writer));
-            },
-            RedirectFrom::Stderr => {
-                parent.stderr(Stdio::from_raw_fd(writer));
-            },
-            RedirectFrom::Both => {
-                let temp_file = File::from_raw_fd(writer);
-                let clone = temp_file.try_clone()?;
-                // We want to make sure that the temp file we created no longer has ownership
-                // over the raw file descriptor otherwise it gets closed
-                temp_file.into_raw_fd();
-                parent.stdout(Stdio::from_raw_fd(writer));
-                parent.stderr(Stdio::from_raw_fd(clone.into_raw_fd()));
-            }
-        }
-        child.stdin(Stdio::from_raw_fd(reader));
-        Ok(())
-    }
 }
 
 /// This function serves three purposes:
@@ -171,25 +111,35 @@ impl<'a> PipelineExecution for Shell<'a> {
     fn execute_pipeline(&mut self, pipeline: &mut Pipeline) -> i32 {
         let background_string = check_if_background_job(&pipeline, self.flags & PRINT_COMMS != 0);
 
-        // Generate a list of commands from the given pipeline
-        let mut piped_commands: Vec<(Command, JobKind)> = pipeline.jobs
-            .drain(..).map(|mut job| {
-                if self.builtins.contains_key(&job.command.as_ref()) {
-                    (job.build_command_builtin(), job.kind)
-                } else {
-                    (job.build_command_external(), job.kind)
-                }
-            }).collect();
+        let mut piped_commands: Vec<(RefinedJob, JobKind)> = {
+            pipeline.jobs
+                .drain(..)
+                .map(|job| {
+                    let refined = if self.builtins.contains_key(job.command.as_ref()) {
+                        RefinedJob::builtin(
+                            job.command,
+                            job.args.drain().skip(1).collect()
+                        )
+                    } else {
+                        let command = Command::new(job.command);
+                        for arg in job.args.drain().skip(1) {
+                            command.arg(arg);
+                        }
+                        RefinedJob::External(command)
+                    };
+                    (refined, job.kind)
+                })
+                .collect()
+        };
         match pipeline.stdin {
             None => (),
             Some(Input::File(ref filename)) => {
                 if let Some(command) = piped_commands.first_mut() {
                     match File::open(filename) {
-                        Ok(file) => unsafe {
-                            command.0.stdin(Stdio::from_raw_fd(file.into_raw_fd()));
-                        },
+                        Ok(file) => command.0.stdin(file),
                         Err(e) => {
-                            eprintln!("ion: failed to redirect '{}' into stdin: {}", filename, e);
+                            eprintln!("ion: failed to redirect '{}' into stdin: {}",
+                                      filename, e)
                         }
                     }
                 }
@@ -202,8 +152,11 @@ impl<'a> PipelineExecution for Shell<'a> {
                             command.0.stdin(stdio);
                         },
                         Err(e) => {
-                            eprintln!("ion: failed to redirect herestring '{}' into stdin: {}",
-                                      string, e);
+                            eprintln!(
+                                "ion: failed to redirect herestring '{}' into stdin: {}",
+                                string,
+                                e
+                            );
                         }
                     }
                 }
@@ -221,16 +174,18 @@ impl<'a> PipelineExecution for Shell<'a> {
                     Ok(f) => unsafe {
                         match stdout.from {
                             RedirectFrom::Both => {
-                                let fd = f.into_raw_fd();
-                                command.0.stderr(Stdio::from_raw_fd(fd));
-                                command.0.stdout(Stdio::from_raw_fd(fd));
+                                match f.try_clone() {
+                                    Ok(f_copy) => {
+                                        command.0.stdout(f);
+                                        command.0.stderr(f_copy);
+                                    },
+                                    Err(e) => {
+                                        eprintln!("ion: failed to redirect both stderr and stdout into file '{:?}'", f);
+                                    }
+                                }
                             },
-                            RedirectFrom::Stderr => {
-                                command.0.stderr(Stdio::from_raw_fd(f.into_raw_fd()));
-                            },
-                            RedirectFrom::Stdout => {
-                                command.0.stdout(Stdio::from_raw_fd(f.into_raw_fd()));
-                            },
+                            RedirectFrom::Stderr => command.0.stderr(f),
+                            RedirectFrom::Stdout => command.0.stdout(f),
                         }
                     },
                     Err(err) => {
@@ -261,7 +216,7 @@ impl<'a> PipelineExecution for Shell<'a> {
 /// This function will panic if called with an empty slice
 pub fn pipe (
     shell: &mut Shell,
-    commands: Vec<(Command, JobKind)>,
+    commands: Vec<(RefinedJob, JobKind)>,
     foreground: bool
 ) -> i32 {
     let mut previous_status = SUCCESS;
@@ -284,9 +239,10 @@ pub fn pipe (
 
             match kind {
                 JobKind::Pipe(mut mode) => {
-                    // We need to remember the commands as they own the file descriptors that are
-                    // created by crossplat::create_pipe. We purposfully drop the pipes that are
-                    // owned by a given command in `wait` in order to close those pipes, sending
+                    // We need to remember the commands as they own the file
+                    // descriptors that are created by sys::pipe.
+                    // We purposfully drop the pipes that are owned by a given
+                    // command in `wait` in order to close those pipes, sending
                     // EOF to the next command
                     let mut remember = Vec::new();
                     // A list of the PIDs in the piped command
@@ -296,23 +252,55 @@ pub fn pipe (
 
                     macro_rules! spawn_proc {
                         ($cmd:expr) => {{
-                            let child = $cmd.before_exec(move || {
-                                signals::unblock();
-                                create_process_group(pgid);
-                                Ok(())
-                            }).spawn();
-                            match child {
-                                Ok(child) => {
-                                    if pgid == 0 {
-                                        pgid = child.id();
-                                        if foreground { set_foreground(pgid); }
+                            match $cmd {
+                                &mut RefinedJob::External(ref mut command) => {
+                                    match {
+                                        command.before_exec(move || {
+                                            signals::unblock();
+                                            create_process_group(pgid);
+                                            Ok(())
+                                        }).spawn()
+                                    } {
+                                        Ok(child) => {
+                                            if pgid == 0 {
+                                                pgid = child.id();
+                                                if foreground {
+                                                    set_foreground(pgid);
+                                                }
+                                            }
+                                            shell.foreground.push(child.id());
+                                            children.push(child.id());
+                                        },
+                                        Err(e) => {
+                                            eprintln!("ion: failed to spawn `{}`: {}",
+                                                      $cmd.short(), e);
+                                            return NO_SUCH_COMMAND
+                                        }
                                     }
-                                    shell.foreground.push(child.id());
-                                    children.push(child.id());
-                                },
-                                Err(e) => {
-                                    eprintln!("ion: failed to spawn `{}`: {}", get_command_name($cmd), e);
-                                    return NO_SUCH_COMMAND
+                                }
+                                &mut RefinedJob::Builtin { name,
+                                                           args,
+                                                           stdin,
+                                                           stdout,
+                                                           stderr } =>
+                                {
+                                    match ion_fork() {
+                                        Ok(Fork::Parent(pid)) => {
+                                            if pgid == 0 {
+                                                pgid = pid;
+                                                if foreground {
+                                                    set_foreground(pgid);
+                                                }
+                                            }
+                                            shell.foreground.push(pid);
+                                            children.push(pid);
+                                        },
+                                        Ok(Fork::Child) => {
+                                            signals::unblock();
+                                            create_process_group(pgid);
+                                            unimplemented!()
+                                        }
+                                    }
                                 }
                             }
                         }};
@@ -320,10 +308,35 @@ pub fn pipe (
 
                     // Append other jobs until all piped jobs are running
                     while let Some((mut child, ckind)) = commands.next() {
-                        if let Err(e) = unsafe {
-                            crossplat::create_pipe(&mut parent, &mut child, mode)
-                        } {
-                            eprintln!("ion: failed to create pipe for redirection: {:?}", e);
+                        match sys::pipe2(sys::O_CLOEXEC) {
+                            Err(e) =>  {
+                                eprintln!("ion: failed to create pipe: {:?}", e);
+                            },
+                            Ok((reader, writer)) => {
+                                reader.foo();
+                                writer.foo();
+                                child.stdin(reader);
+                                match mode {
+                                    RedirectFrom::Stderr => {
+                                        parent.stderr(writer);
+                                    },
+                                    RedirectFrom::Stdout => {
+                                        parent.stdout(writer);
+                                    },
+                                    RedirectFrom::Both => {
+                                        let temp = File::from_raw_fd(writer);
+                                        match temp.try_clone() {
+                                            Err(e) => {
+                                                eprintln!("ion: failed to redirect stdout and stderr");
+                                            }
+                                            Ok(duped) => {
+                                                parent.stderr(temp);
+                                                parent.stdout(duped);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                         spawn_proc!(&mut parent);
                         remember.push(parent);
@@ -340,7 +353,7 @@ pub fn pipe (
                             break
                         }
                     }
-
+                    unimplemented!();
                     previous_kind = kind;
                     previous_status = wait(shell, children, remember);
                     if previous_status == TERMINATED {
@@ -349,7 +362,7 @@ pub fn pipe (
                     }
                 }
                 _ => {
-                    previous_status = execute_command(shell, &mut parent, foreground);
+                    previous_status = execute(shell, &mut parent, foreground);
                     previous_kind = kind;
                 }
             }
@@ -370,25 +383,59 @@ fn terminate_fg(shell: &mut Shell) {
     shell.foreground_send(syscall::SIGTERM as i32);
 }
 
-fn execute_command(shell: &mut Shell, command: &mut Command, foreground: bool) -> i32 {
-    match command.before_exec(move || {
-        signals::unblock();
-        create_process_group(0);
-        Ok(())
-    }).spawn() {
-        Ok(child) => {
-            if foreground { set_foreground(child.id()); }
-            shell.watch_foreground(child.id(), child.id(), || get_full_command(command), |_| ())
-        },
-        Err(e) => {
-            let stderr = io::stderr();
-            let mut stderr = stderr.lock();
-            let _ = if e.kind() == io::ErrorKind::NotFound {
-                writeln!(stderr, "ion: Command not found: {}", get_command_name(command))
-            } else {
-                writeln!(stderr, "ion: Error spawning process: {}", e)
-            };
-            FAILURE
+fn execute(shell: &mut Shell, job: &mut RefinedJob, foreground: bool) -> i32 {
+    match job {
+        &mut RefinedJob::External(ref mut command) => {
+            match {
+                command.before_exec(move || {
+                    signals::unblock();
+                    create_process_group(0);
+                    Ok(())
+                }).spawn()
+            } {
+                Ok(child) => {
+                    if foreground {
+                        set_foreground(child.id());
+                    }
+                    shell.watch_foreground(
+                        child.id(),
+                        child.id(),
+                        || job.long(),
+                        |_| ())
+                },
+                Err(e) => {
+                    if e.kind() == io::ErrorKind::NotFound {
+                        eprintln!("ion: command not found: {}", job.short())
+                    } else {
+                        eprintln!("ion: error spawning process: {}", e)
+                    };
+                    FAILURE
+                }
+            }
+        }
+        &mut RefinedJob::Builtin { name,
+                                   args,
+                                   stdin,
+                                   stdout,
+                                   stderr } =>
+        {
+            match ion_fork() {
+                Ok(Fork::Parent(pid)) => {
+                    if foreground {
+                       set_foreground(pid);
+                    }
+                    shell.watch_foreground(pid, pid, || job.long(), |_| ())
+                },
+                Ok(Fork::Child) => {
+                    signals::unblock();
+                    create_process_group(0);
+                    unimplemented!()
+                },
+                Err(e) => {
+                    eprintln!("ion: fork error: {}", e);
+                    FAILURE
+                }
+            }
         }
     }
 }
@@ -398,11 +445,13 @@ fn execute_command(shell: &mut Shell, command: &mut Command, foreground: bool) -
 fn wait (
     shell: &mut Shell,
     mut children: Vec<u32>,
-    mut commands: Vec<Command>
+    mut commands: Vec<RefinedJob>
 ) -> i32 {
     // TODO: Find a way to only do this when absolutely necessary.
-    let as_string = commands.iter().map(get_full_command)
-            .collect::<Vec<String>>().join(" | ");
+    let as_string = commands.iter()
+        .map(RefinedJob::long)
+        .collect::<Vec<String>>()
+        .join(" | ");
 
     // Each process in the pipe has the same PGID, which is the first process's PID.
     let pgid = children[0];
@@ -416,24 +465,4 @@ fn wait (
             children.remove(id);
         }
     })
-}
-
-fn get_command_name(command: &Command) -> String {
-    format!("{:?}", command).split('"').nth(1).unwrap_or("").to_string()
-}
-
-fn get_full_command(command: &Command) -> String {
-    let command = format!("{:?}", command);
-    let mut arg_iter = command.split_whitespace();
-    let command = arg_iter.next().unwrap();
-    let mut output = String::from(&command[1..command.len()-1]);
-    for argument in arg_iter {
-        output.push(' ');
-        if argument.len() > 2 {
-            output.push_str(&argument[1..argument.len()-1]);
-        } else {
-            output.push_str(&argument);
-        }
-    }
-    output
 }

--- a/src/sys/redox.rs
+++ b/src/sys/redox.rs
@@ -64,6 +64,14 @@ pub fn tcsetpgrp(tty_fd: RawFd, pgid: u32) -> io::Result<()> {
     cvt(res).and(Ok(()))
 }
 
+pub fn dup2(old: RawFd, new: RawFd) -> io::Result<RawFd> {
+    syscall::call::dup2(old, new, &[]).map_err(|e| io::Error::from_raw_os_err(err.errno))
+}
+
+pub fn close(fd: RawFd) -> io::Result<()> {
+    cvt(syscall::call::close(fd)).and(Ok())
+}
+
 // Support function for converting syscall error to io error
 fn cvt(result: Result<usize, syscall::Error>) -> io::Result<usize> {
     result.map_err(|err| io::Error::from_raw_os_error(err.errno))

--- a/src/sys/redox.rs
+++ b/src/sys/redox.rs
@@ -15,6 +15,12 @@ pub const SIGCONT: i32 = syscall::SIGCONT as i32;
 pub const SIGSTOP: i32 = syscall::SIGSTOP as i32;
 pub const SIGTSTP: i32 = syscall::SIGTSTP as i32;
 
+/// XXX: These values were infered from the Redox port of `newlib` and may be
+/// sensitive to changes in redox;
+pub const STDIN_FILENO: i32 = 0;
+pub const STDOUT_FILENO: i32 = 1;
+pub const STDERR_FILENO: i32 = 2;
+
 pub unsafe fn fork() -> io::Result<u32> {
     cvt(syscall::clone(0)).map(|pid| pid as u32)
 }

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -16,6 +16,10 @@ pub const SIGCONT: i32 = libc::SIGCONT;
 pub const SIGSTOP: i32 = libc::SIGSTOP;
 pub const SIGTSTP: i32 = libc::SIGTSTP;
 
+pub const STDOUT_FILENO: i32 = libc::STDOUT_FILENO;
+pub const STDERR_FILENO: i32 = libc::STDERR_FILENO;
+pub const STDIN_FILENO: i32 = libc::STDIN_FILENO;
+
 pub unsafe fn fork() -> io::Result<u32> {
     cvt(libc::fork()).map(|pid| pid as u32)
 }
@@ -52,6 +56,10 @@ pub fn signal(signal: i32, handler: extern "C" fn(i32)) -> io::Result<()> {
 
 pub fn tcsetpgrp(fd: RawFd, pgrp: u32) -> io::Result<()> {
     cvt(unsafe { libc::tcsetpgrp(fd as c_int, pgrp as pid_t) }).and(Ok(()))
+}
+
+pub fn dup2(old: RawFd, new: RawFd) -> io::Result<RawFd> {
+    cvt(unsafe { libc::dup2(old, new) })
 }
 
 // Support functions for converting libc return values to io errors {

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -62,6 +62,10 @@ pub fn dup2(old: RawFd, new: RawFd) -> io::Result<RawFd> {
     cvt(unsafe { libc::dup2(old, new) })
 }
 
+pub fn close(fd: RawFd) -> io::Result<()> {
+    cvt(unsafe { libc::close(fd) }).and(Ok(()))
+}
+
 // Support functions for converting libc return values to io errors {
     trait IsMinusOne {
         fn is_minus_one(&self) -> bool;

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -148,7 +148,7 @@ pub mod job_control {
     use shell::Shell;
     use libc::{self, pid_t};
 
-    use nix::sys::wait::{waitpid, WaitStatus, WNOHANG, WUNTRACED};
+    use nix::sys::wait::{waitpid, wait, WaitStatus, WNOHANG, WUNTRACED};
     #[cfg(not(target_os = "macos"))]
     use nix::sys::wait::{WCONTINUED};
 
@@ -225,7 +225,7 @@ pub mod job_control {
 
     pub fn watch_foreground<'a, F, D>(
         shell: &mut Shell<'a>,
-        pid: u32,
+        _pid: u32,
         last_pid: u32,
         get_command: F,
         mut drop_command: D,
@@ -236,7 +236,7 @@ pub mod job_control {
     {
         let mut exit_status = 0;
         loop {
-            match waitpid(-(pid as pid_t), Some(WUNTRACED)) {
+            match wait() {
                 Ok(WaitStatus::Exited(pid, status)) => if pid == (last_pid as i32) {
                     break status as i32;
                 } else {


### PR DESCRIPTION
**Problem**: Currently if we have a builtin to be run as part of a pipeline, we just take the job, reconstruct it, and run a sub-process such as `ion -c builtin arg1 arg2`. This is problematic as it forces `ion` to re-parse the given arguments which is inefficient and bug prone ( #454 ).

**Solution**: Manually manage running builtins as part of a pipeline by forking the current process and executing the builtin in the child process.

**Changes introduced by this pull request**:
- Replaced the use of `Command` in `shell::pipe` with `RefinedJob`; an enumeration that is either an external command or a builtin
- Modified `shell::pipe::pipe` to fork and execute a builtin for the `RefinedJob::Builtin` instance; behavior for `RefinedJob::External` is roughly the same as before: build a `Command`, run `spawn()`.

**Drawbacks**: The use of `RawFd` everywhere might make #364 more difficult.

**Fixes**: Closes #379 ; Closes #454 

**State**: WIP; I want to make sure there are some regression tests in `examples/`. Also this is a 500+- change so letting it sit for review would be good.

**TODO**:
- [x] Determine the redox equivalent for `STDOUT_FILENO` et al
- [x] Add a regression example in `examples/` for piping to / from a builtin #