### PR TITLE
Less heap

### DIFF
--- a/src/parser/shell_expand/mod.rs
+++ b/src/parser/shell_expand/mod.rs
@@ -67,7 +67,15 @@ fn expand_process<E: Expander>(
                         _ => (),
                     }
                 });
-            slice(current, result.trim_right(), selection)
+            if previous_char_was_whitespace {
+                loop {
+                    result.pop();
+                    if !result.ends_with(' ') {
+                        break;
+                    }
+                }
+            }
+            slice(current, &result, selection)
         }
     }
 }


### PR DESCRIPTION
**Problem**: expand_process have more allocations than necessary.

**Solution**: Mutate the output in place instead of splitting and then joining.

**Changes introduced by this pull request**:

- Added a test for unquoted strings for the expand_process function.

**Drawbacks**: It uses `unsafe`. It's possible to do something "similar" (although not that conservative) without going `unsafe`. In fact that was my first iteration and that solution is in the first and second commit. If you prefer that one instead of the `unsafe` alternative, let me know and I'll revert the last commit.

**TODOs**: Add test for quoted strings! (although out of the scope of this pr).

**Fixes**: #563

**State**: Ready