### PR TITLE
WIP: Allow user to prevent commands from being saved in history

### DIFF
--- a/manual/src/SUMMARY.md
+++ b/manual/src/SUMMARY.md
@@ -46,3 +46,5 @@
 - [Builtin Commands](ch11-00-builtins.md)
 
 - [Ion by Example](ch12-00-examples.md)
+
+- [Command History](ch13-00-history.md)

--- a/manual/src/ch13-00-history.md
+++ b/manual/src/ch13-00-history.md
@@ -1,0 +1,103 @@
+# Command history
+
+## General
+- Ions history can be found at **$HOME/.local/share/ion/history**
+- The `history` builtin can be used to display the entire command history
+  - If you're only interested in the last X entries, use `history | tail -n X`
+- The histories\' behavior can be changed via various environment variables (see section
+  **Variables**)
+- Unlike other shells, `ion` saves repeated commands only once:
+```ion
+# echo "Hello, world!"
+Hello, world!
+# true
+# true
+# false
+# history
+echo "Hello, world!"
+true
+false
+```
+
+## Variables
+The following environment variables can be used to modify Ions history behavior:
+
+### HISTORY_SIZE
+Determines how many entries of the history are kept in memory.
+Default value is **1000**.
+Ideally, this value should be the same as `HISTFILE_SIZE`
+
+### HISTORY_IGNORE
+Specifies which commands should **NOT** be saved in the history.
+This is an array and defaults to an **empty array**, meaning that all commands will be saved.
+Each element of the array can take one of the following options:
+- **all** -> All commands are ignored, nothing will be saved in the history
+- **no_such_command** -> Commands which return `NO_SUCH_COMMAND` will not be saved in the history.
+- **whitespace** -> Commands which start with a [whitespace character](https://doc.rust-lang.org/stable/reference/whitespace.html) will not be saved in the
+history.
+- **regex:xxx** -> Where xxx is treated as a [regular expression](https://doc.rust-lang.org/regex/regex/index.html).
+Commands which match this regular expression will not be saved in the history.
+
+**Notes**
+- You can specify as many elements as you want.
+- Any invalid elements will be silently ignored. They will still be present in the array though.
+- You can also specify as many regular expressions as you want (each as a separate element).
+- However, note that any command that matches **at least one** element will be ignored.
+- (Currently, ) there is no way to specify commands which should always be saved.
+- When specifying **regex:**-elements, it is suggested to surround them with single-quotes (`'`)
+- As all variables, `HISTORY_IGNORE` is not saved between sessions. It is suggested to set it via
+ions init file.
+- The `let HISTORY_IGNORE = [ .. ]` command itself is **not effected** except if the assignment
+command starts with a whitespace and the **whitespace** element is specified in this assignment.
+See the following example:
+```ion
+# echo @HISTORY_IGNORE
+
+# let HISTORY_IGNORE = [ all ] # saved
+# let HISTORY_IGNORE = [ whitespace ] # saved
+#  true # ignored
+#  let HISTORY_IGNORE = [  ] # saved
+#  let HISTORY_IGNORE = [ whitespace ] # ignored
+# history
+echo @HISTORY_IGNORE
+let HISTORY_IGNORE = [ all ] # saved
+let HISTORY_IGNORE = [ whitespace ] # saved
+ let HISTORY_IGNORE = [  ] # saved
+```
+
+**Examples**
+```ion
+# let HISTORY_IGNORE = [ no_such_command ]
+# true # saved
+#  true # saved
+# false # saved
+# trulse # ignored
+```
+
+```ion
+# let HISTORY_IGNORE = [ 'regex:.*' ] # behaves like 'all'
+# true # ignored
+#  true # ignored
+# false # ignored
+# trulse # ignored
+```
+
+**Tips**
+
+I like to add `regex:#ignore$` to my `HISTORY_IGNORE`.
+That way, whenever I want to ignore a command on the fly, I just need to add `#ignore` to the
+end of the line.
+
+### HISTFILE_ENABLED
+Specifies whether the history should be read from/written into the file specified by `HISTFILE`.
+A value of **1** means yes, everything else means no. Defaults to **1**.
+
+### HISTFILE
+The file into which the history should be saved. At the launch of ion the history will be read
+from this file and when ion exits, the history of the session will be appended into the file.
+Defaults to **$HOME/.local/share/ion/history**
+
+### HISTFILE_SIZE
+Specifies how many commands should be saved in `HISTFILE` at most.
+Ideally, this should have the same value as `HISTORY_SIZE`.
+Defaults to **1000**.

--- a/src/shell/assignments.rs
+++ b/src/shell/assignments.rs
@@ -1,6 +1,8 @@
 use std::env;
 use std::io::{self, Write};
 
+use smallstring::SmallString;
+use super::history::ShellHistory;
 use super::Shell;
 use super::status::*;
 use parser::expand_string;
@@ -79,6 +81,11 @@ impl<'a> VariableStore for Shell<'a> {
                             };
 
                             if use_original {
+                                // When we changed the HISTORY_IGNORE variable, update the ignore
+                                // patterns. This happens first because `set_array` consumes 'values'
+                                if key.name == "HISTORY_IGNORE" {
+                                    self.update_ignore_patterns(&values);
+                                }
                                 self.variables.set_array(key.name, values);
                             }
                         }

--- a/src/shell/binary.rs
+++ b/src/shell/binary.rs
@@ -276,16 +276,8 @@ impl<'a> Binary for Shell<'a> {
                     if let Ok(command) = self.terminate_quotes(command) {
                         // Parse and potentially execute the command.
                         self.on_command(command.trim());
-
-                        // Mark the command in the context history if it was a success.
-                        if self.previous_status != NO_SUCH_COMMAND || self.flow_control.level > 0 {
-                            self.set_context_history_from_vars();
-                            if let Err(err) = self.context.as_mut().unwrap().history.push(command.into()) {
-                                let stderr = io::stderr();
-                                let mut stderr = stderr.lock();
-                                let _ = writeln!(stderr, "ion: {}", err);
-                            }
-                        }
+                        // save command in history (or maybe not, depending on HISTORY_IGNORE)
+                        self.save_command_in_history(&command);
                     } else {
                         self.flow_control.level = 0;
                         self.flow_control.current_if_mode = 0;

--- a/src/shell/history.rs
+++ b/src/shell/history.rs
@@ -1,6 +1,23 @@
 use super::Shell;
 use super::status::*;
+
+use regex::Regex;
 use std::io::{self, Write};
+use types::Array;
+
+bitflags! {
+    struct IgnoreFlags: u8 {
+        // Macro definition fails if last flag has a comment at the end of the line.
+        /// ignore all commands ("all")
+        const IGNORE_ALL                = (0b1 << 0);
+        /// ignore commands with leading whitespace ("whitespace")
+        const IGNORE_WHITESPACE         = (0x1 << 1);
+        /// ignore commands with status code 127 ("no_such_command")
+        const IGNORE_NO_SUCH_COMMAND    = (0b1 << 2);
+        /// used if regexes are defined.
+        const IGNORE_BASED_ON_REGEX     = (0b1 << 3);
+    }
+}
 
 /// Contains all history-related functionality for the `Shell`.
 pub trait ShellHistory {
@@ -18,6 +35,18 @@ pub trait ShellHistory {
     /// updated correctly after a command is entered that alters them and just before loading the
     /// history file so that it will be loaded correctly.
     fn set_context_history_from_vars(&mut self);
+
+    /// Saves a command in the history, depending on @HISTORY_IGNORE. Should be called
+    /// immediately after `on_command()`
+    fn save_command_in_history(&mut self, command: &str);
+}
+
+trait ShellHistoryPrivate {
+    /// Returns true if the given command with the given exit status should be saved in the history
+    fn should_save_command(&self, command: &str) -> bool;
+
+    /// Parses the @HISTORY_IGNORE environment variable
+    fn parse_history_ignore(&self) -> (IgnoreFlags, Option<Array>);
 }
 
 impl<'a> ShellHistory for Shell<'a> {
@@ -57,5 +86,91 @@ impl<'a> ShellHistory for Shell<'a> {
         } else {
             context.history.set_file_name(None);
         }
+    }
+
+    fn save_command_in_history(&mut self, command: &str) {
+        if self.should_save_command(command) {
+            // Mark the command in the context history
+            self.set_context_history_from_vars();
+            if let Err(err) = self.context.as_mut().unwrap().history.push(command.into()) {
+                let stderr = io::stderr();
+                let mut stderr = stderr.lock();
+                let _ = writeln!(stderr, "ion: {}", err);
+            }
+        }
+    }
+}
+
+impl<'a> ShellHistoryPrivate for Shell<'a> {
+    fn should_save_command(&self, command: &str) -> bool {
+        let (ignore, regexes) = self.parse_history_ignore();
+
+        // without the second check the command which sets the environment variable would also be
+        // ignored. However, this behavior might not be wanted.
+        if ignore.contains(IGNORE_ALL) && !command.contains("HISTORY_IGNORE") {
+            return false;
+        }
+
+        // Here we allow to also ignore the setting of the environment variable because we assume
+        // the user entered the leading whitespace on purpose.
+        if ignore.contains(IGNORE_WHITESPACE) {
+            if let Some(c) = command.chars().next() {
+                if c.is_whitespace() {
+                    return false;
+                }
+            }
+        }
+
+        if ignore.contains(IGNORE_NO_SUCH_COMMAND) && self.previous_status == NO_SUCH_COMMAND {
+            return false;
+        }
+
+        if let Some(regexes) = regexes {
+            for regex in regexes {
+                // NOTE: If a user defines many (large) regexes this might turn into a bottleneck,
+                // as compiling a regex is expensive (see
+                // https://doc.rust-lang.org/regex/regex/index.html#example-avoid-compiling-the-same-regex-in-a-loop)
+                // However, I don't think that we can use lazy_static here, as we don't know the
+                // regexes at compile time.
+                if let Ok(re) = Regex::new(&regex) {
+                    // ignore command when regex is matched but only if it does not contain
+                    // "HISTORY_IGNORE", otherwise we would also ignore the command which
+                    // sets the variable, which could be annoying.
+                    if re.is_match(command) && !command.contains("HISTORY_IGNORE") {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        // default to true, as it's more likely that we want to save a command in history
+        true
+    }
+
+    fn parse_history_ignore(&self) -> (IgnoreFlags, Option<Array>) {
+        if let Some(ignore_values) = self.variables.get_array("HISTORY_IGNORE") {
+            let mut flags = IgnoreFlags::empty();
+            let mut regexes: Array = Array::new();
+            // for convenience and to avoid typos
+            let regex_prefix = "regex:";
+            for elem in ignore_values {
+                match elem.as_ref() {
+                    "all" => flags |= IGNORE_ALL,
+                    "no_such_command" => flags |= IGNORE_NO_SUCH_COMMAND,
+                    "whitespace" => flags |= IGNORE_WHITESPACE,
+                    // The length check is there to just ignore empty regex definitions
+                    _ if elem.starts_with(regex_prefix) && elem.len() > regex_prefix.len() => {
+                        flags |= IGNORE_BASED_ON_REGEX;
+                        let regex = elem[regex_prefix.len()..].to_owned();
+                        regexes.push(regex);
+                    }
+                    _ => continue,
+                }
+            }
+
+            return (flags, Some(regexes));
+        }
+
+        (IgnoreFlags::empty(), None)
     }
 }

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -16,7 +16,7 @@ pub mod variables;
 
 pub use self::binary::Binary;
 pub use self::flow::FlowLogic;
-pub use self::history::ShellHistory;
+pub use self::history::{ShellHistory, IgnoreSetting};
 pub use self::job::{Job, JobKind};
 pub use self::pipe_exec::{foreground, job_control};
 
@@ -77,6 +77,8 @@ pub struct Shell<'a> {
     pub break_flow: bool,
     /// When the `fg` command is run, this will be used to communicate with the specified background process.
     pub foreground_signals: Arc<ForegroundSignals>,
+    /// Stores the patterns used to determine whether a command should be saved in the history or not
+    ignore_setting: IgnoreSetting,
 }
 
 impl<'a> Shell<'a> {
@@ -97,6 +99,7 @@ impl<'a> Shell<'a> {
             is_background_shell: false,
             break_flow: false,
             foreground_signals: Arc::new(ForegroundSignals::new()),
+            ignore_setting: IgnoreSetting::default(),
         }
     }
 


### PR DESCRIPTION
Commands that should NOT be saved in the history can be defined via the
`HISTORY_IGNORE` environment variable (array). Currently, the following
options are supported:
- `"all"`: No commands will be saved until this option is removed again
- `"whitespace"`: ignores commands with a leading whitespace character
- `"no_such_command"`: ignores commands with exit status NO_SUCH_COMMAND
- `"regex:xxx"`: where xxx is a regex (https://doc.rust-lang.org/regex), ignores all commands that match this regex

**Example**:
```
# echo 5
5
# echo 4
4
# echo 3
3
# echo 2
2
# echo 1
1
# history | tail -5
echo 5
echo 4
echo 3
echo 2
echo 1
# let HISTORY_IGNORE = [ "all" ]
# true
# false
# history | tail -5
echo 3
echo 2
echo 1
history | tail -5
let HISTORY_IGNORE = [ "all" ]
# let HISTORY_IGNORE = [ "whitespace" ]
# history | tail -5
echo 2
echo 1
history | tail -5
let HISTORY_IGNORE = [ "all" ]
let HISTORY_IGNORE = [ "whitespace" ]
# true
#  false
# history | tail -5
history | tail -5
let HISTORY_IGNORE = [ "all" ]
let HISTORY_IGNORE = [ "whitespace" ]
history | tail -5
true
# let HISTORY_IGNORE = [ "no_such_command" ]
# history | tail -5
let HISTORY_IGNORE = [ "whitespace" ]
history | tail -5
true
history | tail -5
let HISTORY_IGNORE = [ "no_such_command" ]
# true
#  false
# trulse
ion: command not found: trulse
# history | tail -5
history | tail -5
let HISTORY_IGNORE = [ "no_such_command" ]
history | tail -5
true
 false
# let HISTORY_IGNORE = [ "whitespace" "regex:false" ]
# true
#  true
# false
#  false
# history | tail -5
true
 false
history | tail -5
let HISTORY_IGNORE = [ "whitespace" "regex:false" ]
true
# let HISTORY_IGNORE = [ "whitespace" "regex:\d" ]
# true
# true 1
# false
# false 2
# history | tail -5
true
history | tail -5
let HISTORY_IGNORE = [ "whitespace" "regex:\d" ]
true
false
# let HISTORY_IGNORE = [ "whitespace" "regex:a{2}" ]
# true
# true a
# true aa
# true aaa
# history | tail -5
false
history | tail -5
let HISTORY_IGNORE = [ "whitespace" "regex:a{2}" ]
true
true a
# let HISTORY_IGNORE = [ "whitespace" regex:[1-2] ]
# true a
# true 122
# true 2
# true 3
# history | tail -5
true a
history | tail -5
let HISTORY_IGNORE = [ "whitespace" regex:[1-2] ]
true
true 3
# let HISTORY_IGNORE = [ "whitespace" regex:[[:alpha:]][[:space:]][[:digit:]] ]
# echo abc123
abc123
# echo abc 123
abc 123
# echo 123 abc
123 abc
# echo def  456 # 2 spaces in between
def  456
# history | tail -5
history | tail -5
let HISTORY_IGNORE = [ "whitespace" regex:[[:alpha:]][[:space:]][[:digit:]] ]
echo abc123
echo 123 abc
echo def  456
# let HISTORY_IGNORE = [ "regex:#ignore" ]
# true
# false #ignore
# history | tail -3
history | tail -5
let HISTORY_IGNORE = [ "regex:#ignore" ]
true
```

**Solution**:
I implemented it in a way that is open for future extensions, unlike `bash`' implementation ;)

**TODOs**:
- documentation
- unit & integration tests

**Fixes**:
#503
#502 (partly, see https://github.com/redox-os/ion/issues/503#issuecomment-323079748)

**State**:
**WIP** This might take me some days though, as I'll be quite busy the next days.

**Other**:
Also open to discussion if you think I could implement something differently, etc.
