### PR TITLE
Fixed bug in tilde resolution

### DIFF
--- a/src/lib/parser/shell_expand/words/mod.rs
+++ b/src/lib/parser/shell_expand/words/mod.rs
@@ -636,6 +636,7 @@ impl<'a, E: Expander + 'a> Iterator for WordIterator<'a, E> {
         let mut start = self.read;
         let mut glob = false;
         let mut tilde = false;
+
         loop {
             if let Some(character) = iterator.next() {
                 match character {
@@ -748,7 +749,6 @@ impl<'a, E: Expander + 'a> Iterator for WordIterator<'a, E> {
                 return None;
             }
         }
-
         while let Some(character) = iterator.next() {
             match character {
                 _ if self.flags.contains(Flags::BACKSL) => self.flags ^= Flags::BACKSL,
@@ -808,14 +808,6 @@ impl<'a, E: Expander + 'a> Iterator for WordIterator<'a, E> {
                 }
                 b'*' | b'?' if !self.flags.contains(Flags::SQUOTE) => {
                     glob = true;
-                }
-                b'~' if !self.flags.intersects(Flags::SQUOTE | Flags::DQUOTE) => {
-                    let output = &self.data[start..self.read];
-                    if output != "" {
-                        return Some(WordToken::Normal(output, glob, tilde));
-                    } else {
-                        return self.next();
-                    }
                 }
                 _ => (),
             }


### PR DESCRIPTION
**Problem**:
The problem exists in tilde resolution. Only the first tilde should be expanded, But the current code expands all tildes. 

**Solution**:
My solution checks current position and only sets tilde, If current position is 0. i.e. `~` is the first character.

**Changes introduced by this pull request**:

- Only the first tilde is resolved instead of all tildes in a string.

**Fixes**:
#709 #708 

**State**: [the state of this PR, e.g. WIP, ready, etc.]
Completed.

------

