### PR TITLE
Unterminated Brace Panic

### DIFF
--- a/examples/arrays_with_braces.ion
+++ b/examples/arrays_with_braces.ion
@@ -1,0 +1,7 @@
+echo [{ }]
+
+echo [{a b c}]
+
+echo [a{b c} d]
+
+echo [a{b,c d} e]

--- a/examples/arrays_with_braces.out
+++ b/examples/arrays_with_braces.out
@@ -1,0 +1,4 @@
+ 
+a b c
+ab c d
+ab ac d e

--- a/src/lib/parser/arguments.rs
+++ b/src/lib/parser/arguments.rs
@@ -58,7 +58,7 @@ impl<'a> Iterator for ArgumentSplitter<'a> {
         }
         let start = self.read;
 
-        let (mut level, mut alevel) = (0, 0);
+        let (mut level, mut alevel, mut blevel) = (0, 0, 0);
         let mut bytes = data.iter().cloned().skip(self.read);
         while let Some(character) = bytes.next() {
             match character {
@@ -88,6 +88,9 @@ impl<'a> Iterator for ArgumentSplitter<'a> {
                 b'[' => alevel += 1,
                 // Decrement the array level
                 b']' => alevel -= 1,
+
+                b'{' => blevel += 1,
+                b'}' => blevel -= 1,
 
                 b'(' => {
                     // Disable VARIAB + ARRAY and enable METHOD.
@@ -125,7 +128,7 @@ impl<'a> Iterator for ArgumentSplitter<'a> {
                 b' ' => {
                     if !self.bitflags
                         .intersects(ArgumentFlags::DOUBLE | ArgumentFlags::METHOD)
-                        && level == 0 && alevel == 0
+                        && level == 0 && alevel == 0 && blevel == 0
                     {
                         break;
                     }


### PR DESCRIPTION
**Problem**:
Unterminated brace panic on ```echo [{ }]```

Caused by ```ArgumentSplitter``` - ```[{ }]``` gets parsed to ```Array('{', '}')```, resulting in the ```brace_expander``` panicking when it recieves only ```'{'```.

**Solution**:
Change the behaviour of ArgumentSplitter to only split by space when not in the middle of a pair of braces (as already happens with arrays).

**Changes introduced by this pull request**:
- Adds ```b'{'``` and ```b'}'``` arms to ```ArgumentSplitter::next``` which increment and decrement ```blevel``` respectively.  As with arrays, ```ArgumentSplitter``` only splits on space when ```blevel = 0```.
- Adds integration test ```arrays_with_braces.ion```

**Fixes**:
fixes #707 

**State**:
Ready