### PR TITLE
More optimizations

### DIFF
--- a/src/lib/builtins/echo.rs
+++ b/src/lib/builtins/echo.rs
@@ -1,4 +1,5 @@
 use std::io::{self, BufWriter, Write};
+use smallvec::SmallVec;
 
 bitflags! {
     struct Flags : u8 {
@@ -10,7 +11,7 @@ bitflags! {
 
 pub(crate) fn echo(args: &[&str]) -> Result<(), io::Error> {
     let mut flags = Flags::empty();
-    let mut data: Vec<&str> = vec![];
+    let mut data: SmallVec<[&str; 16]> = SmallVec::with_capacity(16);
 
     for arg in args {
         match *arg {

--- a/src/lib/builtins/job_control.rs
+++ b/src/lib/builtins/job_control.rs
@@ -4,6 +4,7 @@
 use shell::{
     job_control::{JobControl, ProcessState}, signals, status::*, Shell,
 };
+use smallvec::SmallVec;
 
 /// Disowns given process job IDs, and optionally marks jobs to not receive SIGHUP signals.
 /// The `-a` flag selects all jobs, `-r` selects all running jobs, and `-h` specifies to mark
@@ -17,7 +18,7 @@ pub(crate) fn disown(shell: &mut Shell, args: &[&str]) -> Result<(), String> {
     const RUN_JOBS: u8 = 4;
 
     // Set flags and collect all job specs listed as arguments.
-    let mut collected_jobs = Vec::new();
+    let mut collected_jobs: SmallVec<[u32; 16]> = SmallVec::with_capacity(16);
     let mut flags = 0u8;
     for &arg in args {
         match arg {

--- a/src/lib/builtins/variables.rs
+++ b/src/lib/builtins/variables.rs
@@ -134,11 +134,7 @@ pub(crate) fn alias(vars: &mut Variables, args: &str) -> i32 {
 }
 
 /// Dropping an alias will erase it from the shell.
-pub(crate) fn drop_alias<I: IntoIterator>(vars: &mut Variables, args: I) -> i32
-where
-    I::Item: AsRef<str>,
-{
-    let args = args.into_iter().collect::<Vec<I::Item>>();
+pub(crate) fn drop_alias<S: AsRef<str>>(vars: &mut Variables, args: &[S]) -> i32 {
     if args.len() <= 1 {
         eprintln!("ion: you must specify an alias name");
         return FAILURE;
@@ -153,11 +149,7 @@ where
 }
 
 /// Dropping an array will erase it from the shell.
-pub(crate) fn drop_array<I: IntoIterator>(vars: &mut Variables, args: I) -> i32
-where
-    I::Item: AsRef<str>,
-{
-    let args = args.into_iter().collect::<Vec<I::Item>>();
+pub(crate) fn drop_array<S: AsRef<str>>(vars: &mut Variables, args: &[S]) -> i32 {
     if args.len() <= 2 {
         eprintln!("ion: you must specify an array name");
         return FAILURE;
@@ -178,11 +170,7 @@ where
 }
 
 /// Dropping a variable will erase it from the shell.
-pub(crate) fn drop_variable<I: IntoIterator>(vars: &mut Variables, args: I) -> i32
-where
-    I::Item: AsRef<str>,
-{
-    let args = args.into_iter().collect::<Vec<I::Item>>();
+pub(crate) fn drop_variable<S: AsRef<str>>(vars: &mut Variables, args: &[S]) -> i32 {
     if args.len() <= 1 {
         eprintln!("ion: you must specify a variable name");
         return FAILURE;


### PR DESCRIPTION
Either by switching `Vec`s to `SmallVec`s or by passing slices instead of iterators to avoid needing to collect into a `Vec` in the first place.