### PR TITLE
Add "exists" builtin

### DIFF
--- a/examples/exists.ion
+++ b/examples/exists.ion
@@ -69,6 +69,11 @@ echo $?
 exists -f does-not-exist
 echo $?
 
+fn testFunc a
+  echo $a
+end
+exists --fn testFunc
+echo $?
 
 exists -s
 echo $?

--- a/examples/exists.ion
+++ b/examples/exists.ion
@@ -1,0 +1,91 @@
+# Same tests as in src/builtins/exists.rs:test_evaluate_arguments()
+# TODO: find a better way than to write "echo $?" between each test cases
+exists
+echo $?
+exists foo bar
+echo $?
+
+exists --help
+echo $?
+exists --help unused params
+echo $?
+
+
+exists ""
+echo $?
+exists string
+echo $?
+exists "string with spaces"
+echo $?
+exists "-startswithdash"
+echo $?
+
+
+exists -a
+echo $?
+let emptyarray = []
+echo @emptyarray
+exists -a emptyarray
+echo $?
+let array = [ "element" ]
+echo @array
+exists -a array
+echo $?
+exists -a array
+echo $?
+
+
+exists -b
+echo $?
+let OLDPATH = $PATH
+let PATH = testing/
+echo "PATH = $PATH"
+ls -1 $PATH
+exists -b executable_file
+echo $?
+exists -b empty_file
+echo $?
+exists -b file_does_not_exist
+echo $?
+let PATH = $OLDPATH
+echo "Reset PATH to old path"
+
+exists -d
+echo $?
+exists -d testing/
+echo $?
+exists -d testing/empty_file
+echo $?
+exists -d does/not/exist
+echo $?
+
+
+exists -f
+echo $?
+exists -f testing/
+echo $?
+exists -f testing/empty_file
+echo $?
+exists -f does-not-exist
+echo $?
+
+
+exists -s
+echo $?
+let emptyvar = ""
+echo "emptyvar = $emptyvar"
+exists -s emptyvar
+echo $?
+let testvar = "foobar"
+echo "testvar = $testvar"
+exists -s testvar
+echo $?
+drop testvar
+echo "testvar = $testvar"
+exists -s testvar
+echo $?
+
+exists --foo
+echo $?
+exists -x
+echo $?

--- a/examples/exists.out
+++ b/examples/exists.out
@@ -24,6 +24,9 @@ OPTIONS
         path is a file
         This is the same as test -f
 
+    --fn FUNCTION
+        function is defined
+
     -s STRING
         string var is not empty
 
@@ -45,6 +48,9 @@ EXAMPLES
     Test if array exists and is not empty
         exists -a myArr && echo "myArr exists: @myArr" || echo "myArr does not exist or is empty"
         NOTE: Don't use the '@' sigil, but only the name of the array to check
+
+    Test if a function named 'myFunc' exists
+        exists --fn myFunc && myFunc || echo "No function with name myFunc found"
 
 AUTHOR
     Written by Fabian Würfl.
@@ -74,6 +80,9 @@ OPTIONS
         path is a file
         This is the same as test -f
 
+    --fn FUNCTION
+        function is defined
+
     -s STRING
         string var is not empty
 
@@ -95,6 +104,9 @@ EXAMPLES
     Test if array exists and is not empty
         exists -a myArr && echo "myArr exists: @myArr" || echo "myArr does not exist or is empty"
         NOTE: Don't use the '@' sigil, but only the name of the array to check
+
+    Test if a function named 'myFunc' exists
+        exists --fn myFunc && myFunc || echo "No function with name myFunc found"
 
 AUTHOR
     Written by Fabian Würfl.
@@ -128,6 +140,7 @@ Reset PATH to old path
 1
 0
 1
+0
 0
 emptyvar = 
 1

--- a/examples/exists.out
+++ b/examples/exists.out
@@ -1,0 +1,139 @@
+1
+0
+NAME
+    exists - check whether items exist
+
+SYNOPSIS
+    exists [EXPRESSION]
+
+DESCRIPTION
+    Checks whether the given item exists and returns an exit status of 0 if it does, else 1.
+
+OPTIONS
+    -a ARRAY
+        array var is not empty
+
+    -b BINARY
+        binary is in PATH
+
+    -d PATH
+        path is a directory
+        This is the same as test -d
+
+    -f PATH
+        path is a file
+        This is the same as test -f
+
+    -s STRING
+        string var is not empty
+
+    STRING
+        string is not empty
+        This is the same as test -n
+
+EXAMPLES
+    Test if the file exists:
+        exists -f FILE && echo "The FILE exists" || echo "The FILE does not exist"
+
+    Test if some-command exists in the path and is executable:
+        exists -b some-command && echo "some-command exists" || echo "some-command does not exist"
+
+    Test if variable exists AND is not empty
+        exists -s myVar && echo "myVar exists: $myVar" || echo "myVar does not exist or is empty"
+        NOTE: Don't use the '$' sigil, but only the name of the variable to check
+
+    Test if array exists and is not empty
+        exists -a myArr && echo "myArr exists: @myArr" || echo "myArr does not exist or is empty"
+        NOTE: Don't use the '@' sigil, but only the name of the array to check
+
+AUTHOR
+    Written by Fabian Würfl.
+    Heavily based on implementation of the test builtin, which was written by Michael Murph.
+0
+NAME
+    exists - check whether items exist
+
+SYNOPSIS
+    exists [EXPRESSION]
+
+DESCRIPTION
+    Checks whether the given item exists and returns an exit status of 0 if it does, else 1.
+
+OPTIONS
+    -a ARRAY
+        array var is not empty
+
+    -b BINARY
+        binary is in PATH
+
+    -d PATH
+        path is a directory
+        This is the same as test -d
+
+    -f PATH
+        path is a file
+        This is the same as test -f
+
+    -s STRING
+        string var is not empty
+
+    STRING
+        string is not empty
+        This is the same as test -n
+
+EXAMPLES
+    Test if the file exists:
+        exists -f FILE && echo "The FILE exists" || echo "The FILE does not exist"
+
+    Test if some-command exists in the path and is executable:
+        exists -b some-command && echo "some-command exists" || echo "some-command does not exist"
+
+    Test if variable exists AND is not empty
+        exists -s myVar && echo "myVar exists: $myVar" || echo "myVar does not exist or is empty"
+        NOTE: Don't use the '$' sigil, but only the name of the variable to check
+
+    Test if array exists and is not empty
+        exists -a myArr && echo "myArr exists: @myArr" || echo "myArr does not exist or is empty"
+        NOTE: Don't use the '@' sigil, but only the name of the array to check
+
+AUTHOR
+    Written by Fabian Würfl.
+    Heavily based on implementation of the test builtin, which was written by Michael Murph.
+0
+1
+0
+0
+0
+0
+
+1
+element
+0
+0
+0
+PATH = testing/
+empty_file
+executable_file
+file_with_text
+symlink
+0
+1
+1
+Reset PATH to old path
+0
+0
+1
+1
+0
+1
+0
+1
+0
+emptyvar = 
+1
+testvar = foobar
+0
+testvar = 
+1
+0
+0

--- a/examples/glob.out
+++ b/examples/glob.out
@@ -5,7 +5,7 @@ Cargo.toml
 Cargo.lock Cargo.toml
 Cargo.toml
 Cargo.toml
-examples/else_if.ion examples/fail.ion examples/fibonacci.ion examples/fn.ion examples/for.ion examples/function_piping.ion
+examples/else_if.ion examples/exists.ion examples/fail.ion examples/fibonacci.ion examples/fn.ion examples/for.ion examples/function_piping.ion
 one three two
 three two
 three two

--- a/src/builtins/exists.rs
+++ b/src/builtins/exists.rs
@@ -1,0 +1,164 @@
+
+use std::error::Error;
+use std::fs;
+use std::io::{self, BufWriter};
+use smallstring::SmallString;
+
+const MAN_PAGE: &'static str = r#"NAME
+    exists - perform tests on files and text
+
+SYNOPSIS
+    test [EXPRESSION]
+
+DESCRIPTION
+    Tests the expressions given and returns an exit status of 0 if true, else 1.
+
+OPTIONS
+    -a ARRAY
+        array var is not empty
+
+    -b BINARY
+        binary is in PATH
+
+    -d PATH
+        path is a directory
+
+    -f PATH
+        path is a file
+
+    -s STRING
+        string var is not empty
+
+    STRING
+        string is not empty
+
+EXAMPLES
+    Test if the file exists:
+        exists -f FILE && echo "The FILE exists" || echo "The FILE does not exist"
+
+AUTHOR
+    Written by Fabian Würfl.
+    Heavily based on implementation of the test builtin, which was written by Michael Murph.
+"#; /* @MANEND */
+
+pub fn exists(args: &[&str]) -> Result<bool, String> {
+    let stdout = io::stdout();
+    let mut buffer = BufWriter::new(stdout.lock());
+
+    let arguments = &args[1..];
+    evaluate_arguments(arguments, &mut buffer)
+}
+
+fn evaluate_arguments<W: io::Write>(arguments: &[&str], buffer: &mut W) -> Result<bool, String> {
+    match arguments.first() {
+        Some(&"--help") => {
+            buffer.write_all(MAN_PAGE.as_bytes()).map_err(|x| {
+                x.description().to_owned()
+            })?;
+            buffer.flush().map_err(|x| x.description().to_owned())?;
+            Ok(true)
+        }
+        Some(&s) if s.starts_with("-") => {
+            // Access the second character in the flag string: this will be type of the flag.
+            // If no flag was given, return `SUCCESS`
+            s.chars().nth(1).map_or(Ok(true), |flag| {
+                // If no argument was given, return `SUCCESS`
+                arguments.get(1).map_or(Ok(true), {
+                    |arg|
+                    // Match the correct function to the associated flag
+                    Ok(match_flag_argument(flag, arg))
+                })
+            })
+        }
+        Some(arg) => {
+            // If there is no operator, check if the first argument is non-zero
+            arguments.get(1).map_or(
+                Ok(string_is_nonzero(arg)),
+                |operator| {
+                    // TODO: STRING check
+                    Err("exists: Not implemented.".to_owned())
+                },
+            )
+        }
+        None => Ok(false),
+    }
+}
+
+/// Matches flag arguments to their respective functionaity when the `-` character is detected.
+fn match_flag_argument(flag: char, argument: &str) -> bool {
+    match flag {
+        'a' => array_var_is_not_empty(argument),
+        'b' => binary_is_in_path(argument),
+        'd' => path_is_directory(argument),
+        'f' => path_is_file(argument),
+        's' => string_var_is_not_empty(argument),
+        _ => false,
+    }
+}
+
+/// Returns true if the file is a regular file
+fn path_is_file(filepath: &str) -> bool {
+    fs::metadata(filepath).ok().map_or(false, |metadata| {
+        metadata.file_type().is_file()
+    })
+}
+
+/// Returns true if the file is a directory
+fn path_is_directory(filepath: &str) -> bool {
+    fs::metadata(filepath).ok().map_or(false, |metadata| {
+        metadata.file_type().is_dir()
+    })
+}
+
+/// Returns true if the binary is found in path (and is executable)
+fn binary_is_in_path(filepath: &str) -> bool {
+    false
+}
+
+/// Returns true if the string is not empty
+fn string_is_nonzero(string: &str) -> bool { !string.is_empty() }
+
+/// Returns true if the variable is an array and the array is not empty
+fn array_var_is_not_empty(arrayvar: &str) -> bool {
+    false
+}
+
+/// Returns true if the variable is a string and the array is not empty
+fn string_var_is_not_empty(stringvar: &str) -> bool {
+    false
+}
+
+
+#[test]
+fn test_strings() {
+    assert_eq!(string_is_zero("NOT ZERO"), false);
+    assert_eq!(string_is_zero(""), true);
+    assert_eq!(string_is_nonzero("NOT ZERO"), true);
+    assert_eq!(string_is_nonzero(""), false);
+}
+
+#[test]
+fn test_empty_str() {
+    let mut empty = BufWriter::new(io::sink());
+    let mut eval = |args: Vec<&str>| evaluate_arguments(&args, &mut empty);
+    assert_eq!(eval(vec![""]), Ok(false));
+    assert_eq!(eval(vec!["c", "=", ""]), Ok(false));
+}
+
+#[test]
+fn test_file_exists() {
+    assert_eq!(file_exists("testing/empty_file"), true);
+    assert_eq!(file_exists("this-does-not-exist"), false);
+}
+
+#[test]
+fn test_file_is_regular() {
+    assert_eq!(file_is_regular("testing/empty_file"), true);
+    assert_eq!(file_is_regular("testing"), false);
+}
+
+#[test]
+fn test_file_is_directory() {
+    assert_eq!(file_is_directory("testing"), true);
+    assert_eq!(file_is_directory("testing/empty_file"), false);
+}

--- a/src/builtins/exists.rs
+++ b/src/builtins/exists.rs
@@ -3,13 +3,16 @@ use std::error::Error;
 use std::fs;
 use std::io::{self, BufWriter};
 use std::os::unix::fs::{PermissionsExt};
+#[cfg(test)]
 use smallstring::SmallString;
+#[cfg(test)]
 use smallvec::SmallVec;
 
+#[cfg(test)]
 use builtins::Builtin;
+#[cfg(test)]
 use shell::flow_control::{Function, FunctionArgument, Statement};
 use shell::Shell;
-use shell::variables::Variables;
 
 const MAN_PAGE: &'static str = r#"NAME
     exists - check whether items exist

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -418,8 +418,8 @@ fn builtin_or(args: &[&str], shell: &mut Shell) -> i32 {
     }
 }
 
-fn builtin_exists(args: &[&str], _: &mut Shell) -> i32 {
-    match exists(args) {
+fn builtin_exists(args: &[&str], shell: &mut Shell) -> i32 {
+    match exists(args, shell) {
         Ok(true) => SUCCESS,
         Ok(false) => FAILURE,
         Err(why) => {

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -9,6 +9,7 @@ mod test;
 mod time;
 mod echo;
 mod set;
+mod exists;
 
 use self::conditionals::{contains, ends_with, starts_with};
 use self::echo::echo;
@@ -16,6 +17,7 @@ use self::functions::fn_;
 use self::source::source;
 use self::test::test;
 use self::variables::{alias, drop_alias, drop_array, drop_variable};
+use self::exists::exists;
 
 use fnv::FnvHashMap;
 use std::error::Error;
@@ -152,6 +154,7 @@ impl Builtin {
             contains,
             "Evaluates if the supplied argument contains a given string"
         );
+        insert_builtin!("exists", builtin_exists, "Performs tests on files and text");
 
         commands
     }
@@ -412,5 +415,18 @@ fn builtin_or(args: &[&str], shell: &mut Shell) -> i32 {
             shell.previous_status
         }
         _ => shell.previous_status,
+    }
+}
+
+fn builtin_exists(args: &[&str], _: &mut Shell) -> i32 {
+    match exists(args) {
+        Ok(true) => SUCCESS,
+        Ok(false) => FAILURE,
+        Err(why) => {
+            let stderr = io::stderr();
+            let mut stderr = stderr.lock();
+            let _ = writeln!(stderr, "{}", why);
+            FAILURE
+        }
     }
 }

--- a/src/builtins/test.rs
+++ b/src/builtins/test.rs
@@ -304,6 +304,8 @@ fn file_has_write_permission(filepath: &str) -> bool {
 /// Rust currently does not have a higher level abstraction for obtaining non-standard file modes.
 /// To extract the permissions from the mode, the bitwise AND operator will be used and compared
 /// with the respective execute bits.
+/// Note: This function is 1:1 the same as src/builtins/exists.rs:file_has_execute_permission
+/// If you change the following function, please also update the one in src/builtins/exists.rs
 fn file_has_execute_permission(filepath: &str) -> bool {
     const USER: u32 = 0b1000000;
     const GROUP: u32 = 0b1000;


### PR DESCRIPTION
**Problem**: Implement the `exists` builtin mentioned in #409 

**Solution**:
I copied over the `test` builtin implementation, removed the stuff we don't need in `exists` and implemented the necessary new logic.

**Changes introduced by this pull request**:

- Added `exists` builtin
- Implemented the following flags: `-a`, `-b`, `-d`, `-f`, `--fn`, and `-s`
- Implemented the STRING check
- Implemented unit tests for all functions
- Implemented integration tests

**TODOs**:
- Maybe: `binary_is_in_path` should use the same logic as the one that is used to spawn new processes
- `test_binary_is_in_path` could benefit from some more unit tests, however this requires a more complex/enhanced `testing/`-directory structure

**Fixes**: #409 (partly)

**State**: ready

**Blocking/related**: #409

**Other**:

------

_The above template is not necessary for smaller PRs._
