### PR TITLE
fix for issue #585

### DIFF
--- a/src/parser/arguments.rs
+++ b/src/parser/arguments.rs
@@ -84,7 +84,8 @@ impl<'a> Iterator for ArgumentSplitter<'a> {
                 // Disable METHOD if enabled.
                 b')' if self.flags & METHOD != 0 => self.flags ^= METHOD,
                 // Otherwise decrement the parenthesis level.
-                b')' => level -= 1,
+                b')' if level > 0 =>
+                    level -= 1,
                 // Toggle double quote rules.
                 b'"' => self.flags ^= DOUBLE,
                 // Loop through characters until single quote rules are completed.

--- a/src/parser/arguments.rs
+++ b/src/parser/arguments.rs
@@ -67,6 +67,7 @@ impl<'a> Iterator for ArgumentSplitter<'a> {
         }
         let start = self.read;
 
+        // parenthesis level and array bracket level
         let (mut level, mut alevel) = (0, 0);
         let mut bytes = data.iter().cloned().skip(self.read);
         while let Some(character) = bytes.next() {
@@ -102,10 +103,6 @@ impl<'a> Iterator for ArgumentSplitter<'a> {
                 // Decrement the array level
                 b']' => alevel -= 1,
                 b'(' => {
-                    // If COMM_1 is enabled
-                    // i.e., a '$' was found last
-                    // Increment the parenthesis level.
-
                     // if VARIAB or ARRAY are set
                     // Disable VARIAB + ARRAY and enable METHOD.
                     if self.bitflags.intersects(


### PR DESCRIPTION
**Solution**: 

the `level: u8` variable in the `Iterator::next` implementation for the `ArgumentSplitter` was being decremented when its value was 0, causing a panic (unsigned ints cannot be less than 0).

**Changes introduced by this pull request**

i assumed that `level` represented the depth of the parentheses, so i consolidated the handling of parentheses and added `level +=1` or `level -= 1` respectively.

i also refactored the raw bit flags to use the bitflags crate for a few reason:
1) the crate was already imported
2) it makes the code a lot more readable (to me at least)
3) it helped me understand the code

**Drawbacks**

i just assumed `level` was referring to the parenthesis level, but i could be wrong. if that's the case this pull request should be rejected.
