### PR TITLE
WIP: Add multi stream redirection

### DIFF
--- a/src/parser/statement/parse.rs
+++ b/src/parser/statement/parse.rs
@@ -194,7 +194,7 @@ mod tests {
                     ),
                 ],
                 None,
-                None,
+                ::parser::pipelines::RedirectKind::None,
             ),
             success:    vec![],
             else_if:    vec![],


### PR DESCRIPTION
Add enum `RedirectKind` to consider three distinct cases of redirection.

    1. No redirection [RedirectKind::None]
    2. Single redirection [RedirectKind::Single(Redirection)]
    3. Multiple redirections [RedirectKind::Multiple(Vec<Redirection>)]

The intention is to have the Single case work as it always has, and to
use tempfiles of some kind to handle the the multiple output case.

What is still left to do:
* Turning the memory mapped files into all the real files we need and making sure the following cases are handled.
    ```
    cmd args... > newfile >> appendedfile # no output (or error) redirection
    cmd args... >> output &> out-and-err # an output and a both out+err redirection
    ```
* Redox support (there is currently only a stub)
* (Possibly) reorganize it so that all platform specific code is internal to platform specific files

**Fixes**: #545

**State**: WIP

