### PR TITLE
Remove previous and/or logic

### DIFF
--- a/src/lib/parser/pipelines/mod.rs
+++ b/src/lib/parser/pipelines/mod.rs
@@ -122,8 +122,6 @@ impl fmt::Display for Pipeline {
             }
             match kind {
                 JobKind::Last => (),
-                JobKind::And => tokens.push("&&".into()),
-                JobKind::Or => tokens.push("||".into()),
                 JobKind::Background => tokens.push("&".into()),
                 JobKind::Disown => tokens.push("&!".into()),
                 JobKind::Pipe(RedirectFrom::Stdout) => tokens.push("|".into()),

--- a/src/lib/shell/pipe_exec/mod.rs
+++ b/src/lib/shell/pipe_exec/mod.rs
@@ -8,7 +8,7 @@
 pub mod foreground;
 mod fork;
 pub mod job_control;
-mod streams;
+pub mod streams;
 
 use self::{
     fork::fork_pipe,
@@ -35,6 +35,7 @@ use std::{
     path::Path,
     process::{self, exit},
 };
+use smallvec::SmallVec;
 use sys;
 
 type RefinedItem = (RefinedJob, JobKind, Vec<Redirection>, Vec<Input>);
@@ -246,7 +247,7 @@ fn do_redirection(piped_commands: Vec<RefinedItem>) -> Option<Vec<(RefinedJob, J
 
     // Real logic begins here
     let mut new_commands = Vec::new();
-    let mut prev_kind = JobKind::And;
+    let mut prev_kind = JobKind::Last;
     for (mut job, kind, outputs, mut inputs) in piped_commands {
         match (inputs.len(), prev_kind) {
             (0, _) => {}
@@ -368,7 +369,7 @@ pub(crate) trait PipelineExecution {
 
     /// Waits for all of the children of the assigned pgid to finish executing, returning the
     /// exit status of the last process in the queue.
-    fn wait(&mut self, pgid: u32, commands: Vec<RefinedJob>) -> i32;
+    fn wait(&mut self, pgid: u32, commands: SmallVec<[RefinedJob; 16]>) -> i32;
 
     /// Executes a `RefinedJob` that was created in the `generate_commands` method.
     ///
@@ -626,70 +627,26 @@ impl PipelineExecution for Shell {
     }
 
     fn exec_job(&mut self, job: &mut RefinedJob, _foreground: bool) -> i32 {
-        let long = job.long();
-        match *job {
-            RefinedJob::External {
-                ref name,
-                ref args,
-                ref stdin,
-                ref stdout,
-                ref stderr,
-            } => {
-                if let Ok((stdin_bk, stdout_bk, stderr_bk)) = duplicate_streams() {
-                    let args: Vec<&str> = args.iter().skip(1).map(|x| x as &str).collect();
-                    let code = self.exec_external(&name, &args, stdin, stdout, stderr);
-                    redirect_streams(stdin_bk, stdout_bk, stderr_bk);
-                    return code;
-                }
-                eprintln!(
-                    "ion: failed to `dup` STDOUT, STDIN, or STDERR: not running '{}'",
-                    long
-                );
-                COULD_NOT_EXEC
+        // Duplicate file descriptors, execute command, and redirect back.
+        fn duplicate<F: FnMut() -> i32>(long: &str, mut func: F) -> i32 {
+            if let Ok((stdin_bk, stdout_bk, stderr_bk)) = duplicate_streams() {
+                let code = func();
+                redirect_streams(stdin_bk, stdout_bk, stderr_bk);
+                return code;
             }
-            RefinedJob::Builtin {
-                main,
-                ref args,
-                ref stdin,
-                ref stdout,
-                ref stderr,
-            } => {
-                if let Ok((stdin_bk, stdout_bk, stderr_bk)) = duplicate_streams() {
-                    let args: Vec<&str> = args.iter().map(|x| x as &str).collect();
-                    let code = self.exec_builtin(main, &args, stdout, stderr, stdin);
-                    redirect_streams(stdin_bk, stdout_bk, stderr_bk);
-                    return code;
-                }
-                eprintln!(
-                    "ion: failed to `dup` STDOUT, STDIN, or STDERR: not running '{}'",
-                    long
-                );
-                COULD_NOT_EXEC
-            }
-            RefinedJob::Function {
-                ref name,
-                ref args,
-                ref stdin,
-                ref stdout,
-                ref stderr,
-            } => {
-                if let Ok((stdin_bk, stdout_bk, stderr_bk)) = duplicate_streams() {
-                    let args: Vec<&str> = args.iter().map(|x| x as &str).collect();
-                    let code = self.exec_function(name, &args, stdout, stderr, stdin);
-                    redirect_streams(stdin_bk, stdout_bk, stderr_bk);
-                    return code;
-                }
-                eprintln!(
-                    "ion: failed to `dup` STDOUT, STDIN, or STDERR: not running '{}'",
-                    long
-                );
-                COULD_NOT_EXEC
-            }
-            _ => panic!("exec job should not be able to be called on Cat or Tee jobs"),
+
+            eprintln!(
+                "ion: failed to `dup` STDOUT, STDIN, or STDERR: not running '{}'",
+                long
+            );
+
+            COULD_NOT_EXEC
         }
+
+        duplicate(&job.long(), move || job.exec(self))
     }
 
-    fn wait(&mut self, pgid: u32, commands: Vec<RefinedJob>) -> i32 {
+    fn wait(&mut self, pgid: u32, commands: SmallVec<[RefinedJob; 16]>) -> i32 {
         // TODO: Find a way to only do this when absolutely necessary.
         let as_string = commands
             .iter()
@@ -778,31 +735,6 @@ impl PipelineExecution for Shell {
     }
 }
 
-/// When the `&&` or `||` operator is utilized, commands should be executed
-/// based on the previously-recorded exit status. This function will return
-/// **true** to indicate that the current job should be skipped.
-fn should_skip(previous: &mut JobKind, previous_status: i32, current: JobKind) -> bool {
-    match *previous {
-        JobKind::And if previous_status != SUCCESS => {
-            *previous = if JobKind::Or == current {
-                current
-            } else {
-                *previous
-            };
-            true
-        }
-        JobKind::Or if previous_status == SUCCESS => {
-            *previous = if JobKind::And == current {
-                current
-            } else {
-                *previous
-            };
-            true
-        }
-        _ => false,
-    }
-}
-
 /// Executes a piped job `job1 | job2 | job3`
 ///
 /// This function will panic if called with an empty slice
@@ -812,21 +744,16 @@ pub(crate) fn pipe(
     foreground: bool,
 ) -> i32 {
     let mut previous_status = SUCCESS;
-    let mut previous_kind = JobKind::And;
     let mut commands = commands.into_iter().peekable();
     let mut possible_external_stdio_pipes: Option<Vec<File>> = None;
 
     loop {
         if let Some((mut parent, mut kind)) = commands.next() {
-            if should_skip(&mut previous_kind, previous_status, kind) {
-                continue;
-            }
-
             match kind {
                 JobKind::Pipe(mut mode) => {
                     // We need to remember the commands as they own the file
                     // descriptors that are created by sys::pipe.
-                    let mut remember = Vec::new();
+                    let remember: SmallVec<[RefinedJob; 16]> = SmallVec::new();
                     let mut block_child = true;
                     let (mut pgid, mut last_pid, mut current_pid) = (0, 0, 0);
 
@@ -962,7 +889,6 @@ pub(crate) fn pipe(
                         }
                     }
 
-                    previous_kind = kind;
                     previous_status = shell.wait(pgid, remember);
                     let _ = io::stdout().flush();
                     let _ = io::stderr().flush();
@@ -975,7 +901,6 @@ pub(crate) fn pipe(
                 }
                 _ => {
                     previous_status = shell.exec_job(&mut parent, foreground);
-                    previous_kind = kind;
                     let _ = io::stdout().flush();
                     let _ = io::stderr().flush();
                 }


### PR DESCRIPTION
Now that the statement splitter is handling this, there's no reason to leave this older logic lying around to trip on.