### PR TITLE
Add dummy --login argument to ion

### DIFF
--- a/src/lib/builtins/mod.rs
+++ b/src/lib/builtins/mod.rs
@@ -148,6 +148,10 @@ impl BuiltinMap {
 
 // Definitions of simple builtins go here
 fn builtin_status(args: &[&str], shell: &mut Shell) -> i32 {
+    if check_help(args, MAN_STATUS) {
+        return SUCCESS;
+    }
+
     match status(args, shell) {
         Ok(()) => SUCCESS,
         Err(why) => {

--- a/src/lib/builtins/status.rs
+++ b/src/lib/builtins/status.rs
@@ -49,7 +49,7 @@ pub(crate) fn status(args: &[&str], shell: &mut Shell) -> Result<(), String> {
             }
         }
         let err = "".to_string();
-
+        
         if flags.contains(Flags::LOGIN_SHELL) && !is_login {
             return Err(err);
         }

--- a/src/lib/shell/binary/mod.rs
+++ b/src/lib/shell/binary/mod.rs
@@ -22,7 +22,7 @@ pub const MAN_ION: &'static str = r#"NAME
     ion - ion shell
 
 SYNOPSIS
-    ion [ -h | --help ] [-c] [-n] [-v]
+    ion [ -h | --help ] [-c] [-n] [-v] [-l]
 
 DESCRIPTION
     ion is a commandline shell created to be a faster and easier to use alternative to the 
@@ -37,6 +37,9 @@ OPTIONS
 
     -v or --version
         prints the version, platform and revision of ion then exits.
+
+    -l or --login
+        currently does nothing, however in the futere will run ion as a login shell.
 "#;
 
 pub trait Binary {

--- a/src/lib/shell/binary/mod.rs
+++ b/src/lib/shell/binary/mod.rs
@@ -39,7 +39,7 @@ OPTIONS
         prints the version, platform and revision of ion then exits.
 
     -l or --login
-        currently does nothing, however in the futere will run ion as a login shell.
+        currently does nothing, however in the future will run ion as a login shell.
 "#;
 
 pub trait Binary {

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,9 @@ fn main() {
                 shell.flags |= NO_EXEC;
                 continue;
             }
+            // Ion currently does not do anything when invoked as a login shell, however some scripts 
+            // automatically pass `-l` as an argument so we need to ignore it explicitly.
+            "-l" | "--login" => continue,
             "-c" => shell.execute_arguments(args),
             "-v" | "--version" => shell.display_version(),
             "-h" | "--help" => {


### PR DESCRIPTION
**Problem**: Many terminal emulators automatically pass `-l` as an argument. Currently ion does not do anything when it is invoked as a login shell and doesn't check for `-l`. This means that ion tries to execute `-l` as a shell script.

**Solution**: I implemented a dummy `-l`.