### PR TITLE
Alias reimplementation  #711

### DIFF
--- a/src/lib/builtins/mod.rs
+++ b/src/lib/builtins/mod.rs
@@ -27,7 +27,7 @@ use self::man_pages::*;
 use self::source::source;
 use self::status::status;
 use self::test::test;
-use self::variables::{alias, drop_alias, drop_array, drop_variable};
+use self::variables::{drop_alias, drop_array, drop_variable};
 use types::Array;
 
 use std::env;
@@ -71,7 +71,6 @@ macro_rules! map {
 
 /// Builtins are in A-Z order.
 pub const BUILTINS: &'static BuiltinMap = &map!(
-    "alias" => builtin_alias : "View, set or unset aliases",
     "and" => builtin_and : "Execute the command if the shell's previous status is success",
     "bg" => builtin_bg : "Resumes a stopped background process",
     "bool" => builtin_bool : "If the value is '1' or 'true', return 0 exit status",
@@ -265,11 +264,6 @@ fn builtin_popd(args: &[&str], shell: &mut Shell) -> i32 {
             FAILURE
         }
     }
-}
-
-fn builtin_alias(args: &[&str], shell: &mut Shell) -> i32 {
-    let args_str = args[1..].join(" ");
-    alias(&mut shell.variables, &args_str)
 }
 
 fn builtin_unalias(args: &[&str], shell: &mut Shell) -> i32 {

--- a/src/lib/builtins/variables.rs
+++ b/src/lib/builtins/variables.rs
@@ -1,138 +1,8 @@
 // TODO: Move into grammar
 
-use std::io::{self, Write};
 
 use shell::status::*;
 use shell::variables::Variables;
-use types::*;
-
-fn print_list(list: &VariableContext) {
-    let stdout = io::stdout();
-    let stdout = &mut stdout.lock();
-
-    for (key, value) in list {
-        let _ = stdout
-            .write(key.as_bytes())
-            .and_then(|_| stdout.write_all(b" = "))
-            .and_then(|_| stdout.write_all(value.as_bytes()))
-            .and_then(|_| stdout.write_all(b"\n"));
-    }
-}
-
-enum Binding {
-    InvalidKey(Identifier),
-    ListEntries,
-    KeyOnly(Identifier),
-    KeyValue(Identifier, Value),
-    Math(Identifier, Operator, f32),
-    MathInvalid(Value),
-}
-
-enum Operator {
-    Plus,
-    Minus,
-    Divide,
-    Multiply,
-}
-
-/// Parses alias as a `(key, value)` tuple.
-fn parse_alias(args: &str) -> Binding {
-    // Write all the arguments into a single `String`
-    let mut char_iter = args.chars();
-
-    // Find the key and advance the iterator until the equals operator is found.
-    let mut key = "".to_owned();
-    let mut found_key = false;
-    let mut operator = None;
-
-    // Scans through characters until the key is found, then continues to scan until
-    // the equals operator is found.
-    while let Some(character) = char_iter.next() {
-        match character {
-            ' ' if key.is_empty() => (),
-            ' ' => found_key = true,
-            '+' => {
-                if char_iter.next() == Some('=') {
-                    operator = Some(Operator::Plus);
-                    found_key = true;
-                }
-                break;
-            }
-            '-' => {
-                if char_iter.next() == Some('=') {
-                    operator = Some(Operator::Minus);
-                    found_key = true;
-                }
-                break;
-            }
-            '*' => {
-                if char_iter.next() == Some('=') {
-                    operator = Some(Operator::Multiply);
-                    found_key = true;
-                }
-                break;
-            }
-            '/' => {
-                if char_iter.next() == Some('=') {
-                    operator = Some(Operator::Divide);
-                    found_key = true;
-                }
-                break;
-            }
-            '=' => {
-                found_key = true;
-                break;
-            }
-            _ if !found_key => key.push(character),
-            _ => (),
-        }
-    }
-
-    let key: Identifier = key.into();
-
-    if !found_key && key.is_empty() {
-        Binding::ListEntries
-    } else {
-        let value: Value = char_iter.skip_while(|&x| x == ' ').collect();
-        if value.is_empty() {
-            Binding::KeyOnly(key)
-        } else if !Variables::is_valid_variable_name(&key) {
-            Binding::InvalidKey(key)
-        } else {
-            match operator {
-                Some(operator) => match value.parse::<f32>() {
-                    Ok(value) => Binding::Math(key, operator, value),
-                    Err(_) => Binding::MathInvalid(value),
-                },
-                None => Binding::KeyValue(key, value),
-            }
-        }
-    }
-}
-
-/// The `alias` command will define an alias for another command, and thus may be used as a
-/// command itself.
-pub(crate) fn alias(vars: &mut Variables, args: &str) -> i32 {
-    match parse_alias(args) {
-        Binding::InvalidKey(key) => {
-            eprintln!("ion: alias name, '{}', is invalid", key);
-            return FAILURE;
-        }
-        Binding::KeyValue(key, value) => {
-            vars.aliases.insert(key, value);
-        }
-        Binding::ListEntries => print_list(&vars.aliases),
-        Binding::KeyOnly(key) => {
-            eprintln!("ion: please provide value for alias '{}'", key);
-            return FAILURE;
-        }
-        _ => {
-            eprintln!("ion: invalid alias syntax");
-            return FAILURE;
-        }
-    }
-    SUCCESS
-}
 
 /// Dropping an alias will erase it from the shell.
 pub(crate) fn drop_alias<I: IntoIterator>(vars: &mut Variables, args: I) -> i32
@@ -204,6 +74,7 @@ mod test {
     use super::*;
     use parser::{expand_string, Expander};
     use shell::status::{FAILURE, SUCCESS};
+    use types::*;
 
     struct VariableExpander(pub Variables);
 

--- a/src/lib/parser/mod.rs
+++ b/src/lib/parser/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod assignments;
 mod loops;
 pub(crate) mod pipelines;
 pub(crate) mod shell_expand;
+pub(crate) mod variables;
 mod statement;
 mod quotes;
 

--- a/src/lib/parser/statement/parse.rs
+++ b/src/lib/parser/statement/parse.rs
@@ -3,7 +3,7 @@ use super::functions::{collect_arguments, parse_function};
 use super::super::{pipelines, ArgumentSplitter};
 use super::super::assignments::{split_assignment, Operator};
 use super::super::pipelines::Pipeline;
-use shell::flow_control::{Case, ElseIf, ExportAction, LocalAction, Statement};
+use shell::flow_control::{Case, ElseIf, ExportAction, LocalAction, Statement, AliasAction};
 use std::char;
 
 fn collect<F>(arguments: &str, statement: F) -> Statement
@@ -219,6 +219,11 @@ pub(crate) fn parse(code: &str) -> Statement {
             return Statement::Time(Box::new(parse(cmd[4..].trim_left())))
         }
         _ if cmd.eq("time") => return Statement::Time(Box::new(Statement::Default)),
+        _ if cmd.eq("alias") => return Statement::Alias(AliasAction::List),
+        _ if cmd.starts_with("alias ") => {
+            let args = cmd[6..].trim_left();
+            return Statement::Alias(AliasAction::Assign(args.to_owned()));
+        }
         _ => (),
     }
 

--- a/src/lib/parser/variables.rs
+++ b/src/lib/parser/variables.rs
@@ -60,7 +60,9 @@ fn parse_alias(args: &str) -> Binding {
     if !found_key && key.is_empty() {
         Binding::ListEntries
     } else {
-        let value: Value = char_iter.skip_while(|&x| x == ' ').collect();
+        let mut value: Value = char_iter.skip_while(|&x| x == ' ').collect();
+        value = value.trim_matches(|x| x == '\"' || x == '\'').to_owned();
+
         if value.is_empty() {
             Binding::KeyOnly(key)
         } else if !is_valid_key(&key) {

--- a/src/lib/parser/variables.rs
+++ b/src/lib/parser/variables.rs
@@ -63,12 +63,16 @@ fn parse_alias(args: &str) -> Binding {
         let value: Value = char_iter.skip_while(|&x| x == ' ').collect();
         if value.is_empty() {
             Binding::KeyOnly(key)
-        } else if !Variables::is_valid_variable_name(&key) {
+        } else if !is_valid_key(&key) {
             Binding::InvalidKey(key)
         } else {
             Binding::KeyValue(key, value)
         }
     }
+}
+
+fn is_valid_key(name: &str) -> bool {
+    name.chars().all(|x| x.is_alphanumeric() || x == '_' || x == '+' || x == '-')
 }
 
 /// The `alias` command will define an alias for another command, and thus may be used as a

--- a/src/lib/parser/variables.rs
+++ b/src/lib/parser/variables.rs
@@ -1,0 +1,93 @@
+
+use std::io::{self, Write};
+
+use shell::status::*;
+use shell::variables::Variables;
+use types::*;
+
+/// Prints all aliases as `Key = Value`. 
+pub(crate) fn print_list(list: &VariableContext) {
+    let stdout = io::stdout();
+    let stdout = &mut stdout.lock();
+
+    for (key, value) in list {
+        let _ = stdout
+            .write(key.as_bytes())
+            .and_then(|_| stdout.write_all(b" = "))
+            .and_then(|_| stdout.write_all(value.as_bytes()))
+            .and_then(|_| stdout.write_all(b"\n"));
+    }
+}
+
+pub enum Binding {
+    InvalidKey(Identifier),
+    ListEntries,
+    KeyOnly(Identifier),
+    KeyValue(Identifier, Value),
+}
+
+/// Parse alias as a `(key, value)` tuple.
+fn parse_alias(args: &str) -> Binding {
+    // Write all the arguments into a single `String`. 
+    let mut char_iter = args.chars();
+
+    // Find the key and advance the iterator until the equals operator is found 
+    let mut key = "".to_owned();
+    let mut found_key = false;
+    // Scans through characters until the key is found, then continues to scan until
+    // the equals operator is found.
+    while let Some(character) = char_iter.next()  {
+        match character {
+            ' ' if key.is_empty() => (),
+            ' ' => {
+                found_key = true;
+                break;
+            }
+            '=' if key.is_empty() => (),
+            '=' => {
+                found_key = true;
+                break;
+            }
+            _  => {
+                key.push(character);
+                ()
+            }
+        }
+    }
+
+    let key: Identifier = key.into();
+
+    if !found_key && key.is_empty() {
+        Binding::ListEntries
+    } else {
+        let value: Value = char_iter.skip_while(|&x| x == ' ').collect();
+        if value.is_empty() {
+            Binding::KeyOnly(key)
+        } else if !Variables::is_valid_variable_name(&key) {
+            Binding::InvalidKey(key)
+        } else {
+            Binding::KeyValue(key, value)
+        }
+    }
+}
+
+/// The `alias` command will define an alias for another command, and thus may be used as a
+/// command itself.
+pub(crate) fn alias(vars: &mut Variables, args: &str) -> i32 {
+    match parse_alias(args) {
+        Binding::InvalidKey(key) => {
+            eprintln!("ion: alias name, '{}', is invalid", key);
+            return FAILURE;
+        }
+        Binding::KeyValue(key, value) => {
+            vars.aliases.insert(key, value);
+        }
+        Binding::ListEntries => print_list(&vars.aliases),
+        Binding::KeyOnly(key) => {
+            eprintln!("ion: please provide value for alias '{}'", key);
+            return FAILURE;
+        }
+    }
+    SUCCESS
+}
+

--- a/src/lib/shell/flow.rs
+++ b/src/lib/shell/flow.rs
@@ -1,9 +1,9 @@
 use super::Shell;
 use super::flags::*;
-use super::flow_control::{collect_cases, collect_if, collect_loops, Case, ElseIf, Function, Statement};
+use super::flow_control::{collect_cases, collect_if, collect_loops, Case, ElseIf, Function, Statement, AliasAction};
 use super::job_control::JobControl;
 use super::status::*;
-use parser::{expand_string, parse_and_validate, ForExpression, StatementSplitter};
+use parser::{expand_string, parse_and_validate, variables, ForExpression, StatementSplitter};
 use parser::assignments::{is_array, ReturnValue};
 use parser::pipelines::Pipeline;
 use shell::assignments::VariableStore;
@@ -781,6 +781,16 @@ impl FlowLogic for Shell {
                     self.flow_control.current_statement =
                         Statement::Time(Box::new(self.flow_control.current_statement.clone()));
                 }
+            }
+            Statement::Alias(stmt) => {
+                match stmt {
+                    AliasAction::List => {
+                        variables::print_list(&self.variables.aliases);
+                    }
+                    AliasAction::Assign(args) => {
+                        variables::alias(&mut self.variables, &args);
+                    }
+                };
             }
             // At this level, else and else if keywords are forbidden.
             Statement::ElseIf { .. } | Statement::Else => {

--- a/src/lib/shell/flow_control.rs
+++ b/src/lib/shell/flow_control.rs
@@ -53,6 +53,11 @@ pub(crate) enum ExportAction {
     LocalExport(String),
     Assign(String, Operator, String),
 }
+#[derive(Debug, PartialEq, Clone)]
+pub(crate) enum AliasAction {
+    List,
+    Assign(String)
+}
 
 // TODO: Enable statements and expressions to contain &str values.
 #[derive(Debug, PartialEq, Clone)]
@@ -93,6 +98,7 @@ pub(crate) enum Statement {
     Continue,
     Pipeline(Pipeline),
     Time(Box<Statement>),
+    Alias(AliasAction),
     Default,
 }
 
@@ -115,6 +121,7 @@ impl Statement {
             Statement::Continue => "Continue",
             Statement::Pipeline(_) => "Pipeline { .. }",
             Statement::Time(_) => "Time { .. }",
+            Statement::Alias(_) => "Alias { .. }",
             Statement::Default => "Default",
         }
     }
@@ -291,6 +298,7 @@ where
             | Statement::Let { .. }
             | Statement::Pipeline(_)
             | Statement::Time(_)
+            | Statement::Alias(_)
             | Statement::Break => {
                 // This is the default case with all of the other statements explicitly listed
                 add_to_case!(statement);

--- a/src/lib/shell/variables/mod.rs
+++ b/src/lib/shell/variables/mod.rs
@@ -286,7 +286,7 @@ impl Variables {
     }
 
     pub(crate) fn is_valid_variable_character(c: char) -> bool {
-        c.is_alphanumeric() || c == '_' || c == '?'
+        c.is_alphanumeric() || c == '_' || c == '+' || c == '-'
     }
 
     pub(crate) fn is_valid_variable_name(name: &str) -> bool {

--- a/src/lib/shell/variables/mod.rs
+++ b/src/lib/shell/variables/mod.rs
@@ -286,7 +286,7 @@ impl Variables {
     }
 
     pub(crate) fn is_valid_variable_character(c: char) -> bool {
-        c.is_alphanumeric() || c == '_' || c == '+' || c == '-'
+        c.is_alphanumeric() || c == '_' || c == '?'
     }
 
     pub(crate) fn is_valid_variable_name(name: &str) -> bool {


### PR DESCRIPTION
Alias Reimplementation as discussed in #711 

**Changes introduced by this pull request**:

- Removed Math Expressions parser from `parse_alias`. 
- Alias reimplemented as a keyword exactly like `let` or `export`. 

**Drawbacks**: 
I have made an assumption in my code that might be considered a drawback.

The assumption is that, Any value stored in `alias` will always resolve to a `Statement::Pipeline`, I don't know what should be the appropriate behaviour if it does not resolves to a `Statement::Pipeline`, So, It silently ignores that `PipeItem`. 

**TODOs**:
- Tests(I'll add those if and once this PR is approved)

**Fixes**:
#711 

**State**:
WIP, Everything except for the tests is done.

