### PR TITLE
read builtin detects if `stdin` is a TTY

### DIFF
--- a/examples/builtin_piping.ion
+++ b/examples/builtin_piping.ion
@@ -4,3 +4,6 @@ matches foo '([A-Z])\w+' || echo false
 fn foobar x; end
 
 fn | tr '[a-z]' '[A-Z]'
+
+read foo <<< $(echo bar)
+echo $foo

--- a/examples/builtin_piping.out
+++ b/examples/builtin_piping.out
@@ -2,3 +2,4 @@ true
 false
 # FUNCTIONS
     FOOBAR
+bar

--- a/src/sys/redox.rs
+++ b/src/sys/redox.rs
@@ -82,6 +82,15 @@ pub fn close(fd: RawFd) -> io::Result<()> {
     cvt(syscall::close(fd)).and(Ok(()))
 }
 
+pub fn isatty(fd: RawFd) -> bool {
+    if let Ok(fd) = syscall::dup(f, &[]) {
+        let _ = syscall::close(fd);
+        true
+    } else {
+        false
+    }
+}
+
 // Support function for converting syscall error to io error
 fn cvt(result: Result<usize, syscall::Error>) -> io::Result<usize> {
     result.map_err(|err| io::Error::from_raw_os_error(err.errno))

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -74,6 +74,10 @@ pub fn close(fd: RawFd) -> io::Result<()> {
     cvt(unsafe { libc::close(fd) }).and(Ok(()))
 }
 
+pub fn isatty(fd: RawFd) -> bool {
+    unsafe { libc::isatty(fd) == 1 }
+}
+
 // Support functions for converting libc return values to io errors {
 trait IsMinusOne {
     fn is_minus_one(&self) -> bool;


### PR DESCRIPTION
**Changes introduced by this pull request**:
- Added `sys::isatty` which emulates `libc`'s `isatty`
- `read` builtin detects if `stdin` is a TTY: if so, it uses `liner`, otherwise it reads line by line assigning each new variable to each line

**Drawbacks**: If we have input like:
```
Foo
Bar
Baz
```
and call
```
$ read foo bar < input
```
The last line of input will be lost. Is this desirable? Or should we make like Bash's `read` which uses the last variable as the sink for remaining input. If so, we could make it an array of lines.

**Fixes**: Closes #474. Disclaimer: _this does not resolve all issues mentioned in the issue_ i.e.:
```
echo "foo" | read bar
```
will do nothing as `read bar` is executed in a subshell. 

**State**: Good to go barring the issue mentioned in **Drawbacks**
