### PR TITLE
Make newlines in prompt display correctly

### DIFF
--- a/src/shell/binary/readln.rs
+++ b/src/shell/binary/readln.rs
@@ -170,19 +170,19 @@ fn complete_as_file(current_dir: PathBuf, filename: String, index: usize) -> boo
 /// prints prompt info lines and
 /// returns the last prompt line.
 fn handle_prompt(full_prompt: String) -> Result<String, String> {
-    if !full_prompt.contains("\n") {
+    
+    if let Some(index) = full_prompt.rfind('\n') {
+        let (info, prompt) = full_prompt.split_at(index+1);
+
+        let stdout = io::stdout();
+        let mut handle = stdout.lock();
+        if let Err(why) =
+            handle.write(info.as_bytes()) {
+            return Err(format!("unable to print prompt info: {}", why));
+        }
+
+        return Ok(String::from(prompt))
+    } else {
         return Ok(full_prompt)
-    }
-
-    let stdout = io::stdout();
-    let mut handle = stdout.lock();
-    if let Err(why) =
-        handle.write(full_prompt.as_bytes()) {
-        return Err(format!("unable to print prompt info: {}", why));
-    }
-
-    match full_prompt.lines().last() {
-        Some(prompt) => Ok(String::from(prompt)),
-        None => Err(format!("unable to get prompt"))
     }
 }

--- a/src/shell/binary/readln.rs
+++ b/src/shell/binary/readln.rs
@@ -22,7 +22,7 @@ pub(crate) fn readln(shell: &mut Shell) -> Option<String> {
                 .collect::<Vec<SmallString>>();
 
         loop {
-            let prompt = shell.prompt();
+            let prompt = handle_prompt(shell.prompt()).unwrap();
             let funcs = &shell.functions;
             let vars = &shell.variables;
             let builtins = &shell.builtins;
@@ -165,4 +165,25 @@ fn complete_as_file(current_dir: PathBuf, filename: String, index: usize) -> boo
     }
     // By default assume its not a file
     false
+}
+
+/// takes the input shell,
+/// prints prompt info lines, and
+/// returns the last prompt line.
+fn handle_prompt(full_prompt: String) -> Result<String, String> {
+    if !full_prompt.contains("\n") {
+        return Ok(full_prompt)
+    }
+
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+    if let Err(why) =
+        handle.write(full_prompt.as_bytes()) {
+        return Err(format!("unable to print prompt info: {}", why));
+    }
+
+    match full_prompt.lines().last() {
+        Some(prompt) => Ok(String::from(prompt)),
+        None => Err(format!("unable to get prompt"))
+    }
 }

--- a/src/shell/binary/readln.rs
+++ b/src/shell/binary/readln.rs
@@ -167,8 +167,7 @@ fn complete_as_file(current_dir: PathBuf, filename: String, index: usize) -> boo
     false
 }
 
-/// takes the input shell,
-/// prints prompt info lines, and
+/// prints prompt info lines and
 /// returns the last prompt line.
 fn handle_prompt(full_prompt: String) -> Result<String, String> {
     if !full_prompt.contains("\n") {


### PR DESCRIPTION
**Problem**: 

Prompts containing newlines were not printing properly. The last line would print at the column of the line above it, and any lines before the last would be repeated with every keystroke.

liner runs the function for the prompt every keystroke and erases only the last line from the prompt function it's given. This leads to many trailing prompts and odd behavior in the formatting.

**Solution**: 
My solution was to remove the top lines from the prompt and present them as `prompt_info`, semantically. Then liner can print the last line of the prompt as much as it wants to.

If the prompt contains a newline the lines are printed to stdout, and the last line is supplied to the `liner` library as a prompt.

**Drawbacks**:

I'm new to the project and not sure if I handled the stdout correctly - I could use some guidance there, maybe.

I know we're all speed freaks, but I couldn't help but do a String allocation. It's only once per command, though.

**Fixes**: 

I couldn't find an issue for this. It's my first go at coding on this project, so this is just getting my feet wet.

** Other **

Let me know what else I can do. I'm still reading through the source code.