### PR TITLE
Allow builtins in aliases

### DIFF
--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -240,7 +240,11 @@ impl<'a> Shell {
                         .map(String::from)
                         .chain(pipeline.items[job_no].job.args.drain().skip(1))
                         .collect::<Array>();
-                    pipeline.items[job_no].job.command = new_args[0].clone().into();
+                    if let Some(builtin) = BUILTINS.get(&new_args[0]) {
+                        pipeline.items[job_no].job.builtin = Some(builtin.main);
+                    } else {
+                        pipeline.items[job_no].job.command = new_args[0].clone().into();
+                    }
                     pipeline.items[job_no].job.args = new_args;
                 }
             }


### PR DESCRIPTION
During a pipeline execution, aliases are expanded and split into an
Array. The first item in this array should be either a builtin or a
command. If it is a builtin, assign the Job.builtin fn pointer field.
Otherwise, assume the alias refers to a command. Fixes #622

