### PR TITLE
Escape unescape

### DIFF
--- a/examples/methods.ion
+++ b/examples/methods.ion
@@ -42,3 +42,6 @@ let a = "1 2 3 4 5"
 echo $join(@split(a, " "), $join(a, " "))
 
 echo $regex_replace("one two onemy anemy town", "\ o|\ a" "\ e")
+
+echo $unescape('one two\"\tone')
+echo $escape("'one two'")

--- a/examples/methods.out
+++ b/examples/methods.out
@@ -67,3 +67,5 @@ apple
 sauce
 11 2 3 4 521 2 3 4 531 2 3 4 541 2 3 4 55
 one two enemy enemy town
+one two"	one
+\'one two\'

--- a/src/parser/shell_expand/words/methods/strings.rs
+++ b/src/parser/shell_expand/words/methods/strings.rs
@@ -257,14 +257,13 @@ impl<'a> StringMethod<'a> {
             },
             "escape" => {
                 let word = if let Some(value) = expand.variable(variable, false) {
-                    Some(value)
+                    value
                 } else if is_expression(variable) {
-                    Some(expand_string(variable, expand, false).join(" "))
+                    expand_string(variable, expand, false).join(" ")
                 } else {
-                    None
+                    return;
                 };
                 let out: Vec<String> = word
-                    .unwrap_or(String::from(""))
                     .chars()
                     .map(|c| c.escape_default().to_string())
                     .collect();

--- a/src/parser/shell_expand/words/methods/strings.rs
+++ b/src/parser/shell_expand/words/methods/strings.rs
@@ -184,6 +184,80 @@ impl<'a> StringMethod<'a> {
                 };
                 output.push_str(&out.unwrap_or(0).to_string());
             },
+            "unescape" => {
+                let word = if let Some(value) = expand.variable(variable, false) {
+                    Some(value)
+                } else if is_expression(variable) {
+                    Some(expand_string(variable, expand, false).join(" "))
+                } else {
+                    None
+                };
+                let mut out = String::from("");
+                let mut check = false;
+                let input = word
+                    .unwrap_or(String::from(""))
+                    .to_string();
+                for c in input.chars() {
+                    match c {
+                        '\\' if check => {
+                            out.push(c);
+                            check = false;
+                        }
+                        '\\' => check = true,
+                        '\'' if check => {
+                            out.push(c);
+                            check = false;
+                        }
+                        '\"' if check => {
+                            out.push(c);
+                            check = false;
+                        }
+                        'a' if check => {
+                            out.push('\u{0007}');
+                            check = false;
+                        }
+                        'b' if check => {
+                            out.push('\u{0008}');
+                            check = false;
+                        }
+                        'c' if check => {
+                            out = String::from("");
+                            break;
+                        }
+                        'e' if check => {
+                            out.push('\u{001B}');
+                            check = false;
+                        }
+                        'f' if check => {
+                            out.push('\u{000C}');
+                            check = false;
+                        }
+                        'n' if check => {
+                            out.push('\n');
+                            check = false;
+                        }
+                        'r' if check => {
+                            out.push('\r');
+                            check = false;
+                        }
+                        't' if check => {
+                            out.push('\t');
+                            check = false;
+                        }
+                        'v' if check => {
+                            out.push('\u{000B}');
+                            check = false;
+                        }
+                        _ if check => {
+                            out.push('\\');
+                            out.push(c);
+                            check = false;
+                        }
+                        _ => { out.push(c); }
+                    }
+                }
+                output.push_str(&out);
+            },
             "escape" => {
                 let word = if let Some(value) = expand.variable(variable, false) {
                     Some(value)

--- a/src/parser/shell_expand/words/methods/strings.rs
+++ b/src/parser/shell_expand/words/methods/strings.rs
@@ -183,7 +183,22 @@ impl<'a> StringMethod<'a> {
                     None
                 };
                 output.push_str(&out.unwrap_or(0).to_string());
-            }
+            },
+            "escape" => {
+                let word = if let Some(value) = expand.variable(variable, false) {
+                    Some(value)
+                } else if is_expression(variable) {
+                    Some(expand_string(variable, expand, false).join(" "))
+                } else {
+                    None
+                };
+                let out: Vec<String> = word
+                    .unwrap_or(String::from(""))
+                    .chars()
+                    .map(|c| c.escape_default().to_string())
+                    .collect();
+                output.push_str(&out.join(""));
+            },
             method @ _ => {
                 if sys::is_root() {
                     eprintln!("ion: root is not allowed to execute plugins");

--- a/src/parser/shell_expand/words/methods/strings.rs
+++ b/src/parser/shell_expand/words/methods/strings.rs
@@ -185,78 +185,75 @@ impl<'a> StringMethod<'a> {
                 output.push_str(&out.unwrap_or(0).to_string());
             },
             "unescape" => {
-                let word = if let Some(value) = expand.variable(variable, false) {
-                    Some(value)
-                } else if is_expression(variable) {
-                    Some(expand_string(variable, expand, false).join(" "))
-                } else {
-                    None
-                };
-                let mut out = String::from("");
-                let mut check = false;
-                let input = word
-                    .unwrap_or(String::from(""))
-                    .to_string();
-                for c in input.chars() {
-                    match c {
-                        '\\' if check => {
-                            out.push(c);
-                            check = false;
+                fn unescape(input: String) -> String {
+                    let mut check = false;
+                    let mut out = String::with_capacity(input.len());
+                    for c in input.chars() {
+                        match c {
+                            '\\' if check => {
+                                out.push(c);
+                                check = false;
+                            }
+                            '\\' => check = true,
+                            '\'' if check => {
+                                out.push(c);
+                                check = false;
+                            }
+                            '\"' if check => {
+                                out.push(c);
+                                check = false;
+                            }
+                            'a' if check => {
+                                out.push('\u{0007}');
+                                check = false;
+                            }
+                            'b' if check => {
+                                out.push('\u{0008}');
+                                check = false;
+                            }
+                            'c' if check => {
+                                out = String::from("");
+                                break;
+                            }
+                            'e' if check => {
+                                out.push('\u{001B}');
+                                check = false;
+                            }
+                            'f' if check => {
+                                out.push('\u{000C}');
+                                check = false;
+                            }
+                            'n' if check => {
+                                out.push('\n');
+                                check = false;
+                            }
+                            'r' if check => {
+                                out.push('\r');
+                                check = false;
+                            }
+                            't' if check => {
+                                out.push('\t');
+                                check = false;
+                            }
+                            'v' if check => {
+                                out.push('\u{000B}');
+                                check = false;
+                            }
+                            _ if check => {
+                                out.push('\\');
+                                out.push(c);
+                                check = false;
+                            }
+                            _ => { out.push(c); }
                         }
-                        '\\' => check = true,
-                        '\'' if check => {
-                            out.push(c);
-                            check = false;
-                        }
-                        '\"' if check => {
-                            out.push(c);
-                            check = false;
-                        }
-                        'a' if check => {
-                            out.push('\u{0007}');
-                            check = false;
-                        }
-                        'b' if check => {
-                            out.push('\u{0008}');
-                            check = false;
-                        }
-                        'c' if check => {
-                            out = String::from("");
-                            break;
-                        }
-                        'e' if check => {
-                            out.push('\u{001B}');
-                            check = false;
-                        }
-                        'f' if check => {
-                            out.push('\u{000C}');
-                            check = false;
-                        }
-                        'n' if check => {
-                            out.push('\n');
-                            check = false;
-                        }
-                        'r' if check => {
-                            out.push('\r');
-                            check = false;
-                        }
-                        't' if check => {
-                            out.push('\t');
-                            check = false;
-                        }
-                        'v' if check => {
-                            out.push('\u{000B}');
-                            check = false;
-                        }
-                        _ if check => {
-                            out.push('\\');
-                            out.push(c);
-                            check = false;
-                        }
-                        _ => { out.push(c); }
                     }
+                    out
                 }
-                output.push_str(&out);
+                if let Some(value) = expand.variable(variable, false) {
+                    output.push_str(&unescape(value));
+                } else if is_expression(variable) {
+                    output.push_str(&unescape(expand_string(variable, expand, false).join(" ")));
+                };
             },
             "escape" => {
                 let word = if let Some(value) = expand.variable(variable, false) {


### PR DESCRIPTION
I removed some things from the template that looked like would contain duplicated answers or no answer at all.

**Problem**: Need a way to unescape strings, similar to $"\n".

**Solution**: I created two new methods, escape and unescape.

**Drawbacks**:
- The logic about how to unescape is repeated in the method and in the builtin echo. I wonder if it's possible to dedup that.
- No tests. I didn't know how to write them

**TODOs**: [what is not done yet.]

**Fixes**: #556

**State**: Ready. I guess. More like: Waiting for feedback :).