### PR TITLE
and/or followed by let results in command not found (fixes #619)

### DIFF
--- a/src/lib/builtins/man_pages.rs
+++ b/src/lib/builtins/man_pages.rs
@@ -495,57 +495,6 @@ EXAMPLES
         matches x xs
 "#;
 
-pub(crate) const MAN_NOT: &'static str = r#"NAME
-    not - reverses the exit status of a job
-
-SYNOPSIS
-    not
-
-DESCRIPTION
-    not reverses the exit status of a job. If the exit status is 1 not returns 0 and vice versa.
-"#;
-
-pub(crate) const MAN_AND: &'static str = r#"NAME
-    and - check if to execute another command and a boolean gate.
-
-SYNOPSIS
-    COMMAND and COMMAND
-    COMMAND; and COMMAND
-
-DESCRIPTION
-    and changes the exit status to 0 if the previous command and the next command are true. 
-    and can also be used to execute multiple commands if they all are successful. '&&' is preferred to 'and'
-    in if, while and all other similar conditional statements.  
-
-EXAMPLES
-    Returns an exit of status 0:
-        true and true
-    Returns an exit of status 1:
-        true and false
-
-    Executes all the commands:
-        echo "1"; and echo "2"
-    Executes no commands:
-        false; and echo "1"
-"#;
-
-pub(crate) const MAN_OR: &'static str = r#"NAME
-    or - conditionally run a command
-
-SYNOPSIS
-    COMMAND; or COMMAND
-
-DESCRIPTION
-    or can be used to execute a command if the exit status of the previous command is not 0.
-    or can also be used in if, while and other similar statements, however '||' is preferred.
-
-EXAMPLE
-    Executes all of the code block, prints 2:
-        false; or echo "2" 
-    Does not execute all of the code block, prints 1:
-        echo "1"; or echo "2"
-"#;
-
 pub(crate) const MAN_EXISTS: &'static str = r#"NAME
     exists - check whether items exist
 

--- a/src/lib/builtins/mod.rs
+++ b/src/lib/builtins/mod.rs
@@ -73,7 +73,6 @@ macro_rules! map {
 /// Builtins are in A-Z order.
 pub const BUILTINS: &'static BuiltinMap = &map!(
     "alias" => builtin_alias : "View, set or unset aliases",
-    "and" => builtin_and : "Execute the command if the shell's previous status is success",
     "bg" => builtin_bg : "Resumes a stopped background process",
     "bool" => builtin_bool : "If the value is '1' or 'true', return 0 exit status",
     "calc" => builtin_calc : "Calculate a mathematical expression",
@@ -99,7 +98,6 @@ pub const BUILTINS: &'static BuiltinMap = &map!(
     "jobs" => builtin_jobs : "Displays all jobs that are attached to the background",
     "matches" => builtin_matches : "Checks if a string matches a given regex",
     "not" => builtin_not : "Reverses the exit status value of the given command.",
-    "or" => builtin_or : "Execute the command if the shell's previous status is failure",
     "popd" => builtin_popd : "Pop a directory from the stack",
     "pushd" => builtin_pushd : "Push a directory to the stack",
     "random" => builtin_random : "Outputs a random u64",
@@ -563,32 +561,6 @@ fn builtin_not(args: &[&str], shell: &mut Shell) -> i32 {
     match shell.previous_status {
         SUCCESS => FAILURE,
         FAILURE => SUCCESS,
-        _ => shell.previous_status,
-    }
-}
-
-fn builtin_and(args: &[&str], shell: &mut Shell) -> i32 {
-    if check_help(args, MAN_AND) {
-        return SUCCESS;
-    }
-    match shell.previous_status {
-        SUCCESS => {
-            shell.run_pipeline(&mut args_to_pipeline(&args[1..]));
-            shell.previous_status
-        }
-        _ => shell.previous_status,
-    }
-}
-
-fn builtin_or(args: &[&str], shell: &mut Shell) -> i32 {
-    if check_help(args, MAN_OR) {
-        return SUCCESS;
-    }
-    match shell.previous_status {
-        FAILURE => {
-            shell.run_pipeline(&mut args_to_pipeline(&args[1..]));
-            shell.previous_status
-        }
         _ => shell.previous_status,
     }
 }

--- a/src/lib/parser/statement/mod.rs
+++ b/src/lib/parser/statement/mod.rs
@@ -9,9 +9,9 @@ use shell::flow_control::Statement;
 
 /// Parses a given statement string and return's the corresponding mapped
 /// `Statement`
-pub(crate) fn parse_and_validate<'a>(statement: Result<&str, StatementError<'a>>) -> Statement {
+pub(crate) fn parse_and_validate<'a>(statement: Result<String, StatementError>) -> Statement {
     match statement {
-        Ok(statement) => parse(statement),
+        Ok(statement) => parse(statement.as_str()),
         Err(err) => {
             eprintln!("ion: {}", err);
             Statement::Error(-1)

--- a/src/lib/parser/statement/parse.rs
+++ b/src/lib/parser/statement/parse.rs
@@ -219,6 +219,14 @@ pub(crate) fn parse(code: &str) -> Statement {
             return Statement::Time(Box::new(parse(cmd[4..].trim_left())))
         }
         _ if cmd.eq("time") => return Statement::Time(Box::new(Statement::Default)),
+        _ if cmd.starts_with("and ") => {
+            return Statement::And(Box::new(parse(cmd[3..].trim_left())))
+        }
+        _ if cmd.eq("and") => return Statement::And(Box::new(Statement::Default)),
+        _ if cmd.starts_with("or ") => {
+            return Statement::Or(Box::new(parse(cmd[2..].trim_left())))
+        }
+        _ if cmd.eq("or") => return Statement::Or(Box::new(Statement::Default)),
         _ => (),
     }
 

--- a/src/lib/parser/statement/parse.rs
+++ b/src/lib/parser/statement/parse.rs
@@ -227,6 +227,10 @@ pub(crate) fn parse(code: &str) -> Statement {
             return Statement::Or(Box::new(parse(cmd[2..].trim_left())))
         }
         _ if cmd.eq("or") => return Statement::Or(Box::new(Statement::Default)),
+        _ if cmd.starts_with("not ") => {
+            return Statement::Not(Box::new(parse(cmd[3..].trim_left())))
+        }
+        _ if cmd.eq("not") => return Statement::Not(Box::new(Statement::Default)),
         _ => (),
     }
 

--- a/src/lib/parser/statement/splitter.rs
+++ b/src/lib/parser/statement/splitter.rs
@@ -4,6 +4,7 @@
 
 use std::fmt::{self, Display, Formatter};
 use std::u16;
+use std::cmp::max;
 
 bitflags! {
     pub struct Flags : u16 {
@@ -21,8 +22,8 @@ bitflags! {
 }
 
 #[derive(Debug, PartialEq)]
-pub(crate) enum StatementError<'a> {
-    IllegalCommandName(&'a str),
+pub(crate) enum StatementError {
+    IllegalCommandName(String),
     InvalidCharacter(char, usize),
     UnterminatedSubshell,
     UnterminatedBracedVar,
@@ -32,10 +33,10 @@ pub(crate) enum StatementError<'a> {
     ExpectedCommandButFound(&'static str),
 }
 
-impl<'a> Display for StatementError<'a> {
+impl Display for StatementError {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match *self {
-            StatementError::IllegalCommandName(command) => {
+            StatementError::IllegalCommandName(ref command) => {
                 writeln!(f, "illegal command name: {}", command)
             }
             StatementError::InvalidCharacter(character, position) => writeln!(
@@ -67,8 +68,8 @@ fn is_invalid(byte: u8) -> bool {
         || (byte >= 123 && byte <= 127)
 }
 
-pub(crate) struct StatementSplitter<'a> {
-    data:             &'a str,
+pub(crate) struct StatementSplitter {
+    data:             String,
     read:             usize,
     flags:            Flags,
     a_level:          u8,
@@ -78,8 +79,8 @@ pub(crate) struct StatementSplitter<'a> {
     math_paren_level: i8,
 }
 
-impl<'a> StatementSplitter<'a> {
-    pub(crate) fn new(data: &'a str) -> StatementSplitter<'a> {
+impl<'a> StatementSplitter {
+    pub(crate) fn new(data: String) -> StatementSplitter {
         StatementSplitter {
             data:             data,
             read:             0,
@@ -107,15 +108,16 @@ impl<'a> StatementSplitter<'a> {
     }
 }
 
-impl<'a> Iterator for StatementSplitter<'a> {
-    type Item = Result<&'a str, StatementError<'a>>;
-    fn next(&mut self) -> Option<Result<&'a str, StatementError<'a>>> {
+impl Iterator for StatementSplitter {
+    type Item = Result<String, StatementError>;
+    fn next(&mut self) -> Option<Result<String, StatementError>> {
         let start = self.read;
         let mut first_arg_found = false;
         let mut else_found = false;
         let mut else_pos = 0;
         let mut error = None;
-        let mut bytes = self.data.bytes().skip(self.read);
+        let c = self.data.clone();
+        let mut bytes = c.bytes().skip(self.read);
         while let Some(character) = bytes.next() {
             self.read += 1;
             match character {
@@ -232,9 +234,52 @@ impl<'a> Iterator for StatementSplitter<'a> {
                 {
                     return match error {
                         Some(error) => Some(Err(error)),
-                        None => Some(Ok(self.data[start..self.read - 1].trim())),
+                        None => Some(Ok(String::from(self.data[start..self.read - 1].trim()))),
                     }
                 }
+                b'&' if !self.flags.contains(Flags::DQUOTE) && self.p_level == 0
+                    && self.ap_level == 0 =>
+                {
+                    if self.data.len() > self.read {
+                        match self.data.as_bytes()[self.read] {
+                            b'&' => {
+                                // insert and into data
+                                let c = self.data.clone();
+                                let (statement, rest) = c.split_at(self.read);
+                                self.data = String::from("and ");
+                                self.data.push_str(&rest[1..]);
+                                self.read = 0;
+                                return match error {
+                                    Some(error) => Some(Err(error)),
+                                    None => Some(Ok(String::from(statement[..max(statement.len()-2,0)].trim()))),
+                                }
+                            }
+                            _ => ()
+                        }
+                    }
+                }
+                b'|' if !self.flags.contains(Flags::DQUOTE) && self.p_level == 0
+                    && self.ap_level == 0 =>
+                {
+                    if self.data.len() > self.read {
+                        match self.data.as_bytes()[self.read] {
+                            b'|' => {
+                                // insert and into data
+                                let c = self.data.clone();
+                                let (statement, rest) = c.split_at(self.read);
+                                self.data = String::from("or ");
+                                self.data.push_str(&rest[1..]);
+                                self.read = 0;
+                                return match error {
+                                    Some(error) => Some(Err(error)),
+                                    None => Some(Ok(String::from(statement[..max(statement.len()-2,0)].trim()))),
+                                }
+                            }
+                            _ => ()
+                        }
+                    }
+                }
+
                 b'#' if self.read == 1
                     || (!self.flags.contains(Flags::DQUOTE) && self.p_level + self.ap_level == 0
                         && match self.data.as_bytes()[self.read - 2] {
@@ -246,7 +291,7 @@ impl<'a> Iterator for StatementSplitter<'a> {
                     self.read = self.data.len();
                     return match error {
                         Some(error) => Some(Err(error)),
-                        None => Some(Ok(output)),
+                        None => Some(Ok(String::from(output))),
                     };
                 }
                 b' ' if else_found => {
@@ -254,7 +299,7 @@ impl<'a> Iterator for StatementSplitter<'a> {
                     if !output.is_empty() {
                         if "if" != *output {
                             self.read = else_pos;
-                            return Some(Ok("else"));
+                            return Some(Ok(String::from("else")));
                         }
                     }
                     else_found = false;
@@ -305,7 +350,7 @@ impl<'a> Iterator for StatementSplitter<'a> {
                 None => {
                     let output = self.data[start..].trim();
                     if output.is_empty() {
-                        return Some(Ok(output));
+                        return Some(Ok(String::from(output)));
                     }
                     match output.as_bytes()[0] {
                         b'>' | b'<' | b'^' => {
@@ -314,9 +359,9 @@ impl<'a> Iterator for StatementSplitter<'a> {
                         b'|' => Some(Err(StatementError::ExpectedCommandButFound("pipe"))),
                         b'&' => Some(Err(StatementError::ExpectedCommandButFound("&"))),
                         b'*' | b'%' | b'?' | b'{' | b'}' => {
-                            Some(Err(StatementError::IllegalCommandName(output)))
+                            Some(Err(StatementError::IllegalCommandName(String::from(output))))
                         }
-                        _ => Some(Ok(output)),
+                        _ => Some(Ok(String::from(output))),
                     }
                 }
             }

--- a/src/lib/parser/statement/splitter.rs
+++ b/src/lib/parser/statement/splitter.rs
@@ -372,7 +372,7 @@ impl Iterator for StatementSplitter {
 #[test]
 fn syntax_errors() {
     let command = "echo (echo one); echo $( (echo one); echo ) two; echo $(echo one";
-    let results = StatementSplitter::new(command).collect::<Vec<Result<&str, StatementError>>>();
+    let results = StatementSplitter::new(String::from(command)).collect::<Vec<Result<String, StatementError>>>();
     assert_eq!(results[0], Err(StatementError::InvalidCharacter('(', 6)));
     assert_eq!(results[1], Err(StatementError::InvalidCharacter('(', 26)));
     assert_eq!(results[2], Err(StatementError::InvalidCharacter(')', 43)));
@@ -380,7 +380,7 @@ fn syntax_errors() {
     assert_eq!(results.len(), 4);
 
     let command = ">echo";
-    let results = StatementSplitter::new(command).collect::<Vec<Result<&str, StatementError>>>();
+    let results = StatementSplitter::new(String::from(command)).collect::<Vec<Result<String, StatementError>>>();
     assert_eq!(
         results[0],
         Err(StatementError::ExpectedCommandButFound("redirection"))
@@ -388,7 +388,7 @@ fn syntax_errors() {
     assert_eq!(results.len(), 1);
 
     let command = "echo $((foo bar baz)";
-    let results = StatementSplitter::new(command).collect::<Vec<_>>();
+    let results = StatementSplitter::new(String::from(command)).collect::<Vec<_>>();
     assert_eq!(results[0], Err(StatementError::UnterminatedArithmetic));
     assert_eq!(results.len(), 1);
 }
@@ -396,84 +396,84 @@ fn syntax_errors() {
 #[test]
 fn methods() {
     let command = "echo $join(array, ', '); echo @join(var, ', ')";
-    let statements = StatementSplitter::new(command).collect::<Vec<_>>();
-    assert_eq!(statements[0], Ok("echo $join(array, ', ')"));
-    assert_eq!(statements[1], Ok("echo @join(var, ', ')"));
+    let statements = StatementSplitter::new(String::from(command)).collect::<Vec<_>>();
+    assert_eq!(statements[0], Ok(String::from("echo $join(array, ', ')")));
+    assert_eq!(statements[1], Ok(String::from("echo @join(var, ', ')")));
     assert_eq!(statements.len(), 2);
 }
 
 #[test]
 fn processes() {
     let command = "echo $(seq 1 10); echo $(seq 1 10)";
-    for statement in StatementSplitter::new(command) {
-        assert_eq!(statement, Ok("echo $(seq 1 10)"));
+    for statement in StatementSplitter::new(String::from(command)) {
+        assert_eq!(statement, Ok(String::from("echo $(seq 1 10)")));
     }
 }
 
 #[test]
 fn array_processes() {
     let command = "echo @(echo one; sleep 1); echo @(echo one; sleep 1)";
-    for statement in StatementSplitter::new(command) {
-        assert_eq!(statement, Ok("echo @(echo one; sleep 1)"));
+    for statement in StatementSplitter::new(String::from(command)) {
+        assert_eq!(statement, Ok(String::from("echo @(echo one; sleep 1)")));
     }
 }
 
 #[test]
 fn process_with_statements() {
     let command = "echo $(seq 1 10; seq 1 10)";
-    for statement in StatementSplitter::new(command) {
-        assert_eq!(statement, Ok(command));
+    for statement in StatementSplitter::new(String::from(command)) {
+        assert_eq!(statement, Ok(String::from(command)));
     }
 }
 
 #[test]
 fn quotes() {
     let command = "echo \"This ;'is a test\"; echo 'This ;\" is also a test'";
-    let results = StatementSplitter::new(command).collect::<Vec<Result<&str, StatementError>>>();
+    let results = StatementSplitter::new(String::from(command)).collect::<Vec<Result<String, StatementError>>>();
     assert_eq!(results.len(), 2);
-    assert_eq!(results[0], Ok("echo \"This ;'is a test\""));
-    assert_eq!(results[1], Ok("echo 'This ;\" is also a test'"));
+    assert_eq!(results[0], Ok(String::from("echo \"This ;'is a test\"")));
+    assert_eq!(results[1], Ok(String::from("echo 'This ;\" is also a test'")));
 }
 
 #[test]
 fn comments() {
     let command = "echo $(echo one # two); echo three # four";
-    let results = StatementSplitter::new(command).collect::<Vec<Result<&str, StatementError>>>();
+    let results = StatementSplitter::new(String::from(command)).collect::<Vec<Result<String, StatementError>>>();
     assert_eq!(results.len(), 2);
-    assert_eq!(results[0], Ok("echo $(echo one # two)"));
-    assert_eq!(results[1], Ok("echo three"));
+    assert_eq!(results[0], Ok(String::from("echo $(echo one # two)")));
+    assert_eq!(results[1], Ok(String::from("echo three")));
 }
 
 #[test]
 fn nested_process() {
     let command = "echo $(echo one $(echo two) three)";
-    let results = StatementSplitter::new(command).collect::<Vec<Result<&str, StatementError>>>();
+    let results = StatementSplitter::new(String::from(command)).collect::<Vec<Result<String, StatementError>>>();
     assert_eq!(results.len(), 1);
-    assert_eq!(results[0], Ok(command));
+    assert_eq!(results[0], Ok(String::from(command)));
 
     let command = "echo $(echo $(echo one; echo two); echo two)";
-    let results = StatementSplitter::new(command).collect::<Vec<Result<&str, StatementError>>>();
+    let results = StatementSplitter::new(String::from(command)).collect::<Vec<Result<String, StatementError>>>();
     assert_eq!(results.len(), 1);
-    assert_eq!(results[0], Ok(command));
+    assert_eq!(results[0], Ok(String::from(command)));
 }
 
 #[test]
 fn nested_array_process() {
     let command = "echo @(echo one @(echo two) three)";
-    let results = StatementSplitter::new(command).collect::<Vec<Result<&str, StatementError>>>();
+    let results = StatementSplitter::new(String::from(command)).collect::<Vec<Result<String, StatementError>>>();
     assert_eq!(results.len(), 1);
-    assert_eq!(results[0], Ok(command));
+    assert_eq!(results[0], Ok(String::from(command)));
 
     let command = "echo @(echo @(echo one; echo two); echo two)";
-    let results = StatementSplitter::new(command).collect::<Vec<Result<&str, StatementError>>>();
+    let results = StatementSplitter::new(String::from(command)).collect::<Vec<Result<String, StatementError>>>();
     assert_eq!(results.len(), 1);
-    assert_eq!(results[0], Ok(command));
+    assert_eq!(results[0], Ok(String::from(command)));
 }
 
 #[test]
 fn braced_variables() {
     let command = "echo ${foo}bar ${bar}baz ${baz}quux @{zardoz}wibble";
-    let results = StatementSplitter::new(command).collect::<Vec<Result<&str, StatementError>>>();
+    let results = StatementSplitter::new(String::from(command)).collect::<Vec<Result<String, StatementError>>>();
     assert_eq!(results.len(), 1);
-    assert_eq!(results, vec![Ok(command)]);
+    assert_eq!(results, vec![Ok(String::from(command))]);
 }

--- a/src/lib/shell/flow.rs
+++ b/src/lib/shell/flow.rs
@@ -270,6 +270,7 @@ impl FlowLogic for Shell {
                                 SUCCESS => shell.previous_status = FAILURE,
                                 _ => ()
                             }
+                            shell.variables.set_var("?", &shell.previous_status.to_string());
                         }
                         _ => (),
                     }
@@ -555,12 +556,8 @@ impl FlowLogic for Shell {
                     SUCCESS => self.previous_status = FAILURE,
                     _ => ()
                 }
-                match condition {
-                    Condition::Break => return Condition::Break,
-                    Condition::Continue => return Condition::Continue,
-                    Condition::NoOp => (),
-                    Condition::SigInt => return Condition::SigInt,
-                }
+                let status = self.previous_status.to_string();
+                self.set_var("?", &status);
             }
             Statement::Break => return Condition::Break,
             Statement::Continue => return Condition::Continue,
@@ -912,6 +909,8 @@ impl FlowLogic for Shell {
                         SUCCESS => self.previous_status = FAILURE,
                         _ => ()
                     }
+                    let status = self.previous_status.to_string();
+                    self.set_var("?", &status);
                 } else {
                     // A statement wasn't executed , which means that current_statement has been
                     // set to the inner statement. We fix this here.

--- a/src/lib/shell/flow.rs
+++ b/src/lib/shell/flow.rs
@@ -72,7 +72,7 @@ pub(crate) trait FlowLogic {
 impl FlowLogic for Shell {
     fn on_command(&mut self, command_string: &str) {
         self.break_flow = false;
-        let mut iterator = StatementSplitter::new(command_string).map(parse_and_validate);
+        let mut iterator = StatementSplitter::new(String::from(command_string)).map(parse_and_validate);
 
         // If the value is set to `0`, this means that we don't need to append to an
         // existing partial statement block in memory, but can read and execute

--- a/src/lib/shell/flow_control.rs
+++ b/src/lib/shell/flow_control.rs
@@ -93,6 +93,8 @@ pub(crate) enum Statement {
     Continue,
     Pipeline(Pipeline),
     Time(Box<Statement>),
+    And(Box<Statement>),
+    Or(Box<Statement>),
     Default,
 }
 
@@ -115,6 +117,8 @@ impl Statement {
             Statement::Continue => "Continue",
             Statement::Pipeline(_) => "Pipeline { .. }",
             Statement::Time(_) => "Time { .. }",
+            Statement::And(_) => "And { .. }",
+            Statement::Or(_) => "Or { .. }",
             Statement::Default => "Default",
         }
     }
@@ -291,6 +295,8 @@ where
             | Statement::Let { .. }
             | Statement::Pipeline(_)
             | Statement::Time(_)
+            | Statement::And(_)
+            | Statement::Or(_)
             | Statement::Break => {
                 // This is the default case with all of the other statements explicitly listed
                 add_to_case!(statement);
@@ -314,6 +320,32 @@ pub(crate) fn collect_loops<I: Iterator<Item = Statement>>(
             | Statement::Function { .. }
             | Statement::Match { .. } => *level += 1,
             Statement::Time(ref box_stmt) => match box_stmt.as_ref() {
+                &Statement::While { .. }
+                | &Statement::For { .. }
+                | &Statement::If { .. }
+                | &Statement::Function { .. }
+                | &Statement::Match { .. } => *level += 1,
+                &Statement::End if *level == 1 => {
+                    *level = 0;
+                    break;
+                }
+                &Statement::End => *level -= 1,
+                _ => (),
+            },
+            Statement::And(ref box_stmt) => match box_stmt.as_ref() {
+                &Statement::While { .. }
+                | &Statement::For { .. }
+                | &Statement::If { .. }
+                | &Statement::Function { .. }
+                | &Statement::Match { .. } => *level += 1,
+                &Statement::End if *level == 1 => {
+                    *level = 0;
+                    break;
+                }
+                &Statement::End => *level -= 1,
+                _ => (),
+            },
+            Statement::Or(ref box_stmt) => match box_stmt.as_ref() {
                 &Statement::While { .. }
                 | &Statement::For { .. }
                 | &Statement::If { .. }


### PR DESCRIPTION
**Problem**: [describe the problem you try to solve with this PR.]
and/or must be converted into keywords
**Solution**: [describe carefully what you change by this PR.]
followed suggestions in the issue discussion. Copied `Statement::Time` template
