### PR TITLE
Implement mutiple redirection.

### DIFF
--- a/src/parser/statement/parse.rs
+++ b/src/parser/statement/parse.rs
@@ -171,6 +171,7 @@ pub(crate) fn parse(code: &str) -> Statement {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use self::pipelines::PipeItem;
     use parser::assignments::{KeyBuf, Primitive};
     use shell::{Job, JobKind};
     use shell::flow_control::Statement;
@@ -180,9 +181,9 @@ mod tests {
         // Default case where spaced normally
         let parsed_if = parse("if test 1 -eq 2");
         let correct_parse = Statement::If {
-            expression: Pipeline::new(
-                vec![
-                    Job::new(
+            expression: Pipeline {
+                items: vec![PipeItem {
+                    job: Job::new(
                         vec![
                             "test".to_owned(),
                             "1".to_owned(),
@@ -192,10 +193,10 @@ mod tests {
                             .collect(),
                         JobKind::Last,
                     ),
-                ],
-                None,
-                None,
-            ),
+                    outputs: Vec::new(),
+                    inputs: Vec::new(),
+                }],
+            },
             success:    vec![],
             else_if:    vec![],
             failure:    vec![],

--- a/src/shell/job.rs
+++ b/src/shell/job.rs
@@ -119,6 +119,7 @@ impl TeeItem {
         {
             let mut buf = [0; 4096];
             loop {
+                // TODO: Figure out how to not block on this read
                 let len = source.read(&mut buf)?;
                 if len == 0 { return Ok(()); }
                 for file in sinks.iter_mut() {

--- a/src/shell/job.rs
+++ b/src/shell/job.rs
@@ -1,5 +1,4 @@
 use std::fs::File;
-use std::os::unix::io::{FromRawFd, IntoRawFd};
 use std::process::{Command, Stdio};
 
 // use glob::glob;
@@ -89,9 +88,7 @@ macro_rules! set_field {
     ($self:expr, $field:ident, $arg:expr) => {
         match *$self {
             RefinedJob::External(ref mut command) => {
-                unsafe {
-                    command.$field(Stdio::from_raw_fd($arg.into_raw_fd()));
-                }
+                command.$field(Stdio::from($arg));
             }
             RefinedJob::Builtin { ref mut $field,  .. } | RefinedJob::Function { ref mut $field, .. } => {
                 *$field = Some($arg);

--- a/src/shell/job.rs
+++ b/src/shell/job.rs
@@ -87,7 +87,6 @@ pub(crate) enum RefinedJob {
         sources: Vec<File>,
         stdin: Option<File>,
         stdout: Option<File>,
-        piped: bool
     },
     Tee {
         /// 0 for stdout, 1 for stderr
@@ -192,10 +191,9 @@ impl RefinedJob {
         }
     }
 
-    pub(crate) fn cat(sources: Vec<File>, piped: bool) -> Self {
+    pub(crate) fn cat(sources: Vec<File>) -> Self {
         RefinedJob::Cat {
             sources,
-            piped,
             stdin: None,
             stdout: None,
         }

--- a/src/shell/pipe_exec/fork.rs
+++ b/src/shell/pipe_exec/fork.rs
@@ -8,13 +8,16 @@ use super::pipe;
 use super::super::Shell;
 use super::super::job::{JobKind, RefinedJob};
 use super::super::status::*;
+use ::parser::pipelines::{Input, Redirection};
 use std::process::exit;
+
+type RefinedItem = (RefinedJob, JobKind, Vec<Redirection>, Vec<Input>);
 
 /// Forks the shell, adding the child to the parent's background list, and executing
 /// the given commands in the child fork.
 pub(crate) fn fork_pipe(
     shell: &mut Shell,
-    commands: Vec<(RefinedJob, JobKind)>,
+    commands: Vec<RefinedItem>,
     command_name: String,
 ) -> i32 {
     match unsafe { sys::fork() } {

--- a/src/shell/pipe_exec/fork.rs
+++ b/src/shell/pipe_exec/fork.rs
@@ -8,16 +8,13 @@ use super::pipe;
 use super::super::Shell;
 use super::super::job::{JobKind, RefinedJob};
 use super::super::status::*;
-use ::parser::pipelines::{Input, Redirection};
 use std::process::exit;
-
-type RefinedItem = (RefinedJob, JobKind, Vec<Redirection>, Vec<Input>);
 
 /// Forks the shell, adding the child to the parent's background list, and executing
 /// the given commands in the child fork.
 pub(crate) fn fork_pipe(
     shell: &mut Shell,
-    commands: Vec<RefinedItem>,
+    commands: Vec<(RefinedJob, JobKind)>,
     command_name: String,
 ) -> i32 {
     match unsafe { sys::fork() } {

--- a/src/shell/pipe_exec/mod.rs
+++ b/src/shell/pipe_exec/mod.rs
@@ -922,6 +922,7 @@ pub(crate) fn pipe(
                                             let _ = sys::reset_signal(sys::SIGINT);
                                             let _ = sys::reset_signal(sys::SIGHUP);
                                             let _ = sys::reset_signal(sys::SIGTERM);
+                                            create_process_group(pgid);
                                             let ret = shell.exec_multi_out(
                                                 items,
                                                 stdout,

--- a/src/shell/pipe_exec/mod.rs
+++ b/src/shell/pipe_exec/mod.rs
@@ -150,12 +150,17 @@ fn do_redirection(piped_commands: Vec<RefinedItem>)
                         None
                     }
                 },
-                Input::HereString(ref mut string) => match unsafe { stdin_of(&string) } {
-                    Ok(stdio) => Some(unsafe { File::from_raw_fd(stdio) }),
-                    Err(e) => {
-                        eprintln!("ion: failed to redirect herestring '{}' to stdin: {}",
-                                  string, e);
-                        None
+                Input::HereString(ref mut string) => {
+                    if !string.ends_with('\n') {
+                        string.push('\n');
+                    }
+                    match unsafe { stdin_of(&string) } {
+                        Ok(stdio) => Some(unsafe { File::from_raw_fd(stdio) }),
+                        Err(e) => {
+                            eprintln!("ion: failed to redirect herestring '{}' to stdin: {}",
+                                      string, e);
+                            None
+                        }
                     }
                 }
             }

--- a/src/shell/pipe_exec/mod.rs
+++ b/src/shell/pipe_exec/mod.rs
@@ -380,6 +380,7 @@ pub(crate) trait PipelineExecution {
                      stdout: &Option<File>,
     ) -> i32;
 
+    /// For tee jobs
     fn exec_multi_out(&mut self,
                       items: &mut (Option<TeeItem>, Option<TeeItem>),
                       stdin: &Option<File>,
@@ -690,8 +691,6 @@ impl<'a> PipelineExecution for Shell<'a> {
                       stderr: &Option<File>,
                       kind: JobKind
     ) -> i32 {
-        use ::std::time::Duration;
-        ::std::thread::sleep(Duration::from_secs(30));
         if let Some(ref file) = *stdin {
             redir(file.as_raw_fd(), sys::STDIN_FILENO);
         }


### PR DESCRIPTION
Add multiple redirections, that is, support for things like:

```
cmd <file1 <file2 ^>> err-log > output | cmd2
```
In current ion this doesn't work.

This change at current would be breaking as the statement:
```
tr 'x' 'y' | tr 'y' 'z' < file > file2
```
redirects `file` to the first `tr` command. With this change, we would redirect it to the second.

## Overview
We treat a multiple redirection as it's own job. The only difference between these jobs and normal jobs is that they only read from their source(s) and then write to their sink(s).

### Parsing
Alter `Pipline` contain a vector of `PipeItem`s. A `PipeItem` consists of a `Job`, a `Vec<Redirection>` and a `Vec<Input>`. The above statement would be parsed into two items, `cmd` together with `[file1, file2]` as input and `[err-log, output]` as outputs, and `cmd2` with no `Input`s or `Redirection`s

### Command Generation and Redirection Setup
Added two two new variants of `RefinedJob`, `Cat` and `Tee`, `Cat` for concatenating multiple inputs, `Tee` for splitting multiple outputs. Alter the `generate_commands` function to return a `Vec<(RefinedJob, JobKind, Vec<Redirection>, Vec<Input>)>`, then condense `redirect_input` and `redirect_output` into one function that takes ownership and returns a new `Vec<(RefinedJob, JobKind)>`. It is here that we create the `Tee` and `Cat` jobs that we need and put them in the right spot in the pipeline.

### Execution
Add `exec_multi_in` and `exec_multi_out` to handle the multiple redirections. These are fairly straightforward, they just read their sources and write to their sinks. I didn't add any extra paths to `exec_job` as the new `RefinedJob` kinds are always part of a pipeline.