### PR TITLE
Update test builtin option parsing

### DIFF
--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -357,9 +357,8 @@ fn builtin_echo(args: &[&str], _: &mut Shell) -> i32 {
 }
 
 fn builtin_test(args: &[&str], _: &mut Shell) -> i32 {
-    if check_help(args, MAN_TEST) {
-        return SUCCESS;
-    }
+    // Do not use `check_help` for the `test` builtin. The
+    // `test` builtin contains a "-h" option.
     match test(args) {
         Ok(true) => SUCCESS,
         Ok(false) => FAILURE,

--- a/src/builtins/test.rs
+++ b/src/builtins/test.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 use std::path::Path;
 use std::time::SystemTime;
+use super::man_pages::{print_man, MAN_TEST};
 
 pub(crate) fn test(args: &[&str]) -> Result<bool, String> {
     let arguments = &args[1..];
@@ -22,6 +23,12 @@ fn evaluate_arguments(arguments: &[&str]) -> Result<bool, String> {
                     Ok(match_flag_argument(flag, arg))
                 })
             })
+        }
+        Some(&s) if s == "--help" => {
+            // "--help" only makes sense if it is the first option. Only look for it
+            // in the first position.
+            print_man(MAN_TEST);
+            Ok(true)
         }
         Some(arg) => {
             // If there is no operator, check if the first argument is non-zero


### PR DESCRIPTION
Do not use `check_help` for parsing the help options for the `test`
builtin. The `test` builtin uses the `-h` option to check if the argument
provided is the path to a symbolic link.

Fixes: #653 