### PR TITLE
Make test variable naming consistent. Use @ for arrays

### DIFF
--- a/src/parser/shell_expand/words/methods/arrays.rs
+++ b/src/parser/shell_expand/words/methods/arrays.rs
@@ -225,7 +225,7 @@ mod test {
 
         fn array(&self, variable: &str, _: Select) -> Option<Array> {
             match variable {
-                "$ARRAY" => Some(array!["a", "b", "c"].to_owned()),
+                "ARRAY" => Some(array!["a", "b", "c"].to_owned()),
                 _ => None,
             }
         }
@@ -468,7 +468,7 @@ mod test {
     fn test_reverse() {
         let method = ArrayMethod {
             method:    "reverse",
-            variable:  "$ARRAY",
+            variable:  "@ARRAY",
             pattern:   Pattern::StringPattern("3"),
             selection: Select::All,
         };


### PR DESCRIPTION
Just a minor fix for an incorrect naming I created yesterday. We should be using @ for arrays.