### PR TITLE
Fixed job arguments expanding to empty string

### DIFF
--- a/src/shell/job.rs
+++ b/src/shell/job.rs
@@ -30,7 +30,12 @@ impl Job {
         let mut expanded = Array::new();
         expanded.grow(self.args.len());
         expanded.extend(self.args.drain().flat_map(|arg| {
-            expand_string(&arg, expanders, false)
+            let res = expand_string(&arg, expanders, false);
+            if res.is_empty() {
+                array![""]
+            } else {
+                res
+            }
         }));
         self.args = expanded;
     }
@@ -169,6 +174,34 @@ impl Drop for RefinedJob {
                 close(*stderr);
             }
         }
+    }
+
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parser::ExpanderFunctions;
+    use shell::variables::Variables;
+
+    macro_rules! functions {
+        () => {
+            ExpanderFunctions {
+                vars:     &Variables::default(),
+                tilde:    &|_| None,
+                array:    &|_, _| None,
+                variable: &|_, _| None,
+                command:  &|_| None
+            }
+        }
+    }
+
+    #[test]
+    fn preserve_empty_arg() {
+        let job = Job::new(array!("rename", "", "0", "a"), JobKind::Last);
+        let mut expanded = job.clone();
+        expanded.expand(&functions!());
+        assert_eq!(job, expanded);
     }
 
 }


### PR DESCRIPTION
**Changes introduced by this pull request**:
- If a job argument expands to the empty string, return an array containing the empty string instead.
- Added a regression test w.r.t. job expansion

**Fixes**: Closes #345 (again).

------

I wonder if it would be helpful to make a distinction inside Ion's code-base between string and array values. I.e. `Array` becomes `Value`, and `Value` becomes an enum like:
```
enum Value {
  String(SmallString<...>),
  Array(SmallVec<...>),
}
```
Though we probably can't use `SmallVec`; it would have to be `Vec` (I think). 
