### PR TITLE
Add the exec builtin

### DIFF
--- a/src/builtins/exec.rs
+++ b/src/builtins/exec.rs
@@ -1,0 +1,38 @@
+use builtins::man_pages::{check_help, MAN_EXEC};
+use shell::Shell;
+use std::error::Error;
+use sys::execve;
+
+/// Executes the givent commmand.
+pub(crate) fn exec(shell: &mut Shell, args: &[&str]) -> Result<(), String> {
+    const CLEAR_ENV: u8 = 1;
+
+    let mut flags = 0u8;
+    let mut idx = 0;
+    for &arg in args.iter() {
+        match arg {
+            "-c" => flags |= CLEAR_ENV,
+            _ if check_help(args, MAN_EXEC) => {
+                return Ok(());
+            }
+            _ => break,
+        }
+        idx += 1;
+    }
+
+    match args.get(idx) {
+        Some(argument) => {
+            let args = if args.len() > idx + 1 {
+                &args[idx + 1..]
+            } else {
+                &[]
+            };
+            shell.prep_for_exit();
+            match execve(argument, args, (flags & CLEAR_ENV) == 1) {
+                Ok(_) => Ok(()),
+                Err(err) => Err(err.description().to_owned()),
+            }
+        }
+        None => Err("no command provided".to_owned()),
+    }
+}

--- a/src/builtins/man_pages.rs
+++ b/src/builtins/man_pages.rs
@@ -197,6 +197,22 @@ DESCRIPTION
     all arguments are joined using a space as a separator.
 "#;
 
+pub(crate) const MAN_EXEC: &'static str = r#"NAME
+    exec - Replace the shell with the given command.
+
+SYNOPSIS
+    exec [-ch] [--help] [command [arguments ...]]
+
+DESCRIPTION
+    Execute <command>, replacing the shell with the specified program.
+    The <arguments> following the command become the arguments to
+    <command>.
+
+OPTIONS
+    -c  Execute command with an empty environment.
+"#;
+
+
 pub(crate) const MAN_HISTORY: &'static str = r#"NAME
     history - print command history
 

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -164,7 +164,7 @@ impl<'a> Shell {
         }
     }
 
-    pub(crate) fn exit(&mut self, status: i32) -> ! {
+    pub(crate) fn prep_for_exit(&mut self) {
         // The context has two purposes: if it exists, this is an interactive shell; and the
         // context will also be sent a signal to commit all changes to the history file,
         // and waiting for the history thread in the background to finish.
@@ -174,9 +174,12 @@ impl<'a> Shell {
                 self.background_send(sys::SIGHUP);
             }
             let context = self.context.as_mut().unwrap();
-            context.history.commit_history()
+            context.history.commit_history();
         }
+    }
 
+    pub(crate) fn exit(&mut self, status: i32) -> ! {
+        self.prep_for_exit();
         process::exit(status);
     }
 


### PR DESCRIPTION
**Problem**:
The `exec` builtin does not exist

**Solution**:
Implement the `exec` builtin as a simple wrapper around the`execve` syscall.

**Changes introduced by this pull request**:

 - Add the necessary functions to builtin
 - Add the necessary interfaces for the execve syscall
   - Add sys::unix::execve
   - Add sys::redox::execve

**TODOs**:

 - [x] `exec` hits an assertion [here](https://github.com/redox-os/kernel/blob/master/src/arch/x86_64/paging/mapper.rs#L105-L109) when run from the original shell on redox. For example:

```
# Works
echo -e "#!/usr/bin/ion\nexec ion" > ./test.ion
ion ./test.ion
# Hits assertion
exec ion
```
**Resolution**: This occurred due to the context history not being prepped for exit.

**Fixes**:
 - #608 
