### PR TITLE
Added stepped ranges

### DIFF
--- a/examples/braces.ion
+++ b/examples/braces.ion
@@ -13,3 +13,17 @@ echo {a..d}
 echo {d..a}
 echo {A..D}
 echo {D..A}
+# inclusive stepped ranges
+echo {0..2...4}
+echo {a..2...e}
+echo {A..2...E}
+echo {0..-2...-4}
+echo {e..-2...a}
+echo {E..-2...A}
+# exclusive stepped ranges
+echo {0..2..5}
+echo {a..2..f}
+echo {A..2..F}
+echo {0..-2..-5}
+echo {e..-2..a}
+echo {E..-2..A}

--- a/examples/braces.out
+++ b/examples/braces.out
@@ -11,3 +11,15 @@ a b c
 d c b
 A B C
 D C B
+0 2 4
+a c e
+A C E
+0 -2 -4
+e c a
+E C A
+0 2 4
+a c e
+A C E
+0 -2 -4
+e c
+E C

--- a/src/parser/shell_expand/ranges.rs
+++ b/src/parser/shell_expand/ranges.rs
@@ -1,37 +1,166 @@
 use super::words::{Range, Index};
 
+// SteppedRange is used because as of right now (start..end).step_by(step)
+// is experimental/unstable. It is simply an iterator that creates a range
+// (either backwards or forwards) with a given step which can be positive
+// or negative. Since there are combinations of step sizes and start/end values
+// that can cause infinite loops it comes with a `validate` method and a
+// `new_validated` constructor. If the stepper isn't validated it will validate
+// on first `next` call and silently return None if it is invalid
+struct SteppedRange {
+    start: isize,
+    end: isize,
+    step: isize,
+    inclusive: bool,
+    backwards: bool,
+    validated: bool,
+}
+
+impl SteppedRange {
+    #[inline]
+    fn new(start: isize, end: isize, step:isize, inclusive: bool) -> Self {
+        Self {
+            validated: false,
+            start: start,
+            end: end,
+            step: step,
+            inclusive: inclusive,
+            backwards: start > end,
+        }
+    }
+
+    #[inline]
+    fn new_validated(start: isize, end: isize, step:isize, inclusive: bool) -> Result<Self, &'static str> {
+        let mut s = Self::new(start, end, step, inclusive);
+        match s.validate() {
+            Ok(_) => Ok(s),
+            Err(why) => Err(why),            
+        }
+    }
+
+     // Check for cases that would cause infinite loops 
+    fn validate(&mut self) -> Result<(), &'static str> {
+        if self.start < self.end && self.step < 0 {
+            Err("negative step size with start < end would cause infinite loop")
+        } else if self.start > self.end && self.step > 0 {
+            Err("positive step size with start > end would cause infinite loop")
+        } else if self.step == 0 {
+            Err("0 step size would cause infinite loop")
+        } else {
+            self.validated = true;
+            Ok(())
+        }
+    }
+
+    // since we typically want to return a vec of strings instead of isize
+    #[inline]
+    fn new_string_vec(start: isize, end: isize, step:isize, inclusive: bool) -> Option<Vec<String>> {
+        match Self::new_validated(start, end, step, inclusive) {
+            Ok(s) => Some(s.map(|x| x.to_string()).collect()),
+            Err(_) => None,
+        }
+    }
+}
+
+impl Iterator for SteppedRange {
+    type Item = isize;
+    fn next(&mut self) -> Option<Self::Item> {
+        macro_rules! step_logic {
+            ($left:expr, $right:expr) => {
+                if self.inclusive && $left <= $right {
+                    let v = self.start;
+                    self.start += self.step;
+                    Some(v)
+                } else if !self.inclusive && $left < $right {
+                    let v = self.start;
+                    self.start += self.step;
+                    Some(v)
+                } else {
+                    None
+                }
+            }
+        }
+        if !self.validated {
+            match self.validate() {
+                Ok(_) => self.validated = true,
+                Err(_) => return None,
+            }
+        }
+        // we always return and step `self.start`, but if it is backwards we
+        // need to compare the other way around
+        if self.backwards {
+            step_logic!(self.end, self.start)
+        } else {
+            step_logic!(self.start, self.end)
+        }
+    }
+}
+
 pub fn parse_range(input: &str) -> Option<Vec<String>> {
     let mut bytes_iterator = input.bytes().enumerate();
-    while let Some((id, byte)) = bytes_iterator.next() {
+    let mut parsed_first = false;
+    let mut first = "";
+    let mut step = 1;
+    let mut dots = 0;
+    while let Some((idx, byte)) = bytes_iterator.next() {
         match byte {
             b'0'...b'9' | b'-' | b'a'...b'z' | b'A'...b'Z' => continue,
+            b',' => {
+                first = &input[..idx];
+                parsed_first = true;
+                // match what is following the , as the step size
+                while let Some((inner_idx, inner_byte)) = bytes_iterator.next() {
+                    match inner_byte {
+                        b'0'...b'9' | b'-' => { continue },
+                        b'.' => {
+                            dots += 1;
+                            step = match input[idx + 1..inner_idx].parse::<isize>() {
+                                Ok(v) => v,
+                                Err(_) => return None,
+                            };
+                            break;
+                        },
+                        _ => return None,
+                    } 
+                }
+            }
             b'.' => {
-                let first = &input[..id];
-
-                let mut dots = 1;
+                if !parsed_first {
+                    first = &input[..idx];
+                }
+                dots += 1;
                 while let Some((_, byte)) = bytes_iterator.next() {
                     if byte == b'.' { dots += 1 } else { break }
                 }
-
+            
                 // 2 dots is exclusive 3 dots is inclusive
                 // 1..3 -> 1 2
                 // 1...3 -> 1 2 3
-                if dots != 2 && dots != 3 { break }
-
-                let end = &input[id+dots..];
-
+                if dots != 2 && dots != 3 { return None; }
+                let inclusive = dots == 3;
+            
+                // when using the stepped range we already consumed one b'.' so the
+                // index is off by 1
+                let end = if parsed_first {
+                    &input[idx+dots-1..]
+                } else {
+                    &input[idx+dots..]
+                };
+            
                 if let Ok(start) = first.parse::<isize>() {
                     if let Ok(mut end) = end.parse::<isize>() {
-                        return if start < end {
-                            if dots == 3 {
+                        return if step != 1 {
+                            SteppedRange::new_string_vec(start, end, step, inclusive)
+                        } else if start < end {
+                            if inclusive {
                                 end += 1;
                             }
                             Some((start..end).map(|x| x.to_string()).collect())
                         } else if start > end {
                             if dots == 2 {
-                               end += 1; 
+                                end += 1;
                             }
-                            Some((end..start + 1).rev().map(|x| x.to_string()).collect())
+                            Some((end..start+1).rev().map(|x| x.to_string()).collect())
                         } else {
                             Some(vec![first.to_owned()])
                         }
@@ -39,10 +168,10 @@ pub fn parse_range(input: &str) -> Option<Vec<String>> {
                 } else if first.len() == 1 && end.len() == 1 {
                     let start = first.bytes().next().unwrap();
                     let mut end = end.bytes().next().unwrap();
-
+            
                     let is_valid = ((start >= b'a' && start <= b'z') && (end >= b'a' && end <= b'z'))
                      || ((start >= b'A' && start <= b'Z') && (end >= b'A' && end <= b'Z'));
-
+            
                     if !is_valid { break }
                     return if start < end {
                         if dots == 3 {


### PR DESCRIPTION
Half of #457 

Syntax is now:
`{1..2...7}` -> 1 3 5 7
`{1..2..7}` -> 1 3 5
`{a..2...e}` -> a c e
`{a..2..e}` -> a c

and similarly for backwards and negatives.

Also added some tests to the examples dir.

(I'm not sure why those two earlier commits are in this.. I let my repo get messed up somehow)