### PR TITLE
Replace `ExpanderFunctions` with `Expander` trait

### DIFF
--- a/src/parser/loops/for_grammar.rs
+++ b/src/parser/loops/for_grammar.rs
@@ -1,7 +1,5 @@
-use shell::directory_stack::DirectoryStack;
-use shell::variables::Variables;
 use types::Value;
-use parser::{expand_string, ExpanderFunctions, Select};
+use parser::{expand_string, Expander};
 
 #[derive(Debug, PartialEq)]
 pub enum ForExpression {
@@ -11,9 +9,9 @@ pub enum ForExpression {
 }
 
 impl ForExpression {
-    pub fn new(expression: &[String], dir_stack: &DirectoryStack, variables: &Variables) -> ForExpression {
+    pub fn new<E: Expander>(expression: &[String], expanders: &E) -> ForExpression {
         let output: Vec<_> = expression.iter()
-            .flat_map(|expression| expand_string(expression, &get_expanders!(variables, dir_stack), true))
+            .flat_map(|expression| expand_string(expression, expanders, true))
             .collect();
 
         if output.len() == 1 {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6,7 +6,7 @@ pub mod shell_expand;
 mod statement;
 mod quotes;
 
-pub use self::shell_expand::{Select, Range, Index, Expander, ExpanderFunctions, expand_string, expand_tokens, WordToken, WordIterator};
+pub use self::shell_expand::{Select, Range, Index, Expander, expand_string, expand_tokens, WordToken, WordIterator};
 pub use self::arguments::ArgumentSplitter;
 pub use self::loops::for_grammar::ForExpression;
 pub use self::statement::{StatementSplitter, StatementError, parse_and_validate};

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,79 +1,3 @@
-#[macro_export]
-macro_rules! get_expanders {
-    ($vars:expr, $dir_stack:expr) => {
-        ExpanderFunctions {
-            vars: $vars,
-            tilde: &|tilde: &str| $vars.tilde_expansion(tilde, $dir_stack),
-            array: &|array: &str, selection : Select| {
-                use std::iter::FromIterator;
-                use $crate::types::*;
-                let mut found = match $vars.get_array(array) {
-                    Some(array) => match selection {
-                        Select::None  => None,
-                        Select::All   => Some(array.clone()),
-                        Select::Index(id) => {
-                            id.resolve(array.len())
-                              .and_then(|n| array.get(n))
-                              .map(|x| Array::from_iter(Some(x.to_owned())))
-                        },
-                        Select::Range(range) => {
-                            if let Some((start, length)) = range.bounds(array.len()) {
-                                let array = array.iter()
-                                     .skip(start)
-                                     .take(length)
-                                     .map(|x| x.to_owned())
-                                     .collect::<Array>();
-                                if array.is_empty() {
-                                    None
-                                } else {
-                                    Some(array)
-                                }
-                            } else {
-                                None
-                            }
-                        },
-                        Select::Key(_) => {
-                            None
-                        }
-                    },
-                    None => None
-                };
-                if found.is_none() {
-                    found = match $vars.get_map(array) {
-                        Some(map) => match selection {
-                            Select::All => {
-                                let mut arr = Array::new();
-                                for (_, value) in map {
-                                    arr.push(value.clone());
-                                }
-                                Some(arr)
-                            }
-                            Select::Key(ref key) => {
-                                Some(array![
-                                    map.get(key.get()).unwrap_or(&"".into()).clone()
-                                ])
-                            },
-                            _ => None
-                        },
-                        None => None
-                    }
-                }
-                found
-            },
-            variable: &|variable: &str, quoted: bool| {
-                use ascii_helpers::AsciiReplace;
-                if quoted {
-                    $vars.get_var(variable)
-                } else {
-                    $vars.get_var(variable)
-                        .map(|x| x.ascii_replace('\n', ' ').into())
-                }
-            },
-            command: &|command: &str| $vars.command_expansion(command),
-        }
-    }
-}
-
 mod arguments;
 pub mod assignments;
 mod loops;
@@ -82,7 +6,7 @@ pub mod shell_expand;
 mod statement;
 mod quotes;
 
-pub use self::shell_expand::{Select, Range, Index, ExpanderFunctions, expand_string, expand_tokens, WordToken, WordIterator};
+pub use self::shell_expand::{Select, Range, Index, Expander, ExpanderFunctions, expand_string, expand_tokens, WordToken, WordIterator};
 pub use self::arguments::ArgumentSplitter;
 pub use self::loops::for_grammar::ForExpression;
 pub use self::statement::{StatementSplitter, StatementError, parse_and_validate};

--- a/src/parser/shell_expand/words.rs
+++ b/src/parser/shell_expand/words.rs
@@ -1387,18 +1387,14 @@ impl<'a, E: Expander + 'a> Iterator for WordIterator<'a, E> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use shell::variables::Variables;
+    use types::Value;
+
+    struct Empty;
+
+    impl Expander for Empty {}
 
     macro_rules! functions {
-        () => {
-            ExpanderFunctions {
-                vars:     &Variables::default(),
-                tilde:    &|_| None,
-                array:    &|_, _| None,
-                variable: &|_, _| None,
-                command:  &|_| None
-            }
-        }
+        () => { Empty }
     }
 
     fn compare(input: &str, expected: Vec<WordToken>) {
@@ -1632,20 +1628,20 @@ mod tests {
         compare(input, expected);
     }
 
-    macro_rules! functions_with_vars {
-        () => {
-            ExpanderFunctions {
-                vars:     &Variables::default(),
-                tilde:    &|_| None,
-                array:    &|_, _| None,
-                variable:  &|var : &str, _| match var {
-                    "pkmn1" => "Pokémon".to_owned().into(),
-                    "pkmn2" => "Poke\u{0301}mon".to_owned().into(),
-                    _ => None
-                },
-                command: &|_| None,
+    struct WithVars;
+
+    impl Expander for WithVars {
+        fn variable(&self, var: &str, _: bool) -> Option<Value> {
+            match var {
+                "pkmn1" => "Pokémon".to_owned().into(),
+                "pkmn2" => "Poke\u{0301}mon".to_owned().into(),
+                _ => None
             }
         }
+    }
+
+    macro_rules! functions_with_vars {
+        () => { WithVars }
     }
 
     #[test]

--- a/src/parser/shell_expand/words.rs
+++ b/src/parser/shell_expand/words.rs
@@ -1393,13 +1393,9 @@ mod tests {
 
     impl Expander for Empty {}
 
-    macro_rules! functions {
-        () => { Empty }
-    }
-
     fn compare(input: &str, expected: Vec<WordToken>) {
         let mut correct = 0;
-        for (actual, expected) in WordIterator::new(input, true, &functions!()).zip(expected.iter()) {
+        for (actual, expected) in WordIterator::new(input, true, &Empty).zip(expected.iter()) {
             assert_eq!(actual, *expected, "{:?} != {:?}", actual, expected);
             correct += 1;
         }
@@ -1640,13 +1636,9 @@ mod tests {
         }
     }
 
-    macro_rules! functions_with_vars {
-        () => { WithVars }
-    }
-
     #[test]
     fn array_methods() {
-        let expanders = functions_with_vars!();
+        let expanders = WithVars;
         let method = ArrayMethod {
             method: "graphemes",
             variable: "pkmn1",

--- a/src/shell/binary.rs
+++ b/src/shell/binary.rs
@@ -42,7 +42,7 @@ impl<'a> Binary for Shell<'a> {
     fn prompt(&self) -> String {
         if self.flow_control.level == 0 {
             let prompt_var = self.variables.get_var_or_empty("PROMPT");
-            expand_string(&prompt_var, &get_expanders!(&self.variables, &self.directory_stack), false).join(" ")
+            expand_string(&prompt_var, self, false).join(" ")
         } else {
             "    ".repeat(self.flow_control.level as usize)
         }

--- a/src/shell/job.rs
+++ b/src/shell/job.rs
@@ -143,26 +143,17 @@ impl RefinedJob {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use parser::ExpanderFunctions;
-    use shell::variables::Variables;
+    use parser::Expander;
 
-    macro_rules! functions {
-        () => {
-            ExpanderFunctions {
-                vars:     &Variables::default(),
-                tilde:    &|_| None,
-                array:    &|_, _| None,
-                variable: &|_, _| None,
-                command:  &|_| None
-            }
-        }
-    }
+    struct Empty;
+
+    impl Expander for Empty {}
 
     #[test]
     fn preserve_empty_arg() {
         let job = Job::new(array!("rename", "", "0", "a"), JobKind::Last);
         let mut expanded = job.clone();
-        expanded.expand(&functions!());
+        expanded.expand(&Empty);
         assert_eq!(job, expanded);
     }
 

--- a/src/shell/job.rs
+++ b/src/shell/job.rs
@@ -3,7 +3,7 @@ use std::process::{Command, Stdio};
 use std::os::unix::io::{FromRawFd, IntoRawFd};
 
 //use glob::glob;
-use parser::{expand_string, ExpanderFunctions};
+use parser::{expand_string, Expander};
 use parser::pipelines::RedirectFrom;
 use smallstring::SmallString;
 use types::*;
@@ -26,7 +26,7 @@ impl Job {
 
     /// Takes the current job's arguments and expands them, one argument at a
     /// time, returning a new `Job` with the expanded arguments.
-    pub fn expand(&mut self, expanders: &ExpanderFunctions) {
+    pub fn expand<E: Expander>(&mut self, expanders: &E) {
         let mut expanded = Array::new();
         expanded.grow(self.args.len());
         expanded.extend(self.args.drain().flat_map(|arg| {

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -297,6 +297,8 @@ impl<'a> Shell<'a> {
 
 impl<'a> Expander for Shell<'a> {
     fn tilde(&self, input: &str) -> Option<String> {
+        /// XXX: This is a silly implementation: the `Variables` struct
+        /// should not know nor be responsible for expanding tildes
         self.variables.tilde_expansion(input, &self.directory_stack)
     }
 
@@ -368,7 +370,7 @@ impl<'a> Expander for Shell<'a> {
     }
     /// Expand a subshell expression
     fn command(&self, command: &str) -> Option<Value> {
-        /// XXX: This is a terrible implementation: the `Variables` struct
+        /// XXX: This is a silly implementation: the `Variables` struct
         /// should not know nor be responsible for expanding a subshell
         self.variables.command_expansion(command)
     }


### PR DESCRIPTION
**Problem**: `ExpanderFunctions` was somewhat unruly as:
- It was mostly used through `get_expanders!` which made tracking down errors more cumbersome as it was generated through a macro
- Hard to extend sensibly as the main instance, `get_expanders!`, would lose access to any information that was not contained within `Variables` or `DirectoryStack`
- Had weird artifacts like having a direct reference to a `Variables` but also a separate `variable(&str, bool) -> Option<Value>` function?

**Solution**: Replace `ExpanderFunctions` with an `Expander` trait which provides roughly the same interface as `ExpanderFunctions` but allows the backing implementation to be more complex 

**Changes introduced by this pull request**:
- Removed `ExpanderFunctions`, `get_expanders!` etc.
- Add the aforementioned `Expander` trait
- Have `Shell` implement `Expander` and use `Shell` as the `Expander` for most non-testing instances
- Refactored `let_assignment` and `export_assigment` into `VariableStore` trait, which represents storing a `Binding` as either a local variable or a global (exported) variable
  - This was done as `let_assignment` and `export_assignment` took in a mutable `Variables`, but also required an `ExpanderFunctions` to expand the right hand side. Instead, `Shell` now implements `VariableStore`

**Drawbacks**: I am not sure this is as performant as `ExpanderFunctions` but its more idiomatic IMO.

**Fixes**: This will make #424 much much easier.

**State**: Good to go pending review!