### PR TITLE
Increase default HISTFILE_SIZE to 100000

### DIFF
--- a/manual/src/ch14-00-history.md
+++ b/manual/src/ch14-00-history.md
@@ -100,4 +100,4 @@ Defaults to **$HOME/.local/share/ion/history**
 ### HISTFILE_SIZE
 Specifies how many commands should be saved in `HISTFILE` at most.
 Ideally, this should have the same value as `HISTORY_SIZE`.
-Defaults to **1000**.
+Defaults to **100000**.

--- a/src/lib/shell/variables/mod.rs
+++ b/src/lib/shell/variables/mod.rs
@@ -33,7 +33,7 @@ impl Default for Variables {
         let mut map = FnvHashMap::with_capacity_and_hasher(64, Default::default());
         map.insert("DIRECTORY_STACK_SIZE".into(), "1000".into());
         map.insert("HISTORY_SIZE".into(), "1000".into());
-        map.insert("HISTFILE_SIZE".into(), "1000".into());
+        map.insert("HISTFILE_SIZE".into(), "100000".into());
         map.insert(
             "PROMPT".into(),
             "${x::1B}]0;${USER}: \


### PR DESCRIPTION
I recently reached the default HISTFILE_SIZE limit of 1000 and actually had to spend a bit of time figuring out what the problem is.

I think the current default of 1000 is much too low.
There's really no reason to constrain this to a low value as far as I can see.

I know other shells don't even disable history by default or also have very low limits, but those have historical bagge of running on very small systems.

100_000 seems much more reasonable to me.