### PR TITLE
Fixes "nighlty" typo.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -22,7 +22,7 @@ fn main() {
             eprintln!(
                 "{} {}",
                 Red.bold().paint("Error:"),
-                White.paint("Ion requires nighlty to build.")
+                White.paint("Ion requires nightly to build.")
             );
             // print_version_err(&*version_string);
             eprintln!(


### PR DESCRIPTION
**Problem**: The word Nightly is misspelled

**Solution**: This fixes the spelling

**Changes introduced by this pull request**:

- s/nighlty/nightly/

**Drawbacks**: None