### PR TITLE
Fix issues with escaping on double quote context

### DIFF
--- a/src/builtins/test.rs
+++ b/src/builtins/test.rs
@@ -1,9 +1,9 @@
+use super::man_pages::{print_man, MAN_TEST};
 use smallstring::SmallString;
 use std::fs;
 use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 use std::path::Path;
 use std::time::SystemTime;
-use super::man_pages::{print_man, MAN_TEST};
 
 pub(crate) fn test(args: &[&str]) -> Result<bool, String> {
     let arguments = &args[1..];

--- a/src/parser/shell_expand/words/tests.rs
+++ b/src/parser/shell_expand/words/tests.rs
@@ -58,6 +58,71 @@ fn escape_with_backslash() {
 }
 
 #[test]
+fn escape_control_character() {
+    let input = r#"foo\nbar"#;
+    let expected = vec![
+        WordToken::Normal("foo", false, false),
+        WordToken::Normal("\\nbar", false, false),
+    ];
+
+    compare(input, expected);
+}
+
+#[test]
+fn escaping_double_quotes() {
+    let input = r#""some\"thing\"""#;
+    let expected = vec![
+        WordToken::Normal("some", false, false),
+        WordToken::Normal("\"thing", false, false),
+        WordToken::Normal("\"", false, false),
+    ];
+
+    compare(input, expected);
+}
+
+#[test]
+fn escaping_triple_backslash() {
+    let input = r#""\\\$test""#;
+    let expected = vec![
+        WordToken::Normal("", false, false),
+        WordToken::Normal("\\", false, false),
+        WordToken::Normal("$test", false, false),
+    ];
+
+    compare(input, expected);
+}
+
+#[test]
+fn escaping_all_escapable_characters() {
+    let input = r#"let \$test = arr\[0\]+\@some"#;
+    let expected = vec![
+        WordToken::Normal("let", false, false),
+        WordToken::Whitespace(" "),
+        WordToken::Normal("$test", false, false),
+        WordToken::Whitespace(" "),
+        WordToken::Normal("=", false, false),
+        WordToken::Whitespace(" "),
+        WordToken::Normal("arr", false, false),
+        WordToken::Normal("[0", false, false),
+        WordToken::Normal("]+", false, false),
+        WordToken::Normal("@some", false, false),
+    ];
+
+    compare(input, expected);
+}
+
+#[test]
+fn escape_with_backslash_double_quotes() {
+    let input = r#""\$test""#;
+    let expected = vec![
+        WordToken::Normal("", false, false),
+        WordToken::Normal("$test", false, false),
+    ];
+
+    compare(input, expected);
+}
+
+#[test]
 fn array_expressions() {
     let input = "[ one two [three four]] [[one two] three four][0]";
     let first = vec!["one", "two", "[three four]"];


### PR DESCRIPTION
**Problem**: 
There was an issue escaping strings on double quotes when a string was being extended.
The issue is described here: https://github.com/redox-os/ion/issues/640

**Solution**: 
Escaping symbols on double-quote environment was not working as
intended. The previous code, when it found a backslash on a quote, it
generated a Word which finished with an escape backslash as text.

With the new code, when a backslash is found a word is emitted up to the
backslash. After this, it checks if the following character should be
escaped: If it shouldn't, we don't advance the cursor and we parse that
backslash as text, on a following word. If it should be escaped, we
advance the buffer, to avoid that the backslash is added to the
following word.

**Changes introduced by this pull request**:

- Changed how words are tokenized when extending a string

**Drawbacks**: 

- The new code, when finds a backslash needs to look ahead the following character to know if needs escaping or not.
- A list of escaped characters is need

**Fixes**: https://github.com/redox-os/ion/issues/640
