### PR TITLE
Pipeline Fixes & Tests

### DIFF
--- a/examples/pipelines.ion
+++ b/examples/pipelines.ion
@@ -1,0 +1,6 @@
+echo test | cat | cat
+echo one | cat <<< two
+echo foo | grep foo && echo found foo
+echo foo | grep bar || echo did not find bar
+echo test | grep test && echo found test | cat
+

--- a/examples/pipelines.ion
+++ b/examples/pipelines.ion
@@ -1,0 +1,4 @@
+echo test | cat | cat
+echo one | cat <<< two
+echo foo | grep foo && echo found foo
+echo foo | grep bar || echo did not find bar

--- a/examples/pipelines.ion
+++ b/examples/pipelines.ion
@@ -2,3 +2,4 @@ echo test | cat | cat
 echo one | cat <<< two
 echo foo | grep foo && echo found foo
 echo foo | grep bar || echo did not find bar
+echo test | grep test && echo found test | cat

--- a/examples/pipelines.ion
+++ b/examples/pipelines.ion
@@ -1,5 +1,0 @@
-echo test | cat | cat
-echo one | cat <<< two
-echo foo | grep foo && echo found foo
-echo foo | grep bar || echo did not find bar
-echo test | grep test && echo found test | cat

--- a/examples/pipelines.out
+++ b/examples/pipelines.out
@@ -4,3 +4,5 @@ two
 foo
 found foo
 did not find bar
+test
+found test

--- a/examples/pipelines.out
+++ b/examples/pipelines.out
@@ -1,8 +1,0 @@
-test
-one
-two
-foo
-found foo
-did not find bar
-test
-found test

--- a/examples/pipelines.out
+++ b/examples/pipelines.out
@@ -1,0 +1,6 @@
+test
+one
+two
+foo
+found foo
+did not find bar

--- a/examples/pipelines.out
+++ b/examples/pipelines.out
@@ -1,0 +1,8 @@
+test
+one
+two
+foo
+found foo
+did not find bar
+test
+found test

--- a/src/lib/shell/mod.rs
+++ b/src/lib/shell/mod.rs
@@ -38,7 +38,7 @@ use parser::Terminator;
 use parser::pipelines::Pipeline;
 use smallvec::SmallVec;
 use std::fs::File;
-use std::io::{self, Read};
+use std::io::{self, Read, Write};
 use std::iter::FromIterator;
 use std::ops::Deref;
 use std::path::Path;
@@ -124,6 +124,8 @@ impl ShellBuilder {
         let _ = sys::signal(sys::SIGTERM, handler);
 
         extern "C" fn sigpipe_handler(signal: i32) {
+            let _ = io::stdout().flush();
+            let _ = io::stderr().flush();
             sys::fork_exit(127 + signal);
         }
 

--- a/src/lib/sys/unix/job_control.rs
+++ b/src/lib/sys/unix/job_control.rs
@@ -8,28 +8,38 @@ use std::thread::sleep;
 use std::time::Duration;
 use super::{errno, write_errno};
 
+const OPTS: i32 = WUNTRACED | WCONTINUED | WNOHANG;
+
 pub(crate) fn watch_background(
     fg: Arc<ForegroundSignals>,
     processes: Arc<Mutex<Vec<BackgroundProcess>>>,
-    pid: u32,
+    pgid: u32,
     njob: usize,
 ) {
     let mut fg_was_grabbed = false;
-    loop {
-        if !fg_was_grabbed {
-            if fg.was_grabbed(pid) {
-                fg_was_grabbed = true;
-            }
-        }
+    let mut status;
+    let mut exit_status = 0;
 
-        let opts = WUNTRACED | WCONTINUED | WNOHANG;
-        let mut status = 0;
+    loop {
+        fg_was_grabbed = !fg_was_grabbed && fg.was_grabbed(pgid);
 
         unsafe {
-            let pid = waitpid(-(pid as pid_t), &mut status, opts);
-            match pid {
+            status = 0;
+            match waitpid(-(pgid as pid_t), &mut status, OPTS) {
+                -1 if errno() == ECHILD => {
+                    if !fg_was_grabbed {
+                        eprintln!("ion: ([{}] {}) exited with {}", njob, pgid, status);
+                    }
+                    let mut processes = processes.lock().unwrap();
+                    let process = &mut processes.iter_mut().nth(njob).unwrap();
+                    process.state = ProcessState::Empty;
+                    if fg_was_grabbed {
+                        fg.reply_with(exit_status as i8);
+                    }
+                    break;
+                }
                 -1 => {
-                    eprintln!("ion: ([{}] {}) errored: {}", njob, pid, errno());
+                    eprintln!("ion: ([{}] {}) errored: {}", njob, pgid, errno());
                     let mut processes = processes.lock().unwrap();
                     let process = &mut processes.iter_mut().nth(njob).unwrap();
                     process.state = ProcessState::Empty;
@@ -39,21 +49,10 @@ pub(crate) fn watch_background(
                     break;
                 }
                 0 => (),
-                _ if WIFEXITED(status) => {
+                _pid if WIFEXITED(status) => exit_status = WEXITSTATUS(status),
+                _pid if WIFSTOPPED(status) => {
                     if !fg_was_grabbed {
-                        eprintln!("ion: ([{}] {}) exited with {}", njob, pid, status);
-                    }
-                    let mut processes = processes.lock().unwrap();
-                    let process = &mut processes.iter_mut().nth(njob).unwrap();
-                    process.state = ProcessState::Empty;
-                    if fg_was_grabbed {
-                        fg.reply_with(WEXITSTATUS(status) as i8);
-                    }
-                    break;
-                }
-                _ if WIFSTOPPED(status) => {
-                    if !fg_was_grabbed {
-                        eprintln!("ion: ([{}] {}) Stopped", njob, pid);
+                        eprintln!("ion: ([{}] {}) Stopped", njob, pgid);
                     }
                     let mut processes = processes.lock().unwrap();
                     let process = &mut processes.iter_mut().nth(njob).unwrap();
@@ -63,9 +62,9 @@ pub(crate) fn watch_background(
                     }
                     process.state = ProcessState::Stopped;
                 }
-                _ if WIFCONTINUED(status) => {
+                _pid if WIFCONTINUED(status) => {
                     if !fg_was_grabbed {
-                        eprintln!("ion: ([{}] {}) Running", njob, pid);
+                        eprintln!("ion: ([{}] {}) Running", njob, pgid);
                     }
                     let mut processes = processes.lock().unwrap();
                     let process = &mut processes.iter_mut().nth(njob).unwrap();
@@ -117,8 +116,7 @@ pub(crate) fn watch_foreground(shell: &mut Shell, pid: i32, command: &str) -> i3
                     signaled = 128 + signal as i32;
                 }
                 _pid if WIFSTOPPED(status) => {
-                    // TODO: Rework background control
-                    shell.send_to_background(pid as u32, ProcessState::Stopped, command.into());
+                    shell.send_to_background(pid.abs() as u32, ProcessState::Stopped, command.into());
                     shell.break_flow = true;
                     break 128 + signal as i32;
                 }

--- a/src/lib/sys/unix/mod.rs
+++ b/src/lib/sys/unix/mod.rs
@@ -25,7 +25,19 @@ pub(crate) const STDOUT_FILENO: i32 = libc::STDOUT_FILENO;
 pub(crate) const STDERR_FILENO: i32 = libc::STDERR_FILENO;
 pub(crate) const STDIN_FILENO: i32 = libc::STDIN_FILENO;
 
+// Why each platform wants to be unique in this regard is anyone's guess.
+
+#[cfg(target_os = "linux")]
 fn errno() -> i32 { unsafe { *libc::__errno_location() } }
+
+#[cfg(any(target_os = "openbsd", target_os = "bitrig", target_os = "android"))]
+fn errno() -> i32 { unsafe { *libc::__errno() } }
+
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd"))]
+fn errno() -> i32 { unsafe { *libc::__error() } }
+
+#[cfg(target_os = "dragonfly")]
+fn errno() -> i32 { unsafe { *libc::__dfly_error() } }
 
 fn write_errno(msg: &str, errno: i32) {
     let stderr = io::stderr();

--- a/src/lib/sys/unix/mod.rs
+++ b/src/lib/sys/unix/mod.rs
@@ -56,16 +56,15 @@ pub(crate) fn is_root() -> bool { unsafe { libc::geteuid() == 0 } }
 pub unsafe fn fork() -> io::Result<u32> { cvt(libc::fork()).map(|pid| pid as u32) }
 
 pub fn wait_for_interrupt(pid: u32) -> io::Result<()> {
-    let mut status = 0;
-    let mut result;
+    let mut status;
 
     loop {
-        result = unsafe { waitpid(pid as i32, &mut status, WUNTRACED) };
-        if result == -1 {
-            if errno() == EINTR { continue }
-            break Err(io::Error::from_raw_os_error(errno()));
+        status = 0;
+        match unsafe { waitpid(pid as i32, &mut status, WUNTRACED) } {
+            -1 if errno() == EINTR => continue,
+            -1 => break Err(io::Error::from_raw_os_error(errno())),
+            _ => break Ok(())
         }
-        break Ok(());
     }
 }
 


### PR DESCRIPTION
Found some issues with pipeline execution logic, and so I've fixed them and added tests to prevent this from happening again. The following use cases are now working:

```
echo foo | grep foo && echo found foo
echo foo | grep bar || echo did not find bar
echo test | grep test && echo found test | cat
```