### PR TITLE
distinguish between environment and local variables

### DIFF
--- a/manual/src/ch13-00-history.md
+++ b/manual/src/ch13-00-history.md
@@ -4,7 +4,7 @@
 - Ions history can be found at **$HOME/.local/share/ion/history**
 - The `history` builtin can be used to display the entire command history
   - If you're only interested in the last X entries, use `history | tail -n X`
-- The histories\' behavior can be changed via various environment variables (see section
+- The histories\' behavior can be changed via various local variables (see section
   **Variables**)
 - Unlike other shells, `ion` saves repeated commands only once:
 ```ion
@@ -20,7 +20,7 @@ false
 ```
 
 ## Variables
-The following environment variables can be used to modify Ions history behavior:
+The following local variables can be used to modify Ions history behavior:
 
 ### HISTORY_SIZE
 Determines how many entries of the history are kept in memory.

--- a/src/shell/history.rs
+++ b/src/shell/history.rs
@@ -151,13 +151,13 @@ impl<'a> ShellHistoryPrivate for Shell<'a> {
         let ignore = &self.ignore_setting.flags;
         let regexes = &self.ignore_setting.regexes;
 
-        // without the second check the command which sets the environment variable would also be
+        // without the second check the command which sets the local variable would also be
         // ignored. However, this behavior might not be wanted.
         if ignore.contains(IGNORE_ALL) && !command.contains("HISTORY_IGNORE") {
             return false;
         }
 
-        // Here we allow to also ignore the setting of the environment variable because we assume
+        // Here we allow to also ignore the setting of the local variable because we assume
         // the user entered the leading whitespace on purpose.
         if ignore.contains(IGNORE_WHITESPACE) {
             if command.chars().next().map_or(false, |b| b.is_whitespace()) {


### PR DESCRIPTION
In the history sub-module, only the local variables are used to determine things like the history size, whereas the documentation keeps referring to them as environment variables, which might confuse users who might attempt to export `HISTORY_SIZE` from bash for example, only to find out the changes didn't register.