### PR TITLE
Fix for double quote parsing

### DIFF
--- a/examples/methods.ion
+++ b/examples/methods.ion
@@ -30,7 +30,8 @@ echo $repeat("one ", 5)
 
 echo $join([one two three], "\n")
 echo $join([one two three], "\t")
-echo $join([one two three], "\\n")
+echo $join([one two three], '\\n')
+echo $join([one two three], "\\\\n")
 echo $replace($join([one two three], "\n"), "\n" "\t")
 let a = "applesauce"
 let pos = $find(a, "s")

--- a/examples/methods.out
+++ b/examples/methods.out
@@ -62,6 +62,7 @@ two
 three
 one	two	three
 one\ntwo\nthree
+one\ntwo\nthree
 one	two	three
 apple
 sauce

--- a/examples/strings.ion
+++ b/examples/strings.ion
@@ -2,3 +2,7 @@ echo hello?world
 echo hello*world
 echo hello^world
 echo hello%world
+echo "\$hello"
+echo "\\"
+echo "\n"
+echo "\""

--- a/examples/strings.out
+++ b/examples/strings.out
@@ -2,3 +2,7 @@ hello?world
 hello*world
 hello^world
 hello%world
+$hello
+\
+\n
+"


### PR DESCRIPTION
**Problem**: Fixes some weird backslash behavior

**Solution**: Changed parsing logic for backslash when in double quotes

**Changes introduced by this pull request**:

- tests
- changes to parser logic in `words` module

**Other**

Found some weird behaviour that I tried to fix hear. Seems you already have an issue here: https://github.com/redox-os/ion/issues/640

My changes try to make it work similar to bash. I had to change one test, which I believe is wrong (`"\\n"` should convert to `"\n"`, not `"\\n"`, both bash and fish behave this way).