### PR TITLE
Make ./examples/run_examples.sh fail loudly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ rand = "0.3"
 git = "https://github.com/redox-os/app-dirs-rs.git"
 
 [profile.release]
+debug = true
 lto = true
 panic = "abort"
 

--- a/examples/run_examples.sh
+++ b/examples/run_examples.sh
@@ -51,6 +51,7 @@ function check_return_value {
 # Build debug binary
 cargo build
 
+set +e
 # Iterate over every Ion script in examples directory
 for i in $EXAMPLES_DIR/*.ion; do
     check_return_value $i;

--- a/examples/run_examples.sh
+++ b/examples/run_examples.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e -u -o pipefail
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color


### PR DESCRIPTION
If you do:

```
./examples/run_examples.sh
rm src/types.rs
./examples/run_examples.sh
```

The second run will succeed even though the compilation failed. Fix this
by making the script fail if one of the steps fail.