### PR TITLE
Miscellaneous refactors

### DIFF
--- a/src/lib/builtins/mod.rs
+++ b/src/lib/builtins/mod.rs
@@ -165,7 +165,7 @@ pub fn builtin_cd(args: &[&str], shell: &mut Shell) -> i32 {
                         shell.set_var("OLDPWD", pwd);
                         shell.set_var("PWD", current_dir);
                     }
-                    fork_function(shell, "CD_CHANGE", &["ion"]);
+                    fork_function(shell, "CD_CHANGE", &mut ["ion"].iter());
                 }
                 Err(_) => env::set_var("PWD", "?"),
             };

--- a/src/lib/parser/statement/case.rs
+++ b/src/lib/parser/statement/case.rs
@@ -36,7 +36,13 @@ pub(crate) fn parse_case<'a>(
                 binding = Some(splitter.next().ok_or(CaseError::NoBindVariable)?);
                 match splitter.next() {
                     Some("if") => {
-                        let string = splitter.collect::<Vec<_>>().join(" ");
+                        // Joining by folding is more efficient than collecting into Vec and then joining
+                        let mut string = splitter.fold(String::with_capacity(5), |mut state, element| {
+                            state.push_str(element);
+                            state.push(' ');
+                            state
+                        });
+                        string.pop(); // Pop out the unneeded ' ' character
                         if string.is_empty() {
                             return Err(CaseError::NoConditional);
                         }
@@ -47,7 +53,13 @@ pub(crate) fn parse_case<'a>(
                 }
             }
             Some("if") => {
-                let string = splitter.collect::<Vec<_>>().join(" ");
+                // Joining by folding is more efficient than collecting into Vec and then joining
+                let mut string = splitter.fold(String::with_capacity(5), |mut state, element| {
+                    state.push_str(element);
+                    state.push(' ');
+                    state
+                });
+                string.pop(); // Pop out the unneeded ' ' character
                 if string.is_empty() {
                     return Err(CaseError::NoConditional);
                 }

--- a/src/lib/shell/binary/prompt.rs
+++ b/src/lib/shell/binary/prompt.rs
@@ -20,7 +20,7 @@ pub(crate) fn prompt_fn(shell: &mut Shell) -> Option<String> {
     let mut output = None;
 
     match shell.fork(Capture::StdoutThenIgnoreStderr, |child| unsafe {
-        let _ = function.read().execute(child, &["ion"]);
+        let _ = function.read().execute(child, &mut ["ion"].iter());
     }) {
         Ok(result) => {
             let mut string = String::with_capacity(1024);

--- a/src/lib/shell/fork_function.rs
+++ b/src/lib/shell/fork_function.rs
@@ -1,14 +1,19 @@
 use super::{Capture, Function, Shell};
+use std::iter::ExactSizeIterator;
 use std::process;
 use sys;
 
 pub(crate) fn command_not_found(shell: &mut Shell, command: &str) -> bool {
-    fork_function(shell, "COMMAND_NOT_FOUND", &["ion", &command])
+    fork_function(shell, "COMMAND_NOT_FOUND", &mut ["ion", &command].iter())
 }
 
 /// High-level function for executing a function programmatically.
 /// NOTE: Always add "ion" as a first argument in `args`.
-pub fn fork_function(shell: &mut Shell, fn_name: &str, args: &[&str]) -> bool {
+pub fn fork_function<I>(shell: &mut Shell, fn_name: &str, args: &mut I) -> bool
+where
+    I: ExactSizeIterator,
+    <I as Iterator>::Item: AsRef<str>,
+{
     let function = match shell.functions.get(fn_name) {
         Some(func) => func as *const Function,
         None => return false,

--- a/src/lib/shell/job.rs
+++ b/src/lib/shell/job.rs
@@ -198,6 +198,11 @@ fn collect_args(args: &[String]) -> SmallVec<[&str; 16]> {
         .collect::<SmallVec<[&str; 16]>>()
 }
 
+fn iter_args<'a>(args: &'a [String]) -> impl ExactSizeIterator<Item = &'a str> {
+    args.iter()
+        .map(|x| x as &str)
+}
+
 impl RefinedJob {
     /// Returns a long description of this job: the commands and arguments
     pub(crate) fn long(&self) -> String {
@@ -253,8 +258,8 @@ impl RefinedJob {
                 ref stdout,
                 ref stderr,
             } => {
-                let args = collect_args(&args);
-                shell.exec_function(name, &args, stdout, stderr, stdin)
+                let mut args = iter_args(&args);
+                shell.exec_function(name, &mut args, stdout, stderr, stdin)
             }
             _ => panic!("exec job should not be able to be called on Cat or Tee jobs"),
         }

--- a/src/lib/shell/job.rs
+++ b/src/lib/shell/job.rs
@@ -198,11 +198,6 @@ fn collect_args(args: &[String]) -> SmallVec<[&str; 16]> {
         .collect::<SmallVec<[&str; 16]>>()
 }
 
-fn iter_args<'a>(args: &'a [String]) -> impl ExactSizeIterator<Item = &'a str> {
-    args.iter()
-        .map(|x| x as &str)
-}
-
 impl RefinedJob {
     /// Returns a long description of this job: the commands and arguments
     pub(crate) fn long(&self) -> String {
@@ -238,8 +233,7 @@ impl RefinedJob {
                 ref stdout,
                 ref stderr,
             } => {
-                let args = collect_args(&args[1..]);
-                shell.exec_external(&name, &args, stdin, stdout, stderr)
+                shell.exec_external(&name, args[1..].iter().map(|s| s.as_ref()), stdin, stdout, stderr)
             }
             RefinedJob::Builtin {
                 main,
@@ -258,8 +252,7 @@ impl RefinedJob {
                 ref stdout,
                 ref stderr,
             } => {
-                let mut args = iter_args(&args);
-                shell.exec_function(name, &mut args, stdout, stderr, stdin)
+                shell.exec_function(name, &mut args.iter(), stdout, stderr, stdin)
             }
             _ => panic!("exec job should not be able to be called on Cat or Tee jobs"),
         }


### PR DESCRIPTION
Another refactor opportunity showed up when I saw that you could just either use iterators directly without having to collect into a `Vec` allocation or just pass them between functions instead of slices when other iterators exist to again avoid said allocations.