### PR TITLE
More Foreground Job Control Improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,16 +123,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "failure"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,7 +174,6 @@ dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "calculate 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "errno 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -491,7 +480,6 @@ source = "git+https://github.com/whitequark/rust-xdg#a1c9249f78a5395c2ee3dc8688a
 "checksum clap 2.29.0 (registry+https://github.com/rust-lang/crates.io-index)" = "110d43e343eb29f4f51c1db31beb879d546db27998577e5715270a54bcf41d3f"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum decimal 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e6458723bc760383275fbc02f4c769b2e5f3de782abaf5e7e0b9b7f0368a63ed"
-"checksum errno 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b2c858c42ac0b88532f48fca88b0ed947cad4f1f64d904bcd6c9f138f7b95d70"
 "checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
 "checksum failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ path = "src/lib/lib.rs"
 lto = true
 panic = "abort"
 [target."cfg(all(unix, not(target_os = \"redox\")))".dependencies]
-errno = "0.2.3"
 libc = "0.2"
 libloading = "0.4"
 users = "0.5.1"

--- a/examples/script_exec.ion
+++ b/examples/script_exec.ion
@@ -1,0 +1,3 @@
+for script in examples/a* examples/b*
+    target/debug/ion $script
+end

--- a/examples/script_exec.out
+++ b/examples/script_exec.out
@@ -1,0 +1,104 @@
+one one
+one twoone
+o n e t w o
+111 110 101 116 119 111
+o n e t w o
+firstline secondline
+3 2 1
+a
+3 2 1
+1
+2
+3
+4
+5
+6
+1
+2
+3
+4
+5
+6
+a
+b
+c
+d
+e
+a
+b
+c
+d
+e
+1
+2
+3
+4
+5
+6
+a
+b
+c
+d
+e
+1 2 3 4 5 6
+a b c d e
+1 2 3 4 5 6 a b c d e
+1
+2
+3
+1
+2
+3
+1
+2
+3
+1
+1 2
+1 2 3
+4 5
+1 2 3 4 5
+😉
+😉
+😉
+1 2 3 4 5
+pass
+1A1 1A2 1B1 1B2
+0abc2def5g 0abc2def5h 0abc2def5i 0abc2def6g 0abc2def6h 0abc2def6i 0abc2def7g 0abc2def7h 0abc2def7i 0abc3def5g 0abc3def5h 0abc3def5i 0abc3def6g 0abc3def6h 0abc3def6i 0abc3def7g 0abc3def7h 0abc3def7i 0abc4def5g 0abc4def5h 0abc4def5i 0abc4def6g 0abc4def6h 0abc4def6i 0abc4def7g 0abc4def7h 0abc4def7i 1abc2def5g 1abc2def5h 1abc2def5i 1abc2def6g 1abc2def6h 1abc2def6i 1abc2def7g 1abc2def7h 1abc2def7i 1abc3def5g 1abc3def5h 1abc3def5i 1abc3def6g 1abc3def6h 1abc3def6i 1abc3def7g 1abc3def7h 1abc3def7i 1abc4def5g 1abc4def5h 1abc4def5i 1abc4def6g 1abc4def6h 1abc4def6i 1abc4def7g 1abc4def7h 1abc4def7i
+-1 0 1
+2 1 0
+a b c
+d c b
+A B C
+D C B
+-1 0 1
+2 1 0
+a b c
+d c b
+A B C
+D C B
+0 2 4
+a c e
+A C E
+0 -2 -4
+e c a
+E C A
+0 2 4
+a c e
+A C E
+0 -2 -4
+e c
+E C
+1
+2
+3
+4
+5
+1
+2
+3
+4
+5
+true
+false
+foo
+bar

--- a/src/lib/builtins/exec.rs
+++ b/src/lib/builtins/exec.rs
@@ -28,10 +28,7 @@ pub(crate) fn exec(shell: &mut Shell, args: &[&str]) -> Result<(), String> {
                 &[]
             };
             shell.prep_for_exit();
-            match execve(argument, args, (flags & CLEAR_ENV) == 1) {
-                Ok(_) => Ok(()),
-                Err(err) => Err(err.description().to_owned()),
-            }
+            Err(execve(argument, args, (flags & CLEAR_ENV) == 1).description().to_owned())
         }
         None => Err("no command provided".to_owned()),
     }

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -8,8 +8,6 @@
 #[macro_use]
 extern crate bitflags;
 extern crate calc;
-#[cfg(all(unix, not(target_os = "redox")))]
-extern crate errno;
 extern crate failure;
 #[macro_use]
 extern crate failure_derive;

--- a/src/lib/shell/mod.rs
+++ b/src/lib/shell/mod.rs
@@ -84,9 +84,6 @@ pub struct Shell {
     pub(crate) previous_job: u32,
     /// Contains all the boolean flags that control shell behavior.
     pub flags: u8,
-    /// A temporary field for storing foreground PIDs used by the pipeline
-    /// execution.
-    foreground: Vec<u32>,
     /// Contains information on all of the active background processes that are being managed
     /// by the shell.
     pub(crate) background: Arc<Mutex<Vec<BackgroundProcess>>>,
@@ -170,7 +167,6 @@ impl<'a> Shell {
             previous_job:        !0,
             previous_status:     0,
             flags:               0,
-            foreground:          Vec::new(),
             background:          Arc::new(Mutex::new(Vec::new())),
             is_background_shell: false,
             is_library,

--- a/src/lib/shell/pipe_exec/job_control.rs
+++ b/src/lib/shell/pipe_exec/job_control.rs
@@ -31,7 +31,6 @@ pub(crate) trait JobControl {
     fn set_bg_task_in_foreground(&self, pid: u32, cont: bool) -> i32;
     fn resume_stopped(&mut self);
     fn handle_signal(&self, signal: i32) -> bool;
-    fn foreground_send(&self, signal: i32);
     fn background_send(&self, signal: i32);
     fn watch_foreground(&mut self, pid: i32, command: &str) -> i32;
     fn send_to_background(&mut self, child: u32, state: ProcessState, command: String);
@@ -150,13 +149,6 @@ impl JobControl for Shell {
 
     fn watch_foreground(&mut self, pid: i32, command: &str) -> i32 {
         self_sys::watch_foreground(self, pid, command)
-    }
-
-    /// Send a kill signal to all running foreground tasks.
-    fn foreground_send(&self, signal: i32) {
-        for &process in self.foreground.iter() {
-            let _ = sys::killpg(process, signal);
-        }
     }
 
     /// Resumes all stopped background jobs

--- a/src/lib/shell/pipe_exec/mod.rs
+++ b/src/lib/shell/pipe_exec/mod.rs
@@ -414,8 +414,6 @@ pub(crate) trait PipelineExecution {
 
 impl PipelineExecution for Shell {
     fn execute_pipeline(&mut self, pipeline: &mut Pipeline) -> i32 {
-        // Remove any leftover foreground tasks from the last execution.
-        self.foreground.clear();
         // If the supplied pipeline is a background, a string representing the command
         // and a boolean representing whether it should be disowned is stored here.
         let possible_background_name =
@@ -1002,7 +1000,6 @@ fn spawn_proc(
                     close(stdin);
                     close(stdout);
                     close(stderr);
-                    shell.foreground.push(pid);
                     *last_pid = *current_pid;
                     *current_pid = pid;
                 },
@@ -1025,7 +1022,6 @@ fn spawn_proc(
                 Ok(pid) => {
                     close(stdout);
                     close(stderr);
-                    shell.foreground.push(pid);
                     *last_pid = *current_pid;
                     *current_pid = pid;
                 },
@@ -1048,7 +1044,6 @@ fn spawn_proc(
                 Ok(pid) => {
                     close(stdout);
                     close(stderr);
-                    shell.foreground.push(pid);
                     *last_pid = *current_pid;
                     *current_pid = pid;
                 },
@@ -1069,7 +1064,6 @@ fn spawn_proc(
                 }
                 Ok(pid) => {
                     close(stdout);
-                    shell.foreground.push(pid);
                     *last_pid = *current_pid;
                     *current_pid = pid;
                 }
@@ -1090,7 +1084,6 @@ fn spawn_proc(
                 Ok(pid) => {
                     close(stdout);
                     close(stderr);
-                    shell.foreground.push(pid);
                     *last_pid = *current_pid;
                     *current_pid = pid;
                 }

--- a/src/lib/sys/redox.rs
+++ b/src/lib/sys/redox.rs
@@ -234,9 +234,11 @@ pub mod job_control {
             }
         }
 
+        let pid = get_pid_value(pid);
+
         loop {
             status = 0;
-            let result = waitpid(get_pid_value(pid), &mut status, 0);
+            let result = waitpid(pid, &mut status, 0);
             match result {
                 Err(error) => {
                     match error.errno {
@@ -257,7 +259,7 @@ pub mod job_control {
                             eprintln!("ion: process ended by signal {}", signal);
                             match signal {
                                 SIGINT => {
-                                    shell.foreground_send(signal as i32);
+                                    let _ = syscall::kill(pid, signal as usize);
                                     shell.break_flow = true;
                                 }
                                 _ => {

--- a/src/lib/sys/unix/job_control.rs
+++ b/src/lib/sys/unix/job_control.rs
@@ -6,7 +6,6 @@ use shell::status::{FAILURE, TERMINATED};
 use std::sync::{Arc, Mutex};
 use std::thread::sleep;
 use std::time::Duration;
-use std::io;
 use super::{errno, write_errno};
 
 pub(crate) fn watch_background(
@@ -108,7 +107,7 @@ pub(crate) fn watch_foreground(shell: &mut Shell, pid: i32, command: &str) -> i3
                     eprintln!("ion: process ended by signal {}", signal);
                     match signal {
                         SIGINT => {
-                            shell.foreground_send(signal as i32);
+                            let _ = kill(pid, signal as i32);
                             shell.break_flow = true;
                         }
                         _ => {

--- a/src/lib/sys/unix/mod.rs
+++ b/src/lib/sys/unix/mod.rs
@@ -86,6 +86,124 @@ pub(crate) fn killpg(pgid: u32, signal: i32) -> io::Result<()> {
     cvt(unsafe { libc::kill(-(pgid as pid_t), signal as c_int) }).and(Ok(()))
 }
 
+pub(crate) fn fork_and_exec<F: Fn()>(
+    prog: &str,
+    args: &[&str],
+    stdin: Option<RawFd>,
+    stdout: Option<RawFd>,
+    stderr: Option<RawFd>,
+    clear_env: bool,
+    before_exec: F,
+) -> io::Result<u32> {
+    let prog_str = match CString::new(prog) {
+        Ok(prog) => prog,
+        Err(_) => {
+            return Err(io::Error::last_os_error());
+        }
+    };
+
+    // Create a vector of null-terminated strings.
+    let mut cvt_args: Vec<CString> = Vec::new();
+    cvt_args.push(prog_str.clone());
+    for &arg in args.iter() {
+        match CString::new(arg) {
+            Ok(arg) => cvt_args.push(arg),
+            Err(_) => {
+                return Err(io::Error::last_os_error());
+            }
+        }
+    }
+
+    // Create a null-terminated array of pointers to those strings.
+    let mut arg_ptrs: Vec<*const c_char> = cvt_args.iter().map(|x| x.as_ptr()).collect();
+    arg_ptrs.push(ptr::null());
+
+    // Get the PathBuf of the program if it exists.
+    let prog = if prog.contains('/') {
+        // This is a fully specified path to an executable.
+        Some(prog_str)
+    } else if let Ok(paths) = env::var("PATH") {
+        // This is not a fully specified scheme or path.
+        // Iterate through the possible paths in the
+        // env var PATH that this executable may be found
+        // in and return the first one found.
+        env::split_paths(&paths)
+            .filter_map(|mut path| {
+                path.push(prog);
+                match (path.exists(), path.to_str()) {
+                    (true, Some(path)) => CString::new(path).ok(),
+                    _ => None,
+                }
+            })
+            .next()
+    } else {
+        None
+    };
+
+    let mut env_ptrs: Vec<*const c_char> = Vec::new();
+    let mut env_vars: Vec<CString> = Vec::new();
+
+    // If clear_env is not specified build envp
+    if !clear_env {
+        for (key, value) in env::vars() {
+            match CString::new(format!("{}={}", key, value)) {
+                Ok(var) => env_vars.push(var),
+                Err(_) => {
+                    return Err(io::Error::last_os_error());
+                }
+            }
+        }
+        env_ptrs = env_vars.iter().map(|x| x.as_ptr()).collect();
+    }
+    env_ptrs.push(ptr::null());
+
+    if let Some(prog) = prog {
+        unsafe {
+            match fork()? {
+                0 => {
+                    if let Some(stdin) = stdin {
+                        let _ = dup2(stdin, STDIN_FILENO);
+                        let _ = close(stdin);
+                    }
+
+                    if let Some(stdout) = stdout {
+                        let _ = dup2(stdout, STDOUT_FILENO);
+                        let _ = close(stdout);
+                    }
+
+                    if let Some(stderr) = stderr {
+                        let _ = dup2(stderr, STDERR_FILENO);
+                        let _ = close(stderr);
+                    }
+
+                    before_exec();
+
+                    libc::execve(prog.as_ptr(), arg_ptrs.as_ptr(), env_ptrs.as_ptr());
+                    eprintln!("ion: command exec: {}", io::Error::last_os_error());
+                    fork_exit(1);
+                }
+                pid => {
+                    if let Some(stdin) = stdin {
+                        let _ = close(stdin);
+                    }
+
+                    if let Some(stdout) = stdout {
+                        let _ = close(stdout);
+                    }
+
+                    if let Some(stderr) = stderr {
+                        let _ = close(stderr);
+                    }
+
+                    Ok(pid)
+                }
+            }
+        }
+    } else {
+        Err(io::Error::from_raw_os_error(libc::ENOENT))
+    }
+}
+
 pub(crate) fn execve(prog: &str, args: &[&str], clear_env: bool) -> io::Error {
     let prog_str = match CString::new(prog) {
         Ok(prog) => prog,


### PR DESCRIPTION
- Linux no longer requires the  **errno** crate as a dependency
- The foreground field has been removed from the shell now that it is no longer needed
- Fork + exec no longer performs allocations within child of the fork
- Added a script execution test

I'll be working on background job control next.