### PR TITLE
Fix broken & missing links in documentation

### DIFF
--- a/manual/src/SUMMARY.md
+++ b/manual/src/SUMMARY.md
@@ -11,9 +11,10 @@
     - [Quoting Rules](ch03-03-quotation.md)
     - [Multi-line Arguments](ch03-04-multiargs.md)
     - [Multi-line Comments](ch03-05-multicomments.md)
+    - [General Tips](ch03-06-general.md)
 
 - [Variable Assignments](ch04-00-variables.md)
-        
+
     - [String Variables](ch04-01-strings.md)
     - [Tuple Variables](ch04-02-tuples.md)
     - [Array Variables](ch04-03-arrays.md)
@@ -21,16 +22,16 @@
     - [Exporting Variables](ch04-05-exporting.md)
 
 - [Expansions](ch05-00-expansions.md)
-    
+
     - [Variable Expansions](ch05-01-variable.md)
     - [Process Expansions](ch05-02-process.md)
     - [Brace Expansions](ch05-03-brace.md)
     - [Arithmetic Expansions](ch05-04-arithmetic.md)
-    - [Method Expansions](ch05-05-methods.md)
+    - [Method Expansions](ch05-05-method.md)
 
 - [Slicing Syntax](ch06-00-slicing.md)
 
-- [Control Flow](ch07-00-index.md)
+- [Control Flow](ch07-00-flow.md)
 
     - [Conditionals](ch07-01-conditionals.md)
     - [Loops](ch07-02-loops.md)

--- a/manual/src/ch02-00-features.md
+++ b/manual/src/ch02-00-features.md
@@ -70,7 +70,7 @@ open an issue on the project's GitHub.
 
 Small features that don't belong in any specific category.
 
-[Miscellanious Features](miscellanious.html)
+[Miscellanious Features](ch03-00-miscellaneous.html)
 
 
 ## Shell Expansions / Substitutions
@@ -81,11 +81,12 @@ their own variant of process expansions (**@()**) which splits outputs by whites
 arithmetic logic is more feature-complete, supports floating-point math, and handles larger
 numbers; and Ion supports methods in the same manner as the [Oil shell](http://www.oilshell.org/).
 
-- [Variable Expansions](expansions/variable.html)
-- [Process Expansions](expansions/process.html)
-- [Brace Expansions](expansions/brace.html)
-- [Arithmetic Expansions](expansions/arithmetic.html)
-- [Method Expansions](expansions/methods.html)
+[Expansions](ch05-00-expansions.html)
+- [Variable Expansions](ch05-01-variable.html)
+- [Process Expansions](ch05-02-process.html)
+- [Brace Expansions](ch05-03-brace.html)
+- [Arithmetic Expansions](ch05-04-arithmetic.html)
+- [Method Expansions](ch05-05-method.html)
 
 ## Slicing Syntax
 
@@ -95,7 +96,7 @@ expanded value is an index, inclusive range, or exclusive range. This eliminates
 for temporarily storing and/or piping values to other commands, instead performing the slicing at
 parse-time.
 
-[Slicing Syntax](slicing.html)
+[Slicing Syntax](ch06-00-slicing.html)
 
 ## Control Flow
 
@@ -105,6 +106,7 @@ determined by various control flow keywords, such as `if`, `while`, `for`, `brea
 differences, such as that all blocks are ended with the `end` keyword; and the `do`/`then`
 keywords aren't necessary.
 
-[Control Flow](flow/index.html)
-- [Conditionals](flow/conditionals.html)
-- [Loops](flow/loops.html)
+[Control Flow](ch07-00-flow.html)
+- [Conditionals](ch07-01-conditionals.html)
+- [Loops](ch07-02-loops.html)
+- [Matches](ch07-03-matches.html)

--- a/manual/src/ch03-00-miscellaneous.md
+++ b/manual/src/ch03-00-miscellaneous.md
@@ -2,8 +2,9 @@
 
 These are features of Ion that don't belong to any specific category:
 
-- [Implicit `cd`](ch03-01-implicitcd.md)
-- [XDG App Directories](ch03-02-xdg.md)
-- [Quoting Rules](ch03-03-quotation.md)
-- [Multi-line Arguments](ch03-04-multiargs.md)
-- [Multi-line Comments](ch03-05-multicomments.md)
+- [Implicit `cd`](ch03-01-implicitcd.html)
+- [XDG App Directories](ch03-02-xdg.html)
+- [Quoting Rules](ch03-03-quotation.html)
+- [Multi-line Arguments](ch03-04-multiargs.html)
+- [Multi-line Comments](ch03-05-multicomments.html)
+- [General Tips](ch03-06-general.html)

--- a/manual/src/ch03-01-implicitcd.md
+++ b/manual/src/ch03-01-implicitcd.md
@@ -1,6 +1,7 @@
 # Implicit `cd`
 
-Like the [Friendly Interactive Shell](), Ion also supports executing the `cd` command automatically
+Like the [Friendly Interactive Shell](https://fishshell.com/), Ion also supports
+executing the `cd` command automatically
 when given a path. Paths are denoted by beginning with `.`/`/`/`~`, or ending with `/`.
 
 ```ion

--- a/manual/src/ch05-00-expansions.md
+++ b/manual/src/ch05-00-expansions.md
@@ -6,8 +6,8 @@ their own variant of process expansions (**@()**) which splits outputs by whites
 arithmetic logic is more feature-complete, supports floating-point math, and handles larger
 numbers; and Ion supports methods in the same manner as the [Oil shell](http://www.oilshell.org/).
 
-- [Variable Expansions](expansions/variable.html)
-- [Process Expansions](expansions/process.html)
-- [Brace Expansions](expansions/brace.html)
-- [Arithmetic Expansions](expansions/arithmetic.html)
-- [Method Expansions](expansions/methods.html)
+- [Variable Expansions](ch05-01-variable.html)
+- [Process Expansions](ch05-02-process.html)
+- [Brace Expansions](ch05-03-brace.html)
+- [Arithmetic Expansions](ch05-04-arithmetic.html)
+- [Method Expansions](ch05-05-method.html)

--- a/manual/src/ch07-00-flow.md
+++ b/manual/src/ch07-00-flow.md
@@ -6,5 +6,6 @@ determined by various control flow keywords, such as `if`, `while`, `for`, `brea
 differences, such as that all blocks are ended with the `end` keyword; and the `do`/`then`
 keywords aren't necessary.
 
-- [Conditionals](flow/conditionals.html)
-- [Loops](flow/loops.html)
+- [Conditionals](ch07-01-conditionals.html)
+- [Loops](ch07-02-loops.html)
+- [Matches](ch07-03-matches.html)

--- a/manual/src/ch07-00-index.md
+++ b/manual/src/ch07-00-index.md
@@ -1,1 +1,0 @@
-# Control Flow


### PR DESCRIPTION
**Problem**: #499 Changed the documentation's directory structure without adapting the references within the documentation. As a result, most references to other documentation-pages were broken.

**Solution**: I updated all broken references to reflect the new directory structure.

**Changes introduced by this pull request**:

- Fixed broken references to other documentation pages
- Added missing references to documentation pages
- Added missing link to Friendly interactive shell
- Deleted one obsolete file

**Drawbacks**: None that I know of.

**TODOs**: Nothing

**Fixes**: None

**State**: ready to merge

**Blocking/related**: #499 

**Other**: 

------

_The above template is not necessary for smaller PRs._

_It still felt good to fill it out ;-)_
