### PR TITLE
Fix descending inclusive ranges

### DIFF
--- a/src/lib/parser/shell_expand/ranges.rs
+++ b/src/lib/parser/shell_expand/ranges.rs
@@ -58,7 +58,7 @@ fn numeric_range(
         stepped_range_numeric(start, end, step)
     } else if start > end {
         if inclusive {
-            end += if end <= 0 { -1 } else { 1 };
+            end -= 1;
         }
         stepped_range_numeric(start, end, step)
     } else {


### PR DESCRIPTION
**Problem**:
Descending inclusive range brace expansions calculated its limits incorrectly.

For example the expression `{20...10}` returned:
```
20 19 18 17 16 15 14 13 12
```
instead of
```
20 19 18 17 16 15 14 13 12 11 10
```

**State**:
Ready

**Other**:
The range tests in Ion are a bit lacking of edge cases, so I stress tested the fix [with this script](https://gist.github.com/xTibor/67e83e5e72d6503af4ae41b88be9523d) just to make sure I'm not introducing any regressions.
