### PR TITLE
Fix to array parsing issue 

### DIFF
--- a/src/lib/parser/shell_expand/words/mod.rs
+++ b/src/lib/parser/shell_expand/words/mod.rs
@@ -574,8 +574,11 @@ impl<'a, E: Expander + 'a> WordIterator<'a, E> {
                 b' ' | b'"' | b'\'' | b'$' | b'{' | b'}' => break,
                 b']' => {
                     // If the glob is less than three bytes in width, then it's empty and thus
-                    // invalid.
-                    if !(moves <= 3 && square_bracket == 1) {
+                    // invalid. If it's not adjacent to text, it's not a glob.
+                    let next_char = iter.clone().next();
+                    if !(moves <= 3 && square_bracket == 1)
+                        && (next_char != None && next_char != Some(b' '))
+                    {
                         glob = true;
                         break;
                     }


### PR DESCRIPTION
**Solution**:
Glob_check was incorporating one element arrays into globs and somehow consuming them. The fix simply checks if the `b']'` is not succeeded by another character, which would make it a glob pattern.

**Fixes**:
Array Parsing Issue #638