### PR TITLE
Allow functions to be called with not all variables provided

### DIFF
--- a/src/lib/shell/flow_control.rs
+++ b/src/lib/shell/flow_control.rs
@@ -178,7 +178,7 @@ impl Function {
     pub(crate) fn get_description<'a>(&'a self) -> Option<&'a String> { self.description.as_ref() }
 
     pub(crate) fn execute(self, shell: &mut Shell, args: &[&str]) -> Result<(), FunctionError> {
-        if args.len() - 1 != self.args.len() {
+        if args.len() - 1 > self.args.len() {
             return Err(FunctionError::InvalidArgumentCount);
         }
 


### PR DESCRIPTION
**Problem:**
Some use cases require a function to be versatile, and be able to provide optional arguments. For example, the build scripts for packages in the Gentoo and Exherbo linux distributions are all written in bash. Package management is done via a complex (but very nice) framework of bash scripts that provide functions for anything one would want to do. Many functions have default behaviors for unprovided variables: for example, take option() from [Exherbo's cgit](https://git.exherbo.org/paludis/paludis.git/tree/paludis/repositories/e/ebuild/exheres-0/list_functions.bash).

```
option()
{
    [[ "${#@}" -gt 3 ]] && die "$0 takes at most three arguments"
    optionq "${1}"
    local r=$?
    if [[ ${r} -eq 0 ]] ; then
        [[ -n "${2}" ]] && echo "${2}"
    else
        [[ -n "${3}" ]] && echo "${3}"
    fi
    return ${r}
}
```

**Solution:**
Change the check for the correct number of arguments so that this succeeds, when it used to fail:
```
#!/usr/bin/env ion
fn foo a b c
    echo $a $b $c
end
foo bar
```

**Other Tidbit:**
Another thing that I don't see how is possible is the "edo" command in Exherbo. In the build scripts, any command can be just wrapped around edo to print the command to stdout in addition to being executed. A code snippet is taken from [here](https://git.exherbo.org/paludis/paludis.git/tree/paludis/repositories/e/ebuild/exheres-0/build_functions.bash).
```
edo()
{
    echo "$@" 1>&2
    "$@" || paludis_die_unless_nonfatal "$* failed" || return 247
}
```

This PR is just some food for thought, and some real world ways I use bash. :)