### PR TITLE
Added a --version flag

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -4,7 +4,7 @@
 
 **Actual behavior**: [describe the actual behavior, which is presented through the repro.].
 
-**Build information**: [output of `rustc -V`, `git rev-parse HEAD`, `qemu-i386 -version`, `uname -a`, etc.]
+**Build information**: [output of `rustc -V`, `git rev-parse HEAD`, `qemu-i386 -version`, `uname -a`, `ion --version`, etc.]
 
 **Blocking/related**: [issues or PRs blocking or being related to this issue.]
 

--- a/build.rs
+++ b/build.rs
@@ -56,7 +56,10 @@ fn main() {
             println!("cargo:warning={}", "Build may fail due to incompatible rustc version.");
         }
     }
-    write_version_file().unwrap();
+    match write_version_file() {
+        Ok(_) => {},
+        Err(e) => panic!("Failed to create a version file: {:?}", e),
+    }
 }
 
 fn write_version_file() -> io::Result<()> {
@@ -74,6 +77,6 @@ fn write_version_file() -> io::Result<()> {
     let target = env::var("TARGET").unwrap();
     let version_fname = Path::new(&env::var("OUT_DIR").unwrap()).join("version_string");
     let mut version_file = File::create(&version_fname)?;
-    write!(&mut version_file, "\"ion {} ({}) rev {}\"", version, target, rev)?;
+    write!(&mut version_file, "r#\"ion {} ({})\nrev {}\"#", version, target, rev.trim())?;
     Ok(())
 }

--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,11 @@ use version_check::is_min_version;
 // `loop` (RFC 1624, rust-lang/rust GitHub issue #37339).
 const MIN_VERSION: &'static str = "1.19.0";
 
+use std::env;
+use std::path::Path;
+use std::fs::File;
+use std::io::{self, Write, Read};
+
 // Convenience macro for writing to stderr.
 macro_rules! printerr {
     ($($arg:tt)*) => ({
@@ -51,4 +56,24 @@ fn main() {
             println!("cargo:warning={}", "Build may fail due to incompatible rustc version.");
         }
     }
+    write_version_file().unwrap();
+}
+
+fn write_version_file() -> io::Result<()> {
+    // get the .git/refs/head/master file and read that for the rev
+    let git_file = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap())
+        .join(".git")
+        .join("refs")
+        .join("heads")
+        .join("master");
+    println!("opening {:?}", git_file);
+    let mut file = File::open(git_file)?;
+    let mut rev = String::new();
+    file.read_to_string(&mut rev)?;
+    let version = env::var("CARGO_PKG_VERSION").unwrap();
+    let target = env::var("TARGET").unwrap();
+    let version_fname = Path::new(&env::var("OUT_DIR").unwrap()).join("version_string");
+    let mut version_file = File::create(&version_fname)?;
+    write!(&mut version_file, "\"ion {} ({}) rev {}\"", version, target, rev)?;
+    Ok(())
 }

--- a/build.rs
+++ b/build.rs
@@ -69,7 +69,6 @@ fn write_version_file() -> io::Result<()> {
         .join("refs")
         .join("heads")
         .join("master");
-    println!("opening {:?}", git_file);
     let mut file = File::open(git_file)?;
     let mut rev = String::new();
     file.read_to_string(&mut rev)?;

--- a/src/shell/binary.rs
+++ b/src/shell/binary.rs
@@ -304,17 +304,6 @@ impl<'a> Binary for Shell<'a> {
     fn main(mut self) {
         let mut args = env::args().skip(1);
         if let Some(path) = args.next() {
-<<<<<<< Updated upstream
-            if path == "-c" {
-                self.execute_arguments(args);
-            } else {
-                let mut array = SmallVec::from_iter(Some(path.clone().into()));
-                for arg in args {
-                    array.push(arg.into());
-                }
-                self.variables.set_array("args", array);
-                self.execute_script(&path);
-=======
             match path.as_str() {
                 "-c" => self.execute_arguments(args),
                 "--version" => self.display_version(),
@@ -326,7 +315,6 @@ impl<'a> Binary for Shell<'a> {
                     self.variables.set_array("args", array);
                     self.execute_script(&path);
                 }
->>>>>>> Stashed changes
             }
 
             self.wait_for_background();

--- a/src/shell/binary.rs
+++ b/src/shell/binary.rs
@@ -15,6 +15,7 @@ use std::io::{self, ErrorKind, Read, Write};
 use std::iter::{self, FromIterator};
 use std::mem;
 use std::path::{Path, PathBuf};
+use std::process;
 use sys;
 use types::*;
 
@@ -36,6 +37,8 @@ pub trait Binary {
     fn readln(&mut self) -> Option<String>;
     /// Generates the prompt that will be used by Liner.
     fn prompt(&self) -> String;
+    /// Display version information and exit
+    fn display_version(&self);
 }
 
 impl<'a> Binary for Shell<'a> {
@@ -301,6 +304,7 @@ impl<'a> Binary for Shell<'a> {
     fn main(mut self) {
         let mut args = env::args().skip(1);
         if let Some(path) = args.next() {
+<<<<<<< Updated upstream
             if path == "-c" {
                 self.execute_arguments(args);
             } else {
@@ -310,6 +314,19 @@ impl<'a> Binary for Shell<'a> {
                 }
                 self.variables.set_array("args", array);
                 self.execute_script(&path);
+=======
+            match path.as_str() {
+                "-c" => self.execute_arguments(args),
+                "--version" => self.display_version(),
+                _ => {
+                    let mut array = SmallVec::from_iter(Some(path.clone().into()));
+                    for arg in args {
+                        array.push(arg.into());
+                    }
+                    self.variables.set_array("args", array);
+                    self.execute_script(&path);
+                }
+>>>>>>> Stashed changes
             }
 
             self.wait_for_background();
@@ -318,6 +335,11 @@ impl<'a> Binary for Shell<'a> {
         } else {
             self.execute_interactive();
         }
+    }
+
+    fn display_version(&self) {
+        println!("{}", include!(concat!(env!("OUT_DIR"), "/version_string")));
+        process::exit(0);
     }
 
     fn execute_script<P: AsRef<Path>>(&mut self, path: P) {


### PR DESCRIPTION
Adds a flag to display the version and git rev.

```
$ ion --version
ion 1.0.5 (x86_64-unknown-linux-gnu)
rev d1d02727024f98b199490122604bc8a7712c2fe4
```

# Issues

`include!(concat!(env!("OUT_DIR"), "/version_string"))` might eventually be an issue if `/` isn't the default path separator though. You can't use `Path::MAIN_SEPARATOR` there.

First this tries to get the revision from `git rev-parse master` and then falls back to trying the `.git/refs/heads/master` file if the command fails. That kinda locks in the build to master branch, but I think that is OK?

(Sorry about the messy commits..)

This would close issue #515 