### PR TITLE
Update the disown command

### DIFF
--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -357,7 +357,15 @@ fn builtin_suspend(_: &[&str], _: &mut Shell) -> i32 {
 }
 
 fn builtin_disown(args: &[&str], shell: &mut Shell) -> i32 {
-    job_control::disown(shell, &args[1..])
+    match job_control::disown(shell, &args[1..]) {
+        Ok(()) => SUCCESS,
+        Err(err) => {
+            let stderr = io::stderr();
+            let mut stderr = stderr.lock();
+            let _ = writeln!(stderr, "ion: disown: {}", err);
+            FAILURE
+        }
+    }
 }
 
 fn builtin_help(args: &[&str], shell: &mut Shell) -> i32 {


### PR DESCRIPTION
**Problem**:

 - disown panics if
   - No arguments are provided to the command
   - No jobspec's are provided to the -r or -h options
 - disown does not have a help option

**Solution**:

Add a few extra checks in the implementation of `disown` and add
`disown::print_help`.

**Other:**

I hit this a few times as I was learning how to use disown.
