### PR TITLE
rust-toolchain for latest nightly

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
Should fix AUR builds with Rustup, and clearly marks what we're targeting.

Closes #519.
