### PR TITLE
Foreground Job Control Overhaul

### DIFF
--- a/src/lib/shell/job.rs
+++ b/src/lib/shell/job.rs
@@ -5,7 +5,6 @@ use parser::pipelines::RedirectFrom;
 use smallstring::SmallString;
 use std::fmt;
 use std::fs::File;
-use std::process::{Command, Stdio};
 use std::str;
 use types::*;
 

--- a/src/lib/shell/mod.rs
+++ b/src/lib/shell/mod.rs
@@ -128,7 +128,6 @@ impl ShellBuilder {
 
         extern "C" fn sigpipe_handler(signal: i32) {
             use std::process::exit;
-            eprintln!("received SIGPIPE");
             exit(127 + signal);
         }
 

--- a/src/lib/shell/mod.rs
+++ b/src/lib/shell/mod.rs
@@ -126,6 +126,14 @@ impl ShellBuilder {
         let _ = sys::signal(sys::SIGINT, handler);
         let _ = sys::signal(sys::SIGTERM, handler);
 
+        extern "C" fn sigpipe_handler(signal: i32) {
+            use std::process::exit;
+            eprintln!("received SIGPIPE");
+            exit(127 + signal);
+        }
+
+        let _ = sys::signal(sys::SIGPIPE, sigpipe_handler);
+
         self
     }
 

--- a/src/lib/shell/mod.rs
+++ b/src/lib/shell/mod.rs
@@ -328,6 +328,7 @@ impl<'a> Shell {
             self.set_var("?", &code.to_string());
             self.previous_status = code;
         }
+
         exit_status
     }
 

--- a/src/lib/shell/mod.rs
+++ b/src/lib/shell/mod.rs
@@ -127,8 +127,7 @@ impl ShellBuilder {
         let _ = sys::signal(sys::SIGTERM, handler);
 
         extern "C" fn sigpipe_handler(signal: i32) {
-            use std::process::exit;
-            exit(127 + signal);
+            sys::fork_exit(127 + signal);
         }
 
         let _ = sys::signal(sys::SIGPIPE, sigpipe_handler);

--- a/src/lib/shell/pipe_exec/job_control.rs
+++ b/src/lib/shell/pipe_exec/job_control.rs
@@ -33,16 +33,7 @@ pub(crate) trait JobControl {
     fn handle_signal(&self, signal: i32) -> bool;
     fn foreground_send(&self, signal: i32);
     fn background_send(&self, signal: i32);
-    fn watch_foreground<F, D>(
-        &mut self,
-        pid: u32,
-        last_pid: u32,
-        get_command: F,
-        drop_command: D,
-    ) -> i32
-    where
-        F: FnOnce() -> String,
-        D: FnMut(i32);
+    fn watch_foreground(&mut self, pids: Vec<u32>, command: &str) -> i32;
     fn send_to_background(&mut self, child: u32, state: ProcessState, command: String);
 }
 
@@ -157,18 +148,8 @@ impl JobControl for Shell {
         self.exit(sigcode);
     }
 
-    fn watch_foreground<F, D>(
-        &mut self,
-        pid: u32,
-        last_pid: u32,
-        get_command: F,
-        drop_command: D,
-    ) -> i32
-    where
-        F: FnOnce() -> String,
-        D: FnMut(i32),
-    {
-        self_sys::watch_foreground(self, pid, last_pid, get_command, drop_command)
+    fn watch_foreground(&mut self, pids: Vec<u32>, command: &str) -> i32 {
+        self_sys::watch_foreground(self, pids, command)
     }
 
     /// Send a kill signal to all running foreground tasks.

--- a/src/lib/shell/pipe_exec/job_control.rs
+++ b/src/lib/shell/pipe_exec/job_control.rs
@@ -33,7 +33,7 @@ pub(crate) trait JobControl {
     fn handle_signal(&self, signal: i32) -> bool;
     fn foreground_send(&self, signal: i32);
     fn background_send(&self, signal: i32);
-    fn watch_foreground(&mut self, pids: Vec<u32>, command: &str) -> i32;
+    fn watch_foreground(&mut self, pid: i32, command: &str) -> i32;
     fn send_to_background(&mut self, child: u32, state: ProcessState, command: String);
 }
 
@@ -148,8 +148,8 @@ impl JobControl for Shell {
         self.exit(sigcode);
     }
 
-    fn watch_foreground(&mut self, pids: Vec<u32>, command: &str) -> i32 {
-        self_sys::watch_foreground(self, pids, command)
+    fn watch_foreground(&mut self, pid: i32, command: &str) -> i32 {
+        self_sys::watch_foreground(self, pid, command)
     }
 
     /// Send a kill signal to all running foreground tasks.

--- a/src/lib/shell/pipe_exec/mod.rs
+++ b/src/lib/shell/pipe_exec/mod.rs
@@ -504,7 +504,7 @@ impl PipelineExecution for Shell {
         self.watch_foreground(-(pgid as i32), &as_string)
     }
 
-    fn exec_job(&mut self, job: &mut RefinedJob, foreground: bool) -> i32 {
+    fn exec_job(&mut self, job: &mut RefinedJob, _foreground: bool) -> i32 {
         let short = job.short();
         let long = job.long();
         match *job {
@@ -730,6 +730,7 @@ impl PipelineExecution for Shell {
 
                 prepare_child(false);
                 if let Err(_why) = sys::execve(name, &args, false) {
+                    command_not_found(self, name);
                     sys::fork_exit(NO_SUCH_COMMAND);
                 }
                 unreachable!()
@@ -976,6 +977,7 @@ fn spawn_proc(
 
                     prepare_child(child_blocked);
                     if let Err(_why) = sys::execve(&name, &args, false) {
+                        command_not_found(shell, name);
                         sys::fork_exit(NO_SUCH_COMMAND);
                     }
                 },

--- a/src/lib/shell/plugins/library_iter/mod.rs
+++ b/src/lib/shell/plugins/library_iter/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(target_os = "redox")]
 mod redox;
-#[cfg(target_os = "redox")]
-pub(crate) use self::redox::*;
+// #[cfg(target_os = "redox")]
+// pub(crate) use self::redox::*;
 
 #[cfg(all(unix, not(target_os = "redox")))]
 mod unix;

--- a/src/lib/shell/plugins/mod.rs
+++ b/src/lib/shell/plugins/mod.rs
@@ -3,6 +3,7 @@ pub mod namespaces;
 mod library_iter;
 mod string;
 
+#[cfg(not(target_os = "redox"))]
 pub(crate) use self::library_iter::*;
 pub(crate) use self::string::StringError;
 

--- a/src/lib/sys/redox.rs
+++ b/src/lib/sys/redox.rs
@@ -207,17 +207,8 @@ pub mod job_control {
         // TODO: Implement this using syscall::call::waitpid
     }
 
-    pub(crate) fn watch_foreground<F, D>(
-        shell: &mut Shell,
-        _pid: u32,
-        last_pid: u32,
-        _get_command: F,
-        mut drop_command: D,
-    ) -> i32
-    where
-        F: FnOnce() -> String,
-        D: FnMut(i32),
-    {
+    // TODO: This is very outdated -- copy code from the Linux side.
+    pub(crate) fn watch_foreground(shell: &mut Shell, _pids: Vec<i32>, _command: &str ) -> i32;
         let mut exit_status = 0;
         loop {
             let mut status_raw = 0;
@@ -228,7 +219,6 @@ pub mod job_control {
                         if pid == (last_pid as usize) {
                             break code;
                         } else {
-                            drop_command(pid as i32);
                             exit_status = code;
                         }
                     } else if let Some(signal) = status.signal() {

--- a/src/lib/sys/redox.rs
+++ b/src/lib/sys/redox.rs
@@ -5,9 +5,9 @@ use std::env;
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::RawFd;
 use std::path::PathBuf;
-use std::process::exit;
-
-use syscall::SigAction;
+use std::process::{exit, ExitStatus};
+use std::os::unix::process::ExitStatusExt;
+use syscall::{EINTR, SigAction, waitpid};
 
 pub(crate) const PATH_SEPARATOR: &str = ";";
 pub(crate) const NULL_PATH: &str = "null:";
@@ -19,6 +19,7 @@ pub(crate) const SIGTERM: i32 = syscall::SIGTERM as i32;
 pub(crate) const SIGCONT: i32 = syscall::SIGCONT as i32;
 pub(crate) const SIGSTOP: i32 = syscall::SIGSTOP as i32;
 pub(crate) const SIGTSTP: i32 = syscall::SIGTSTP as i32;
+pub(crate) const SIGPIPE: i32 = syscall::SIGPIPE as i32;
 
 pub(crate) const STDIN_FILENO: RawFd = 0;
 pub(crate) const STDOUT_FILENO: RawFd = 1;
@@ -34,21 +35,33 @@ pub unsafe fn fork() -> io::Result<u32> { cvt(syscall::clone(0)).map(|pid| pid a
 
 pub fn fork_exit(status: i32) -> ! { exit(status) }
 
+pub fn wait_for_interrupt(pid: u32) -> io::Result<()> {
+    let mut status = 0;
+
+    loop {
+        match waitpid(pid as usize, &mut status, 0) {
+            Err(ref error) if error.errno == EINTR => continue,
+            Err(ref error) => break Err(io::Error::from_raw_os_error(error.errno)),
+            Ok(_) => break Ok(()),
+        }
+    }
+}
+
 pub fn wait_for_child(pid: u32) -> io::Result<u8> {
     let mut status;
     use syscall::{waitpid, ECHILD};
 
     loop {
         status = 0;
-        match unsafe { waitpid(pid as usize, &mut status, 0) } {
+        match waitpid(pid as usize, &mut status, 0) {
             Err(ref error) if error.errno == ECHILD => break,
             Err(error) => return Err(io::Error::from_raw_os_error(error.errno)),
             _ => ()
         }
     }
 
-    // Ok(WEXITSTATUS(status) as u8)
-    Ok(0)
+    let status = ExitStatus::from_raw(status as i32);
+    Ok(status.code().unwrap_or(0) as u8)
 }
 
 pub(crate) fn getpid() -> io::Result<u32> { cvt(syscall::getpid()).map(|pid| pid as u32) }
@@ -192,11 +205,12 @@ pub mod job_control {
 
     use shell::Shell;
     use shell::foreground::ForegroundSignals;
-    use shell::status::{FAILURE, TERMINATED};
+    use shell::status::FAILURE;
     use std::os::unix::process::ExitStatusExt;
     use std::process::ExitStatus;
     use std::sync::{Arc, Mutex};
-    use syscall;
+    use syscall::{ECHILD, waitpid};
+    use super::{SIGINT, SIGPIPE};
 
     pub(crate) fn watch_background(
         _fg: Arc<ForegroundSignals>,
@@ -207,44 +221,62 @@ pub mod job_control {
         // TODO: Implement this using syscall::call::waitpid
     }
 
-    // TODO: This is very outdated -- copy code from the Linux side.
-    pub(crate) fn watch_foreground(shell: &mut Shell, _pids: Vec<i32>, _command: &str ) -> i32;
+    pub(crate) fn watch_foreground(shell: &mut Shell, pid: i32, command: &str ) -> i32 {
+        let mut signaled = 0;
         let mut exit_status = 0;
+        let mut status;
+
+        fn get_pid_value(pid: i32) -> usize {
+            if pid < 0 {
+                !(pid.abs() as usize)
+            } else {
+                pid as usize
+            }
+        }
+
         loop {
-            let mut status_raw = 0;
-            match syscall::waitpid(0, &mut status_raw, 0) {
-                Ok(pid) => {
-                    let status = ExitStatus::from_raw(status_raw as i32);
-                    if let Some(code) = status.code() {
-                        if pid == (last_pid as usize) {
-                            break code;
-                        } else {
-                            exit_status = code;
+            status = 0;
+            let result = waitpid(get_pid_value(pid), &mut status, 0);
+            match result {
+                Err(error) => {
+                    match error.errno {
+                        ECHILD if signaled == 0 => break exit_status,
+                        ECHILD => break signaled,
+                        _ => {
+                            eprintln!("ion: waitpid error: {}", error);
+                            break FAILURE;
                         }
-                    } else if let Some(signal) = status.signal() {
-                        eprintln!("ion: process ended by signal: {}", signal);
-                        if signal == syscall::SIGTERM as i32 {
-                            shell.handle_signal(signal);
-                            shell.exit(TERMINATED);
-                        } else if signal == syscall::SIGHUP as i32 {
-                            shell.handle_signal(signal);
-                            shell.exit(TERMINATED);
-                        } else if signal == syscall::SIGINT as i32 {
-                            shell.foreground_send(signal);
-                            shell.break_flow = true;
-                        }
-                        break TERMINATED;
-                    } else {
-                        eprintln!("ion: process ended with unknown status: {}", status);
-                        break TERMINATED;
                     }
                 }
-                Err(err) => if err.errno == syscall::ECHILD {
-                    break exit_status;
-                } else {
-                    eprintln!("ion: process doesn't exist: {}", err);
-                    break FAILURE;
-                },
+                Ok(0) => (),
+                Ok(pid) => {
+                    let es = ExitStatus::from_raw(status as i32);
+                    match es.signal() {
+                        Some(SIGPIPE) => continue,
+                        Some(signal) => {
+                            eprintln!("ion: process ended by signal {}", signal);
+                            match signal {
+                                SIGINT => {
+                                    shell.foreground_send(signal as i32);
+                                    shell.break_flow = true;
+                                }
+                                _ => {
+                                    shell.handle_signal(signal);
+                                }
+                            }
+                            signaled = 128 + signal as i32;
+                        }
+                        None => {
+                            exit_status = es.code().unwrap();
+                        }
+                    }
+                }
+                // TODO: Background job control for Redox
+                // _pid if WIFSTOPPED(status) => {
+                //     shell.send_to_background(pid as u32, ProcessState::Stopped, command.into());
+                //     shell.break_flow = true;
+                //     break 128 + signal as i32;
+                // }
             }
         }
     }

--- a/src/lib/sys/unix/job_control.rs
+++ b/src/lib/sys/unix/job_control.rs
@@ -83,7 +83,7 @@ pub(crate) fn watch_foreground(shell: &mut Shell, pid: i32, command: &str) -> i3
     let mut exit_status = 0;
     let mut status;
 
-    let exit_status = loop {
+    loop {
         unsafe {
             status = 0;
             match waitpid(pid, &mut status, WUNTRACED) {
@@ -126,7 +126,5 @@ pub(crate) fn watch_foreground(shell: &mut Shell, pid: i32, command: &str) -> i3
                 _ => (),
             }
         }
-    };
-
-    exit_status
+    }
 }

--- a/src/lib/sys/unix/job_control.rs
+++ b/src/lib/sys/unix/job_control.rs
@@ -83,7 +83,7 @@ pub(crate) fn watch_foreground(shell: &mut Shell, pid: i32, command: &str) -> i3
     let mut exit_status = 0;
     let mut status;
 
-    loop {
+    let exit_status = loop {
         unsafe {
             status = 0;
             match waitpid(pid, &mut status, WUNTRACED) {
@@ -126,5 +126,7 @@ pub(crate) fn watch_foreground(shell: &mut Shell, pid: i32, command: &str) -> i3
                 _ => (),
             }
         }
-    }
+    };
+
+    exit_status
 }

--- a/src/lib/sys/unix/mod.rs
+++ b/src/lib/sys/unix/mod.rs
@@ -19,6 +19,7 @@ pub(crate) const SIGTERM: i32 = libc::SIGTERM;
 pub(crate) const SIGCONT: i32 = libc::SIGCONT;
 pub(crate) const SIGSTOP: i32 = libc::SIGSTOP;
 pub(crate) const SIGTSTP: i32 = libc::SIGTSTP;
+pub(crate) const SIGPIPE: i32 = libc::SIGPIPE;
 
 pub(crate) const STDOUT_FILENO: i32 = libc::STDOUT_FILENO;
 pub(crate) const STDERR_FILENO: i32 = libc::STDERR_FILENO;
@@ -45,23 +46,6 @@ pub fn wait_for_interrupt(pid: u32) -> io::Result<()> {
             break Err(io::Error::from_raw_os_error(errno()));
         }
         break Ok(());
-    }
-}
-
-pub fn make_fd_blocking(fd: RawFd) -> io::Result<()> {
-    let mut err = 0;
-
-    unsafe {
-        let flags = fcntl(fd, F_GETFL, 0);
-        if flags & O_NONBLOCK != 0 {
-            err = fcntl(fd, F_SETFL, flags ^ O_NONBLOCK);
-        }
-    }
-
-    if err == -1 {
-        Err(io::Error::from_raw_os_error(errno()))
-    } else {
-        Ok(())
     }
 }
 

--- a/src/lib/sys/unix/mod.rs
+++ b/src/lib/sys/unix/mod.rs
@@ -3,7 +3,7 @@ extern crate libc;
 pub mod job_control;
 pub mod signals;
 
-use libc::{c_char, c_int, fcntl, F_GETFL, F_SETFL, O_NONBLOCK, pid_t, sighandler_t, waitpid, ECHILD, EINTR, WEXITSTATUS, WUNTRACED};
+use libc::{c_char, c_int, pid_t, sighandler_t, waitpid, ECHILD, EINTR, WEXITSTATUS, WUNTRACED};
 use std::{io, ptr};
 use std::env;
 use std::ffi::CString;


### PR DESCRIPTION
Job control in Ion was a complete mess, and it was a wonder that it even worked at one point to begin with! I've gone through and fixed a number of issues related to foreground job management.

- Processes are no longer preemptively killed by Ion to emulate SIGPIPE support.
- Processes within a pipeline are now assigned the same PGID.
- A SIGPIPE handler is now registered so that processes exit when they receive a SIGPIPE.
- Jobs should exit with the correct exit statuses in more situations.
- External commands now use fork + exec, rather than `std::process::Command`.
- Redox's foreground job management was also improved.
- Some refactoring was performed, with more refactoring planned in the future.

There's likely some issues that remain to be addressed though. Needs more testing & bug reports. Background job management remains to be mostly broken for now, so that's an area to look into next.