### PR TITLE
Clean up some technical debt and add tests

### DIFF
--- a/src/parser/shell_expand/mod.rs
+++ b/src/parser/shell_expand/mod.rs
@@ -588,6 +588,14 @@ mod test {
     }
 
     #[test]
+    fn expand_process_quoted() {
+        let mut output = String::new();
+        let line = " Mary   had\ta little  \n\t lamb\t";
+        expand_process(&mut output, line, Select::All, &CommandExpander, true);
+        assert_eq!(output, line);
+    }
+
+    #[test]
     fn expand_process_unquoted() {
         let mut output = String::new();
         let line = " Mary   had\ta little  \n\t lamb\t";


### PR DESCRIPTION
I decided to clean up some technical debt that I added in the previous commits and also add bunch of tests. 

I introduced tests for the `expand_process` function in the case of a quoted expression and tests for all the string methods. The later ones have a hidden reason: I used to make sure I understand those methods in order to write documentation about them for The Book. Because I'll use them as a reference, I'd appreciate feedback if on whether I got any wrong use case or if I'm missing one.

Also, while writing the tests, I found and fixed a bug:

```
$ echo $find("FOOBAR", "F")
0
$ echo $find("FOOBAR", "P")
0
```

To fix this, I just changed the value returned in case of `None` for a -1. Let me know if that's not what you'd expect.