### PR TITLE
Run builtins in place when not part of a pipeline of data

### DIFF
--- a/src/sys/redox.rs
+++ b/src/sys/redox.rs
@@ -72,6 +72,10 @@ pub fn tcsetpgrp(tty_fd: RawFd, pgid: u32) -> io::Result<()> {
     cvt(res).and(Ok(()))
 }
 
+pub fn dup(fd: RawFd) -> io::Result<RawFd> {
+    syscall::call::dup(fd, &[]).map_err(|e| io::Error::from_raw_os_error(err.errno))
+}
+
 pub fn dup2(old: RawFd, new: RawFd) -> io::Result<RawFd> {
     syscall::call::dup2(old, new, &[]).map_err(|e| io::Error::from_raw_os_err(err.errno))
 }

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -62,6 +62,10 @@ pub fn tcsetpgrp(fd: RawFd, pgrp: u32) -> io::Result<()> {
     cvt(unsafe { libc::tcsetpgrp(fd as c_int, pgrp as pid_t) }).and(Ok(()))
 }
 
+pub fn dup(fd: RawFd) -> io::Result<RawFd> {
+    cvt(unsafe { libc::dup(fd) })
+}
+
 pub fn dup2(old: RawFd, new: RawFd) -> io::Result<RawFd> {
     cvt(unsafe { libc::dup2(old, new) })
 }


### PR DESCRIPTION
**Changes introduced by this pull request**:
- `shell::pipe::execute` will run a builtin in place and set the appropriate return code instead of forking

**Fixes**: Closes #332.

**State**: Good to go!
