### PR TITLE
RawFDs now managed by forked process, not shell::pipe::builtin, when appropriate

### DIFF
--- a/src/shell/job.rs
+++ b/src/shell/job.rs
@@ -156,7 +156,9 @@ impl Drop for RefinedJob {
                 fn close(fd: Option<RawFd>) {
                     if let Some(fd) = fd {
                         if let Err(e) = sys::close(fd) {
-                            eprintln!("ion: failed to close file '{}': {}", fd, e);
+                            eprintln!("ion: failed to close file descriptor '{}': {}",
+                                      fd,
+                                      e);
                         }
                     }
                 }


### PR DESCRIPTION
**Changes introduced by this pull request**:
- `shell::pipe::builtin` will not close any file descriptors: this will be done by `RefinedJob::drop` or inside the child process if appropriate. This prevents a double close in the case of a builtin being run in the parent process.

**Fixes**: Closes #478 

----

@mmstick: I'm thinking about replacing all of the `RawFd`s with `File`s. It would mean that `RefinedJob` doesn't need to have a custom `Drop` implementation and it means we are less dependent on *nix specific things. Thoughts?