### PR TITLE
Perform builtin lookup when parsing

### DIFF
--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -40,6 +40,8 @@ const SOURCE_DESC: &str = "Evaluate the file following the command or re-initial
 const DISOWN_DESC: &str =
     "Disowning a process removes that process from the shell's background process table.";
 
+pub type BuiltinFunction = fn(&[&str], &mut Shell) -> i32;
+
 macro_rules! map {
     ($($name:expr => $func:ident: $help:expr),+) => {{
         BuiltinMap {
@@ -96,13 +98,13 @@ pub const BUILTINS: &'static BuiltinMap = &map!(
 pub struct Builtin {
     pub name: &'static str,
     pub help: &'static str,
-    pub main: fn(&[&str], &mut Shell) -> i32,
+    pub main: BuiltinFunction,
 }
 
 pub struct BuiltinMap {
     pub(crate) name:      &'static [&'static str],
     pub(crate) help:      &'static [&'static str],
-    pub(crate) functions: &'static [fn(&[&str], &mut Shell) -> i32],
+    pub(crate) functions: &'static [BuiltinFunction],
 }
 
 impl BuiltinMap {

--- a/src/shell/job.rs
+++ b/src/shell/job.rs
@@ -60,7 +60,7 @@ impl PartialEq for Job {
 
 impl fmt::Debug for Job {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Jon {{ command: {}, args: {:?}, kind: {:?} }}", self.command, self.args, self.kind)
+        write!(f, "Job {{ command: {}, args: {:?}, kind: {:?} }}", self.command, self.args, self.kind)
     }
 }
 

--- a/src/shell/job.rs
+++ b/src/shell/job.rs
@@ -1,7 +1,9 @@
 use super::Shell;
+use builtins::{BuiltinFunction, BUILTINS};
 use parser::expand_string;
 use parser::pipelines::RedirectFrom;
 use smallstring::SmallString;
+use std::fmt;
 use std::fs::File;
 use std::process::{Command, Stdio};
 use std::str;
@@ -16,20 +18,23 @@ pub(crate) enum JobKind {
     Pipe(RedirectFrom),
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone)]
 pub(crate) struct Job {
     pub command: Identifier,
     pub args:    Array,
     pub kind:    JobKind,
+    pub builtin:    Option<BuiltinFunction>,
 }
 
 impl Job {
     pub(crate) fn new(args: Array, kind: JobKind) -> Self {
         let command = SmallString::from_str(&args[0]);
+        let builtin = BUILTINS.get(command.as_ref()).map(|b| b.main);
         Job {
             command,
             args,
             kind,
+            builtin,
         }
     }
 
@@ -42,6 +47,20 @@ impl Job {
             self.args.drain().flat_map(|arg| expand_arg(&arg, shell)).filter(|x| !x.is_empty()),
         );
         self.args = expanded;
+    }
+}
+
+impl PartialEq for Job {
+    fn eq(&self, other: &Job) -> bool {
+        self.command == other.command &&
+        self.args == other.args &&
+        self.kind == other.kind
+    }
+}
+
+impl fmt::Debug for Job {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Jon {{ command: {}, args: {:?}, kind: {:?} }}", self.command, self.args, self.kind)
     }
 }
 

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -233,7 +233,6 @@ impl<'a> Shell {
     /// if an alias branch was executed.
     fn run_pipeline(&mut self, pipeline: &mut Pipeline) -> Option<i32> {
         let command_start_time = SystemTime::now();
-        let builtins = self.builtins;
 
         // Expand any aliases found
         for job_no in 0..pipeline.items.len() {
@@ -251,10 +250,7 @@ impl<'a> Shell {
         }
 
         // Branch if -> input == shell command i.e. echo
-        let exit_status = if let Some(command) = {
-            let key: &str = pipeline.items[0].job.command.as_ref();
-            builtins.get(key)
-        } {
+        let exit_status = if let Some(main) = pipeline.items[0].job.builtin {
             pipeline.expand(self);
             // Run the 'main' of the command and set exit_status
             if !pipeline.requires_piping() {
@@ -266,7 +262,7 @@ impl<'a> Shell {
                 if self.flags & NO_EXEC != 0 {
                     Some(SUCCESS)
                 } else {
-                    Some((command.main)(&small, self))
+                    Some(main(&small, self))
                 }
             } else {
                 Some(self.execute_pipeline(pipeline))


### PR DESCRIPTION
I wasn't able to find how to run the benchmarks, if you give me instructions, I'll be happy to include them in the pr.

**Problem**: Perform lookup of builtin when parsing and not when executing, to improve for loops.

**Solution**: Perform the same logic to detect if a command is a builtin or not when creating a job and store in the struct an option for the pointer of the function of the builtin. On execution, check if that option is set to something instead of looking for the builtin.

**Changes introduced by this pull request**:

- Add a type alias for the builtin function, `BuiltinFunction`.
- Add a new member to the job struct of type `Option<BuiltinFunction>` and name `builtin`.
- Make custom Implementations of the traits `PartialEq` and `Debug` for the job struct, since function pointer don't have one.
- On job creation, determine if the command is a builtin and set the `builtin` value accordingly.
- On job execution, use that struct member to determine whether a job is a builtin or not.

**TODOs**: Is there any other `fn(&[&str], &mut Shell) -> i32` that we can change to `BuiltinFunction`?

**Fixes**: Expensive lookups on for loops.

**State**: Ready for review.

**Blocking/related**: #569 