### PR TITLE
Make IonError derive debug

### DIFF
--- a/src/shell/library.rs
+++ b/src/shell/library.rs
@@ -6,6 +6,7 @@ use std::fs::File;
 use std::io::{self, Read};
 use std::path::Path;
 
+#[derive(Debug)]
 pub enum IonError {
     Fork(io::Error),
 }


### PR DESCRIPTION
Required to unwrap().