### PR TITLE
Fix piping issue

### DIFF
--- a/src/lib/builtins/mod.rs
+++ b/src/lib/builtins/mod.rs
@@ -165,7 +165,7 @@ pub fn builtin_cd(args: &[&str], shell: &mut Shell) -> i32 {
                         shell.set_var("OLDPWD", pwd);
                         shell.set_var("PWD", current_dir);
                     }
-                    fork_function(shell, "CD_CHANGE", &mut ["ion"].iter());
+                    fork_function(shell, "CD_CHANGE", &["ion"]);
                 }
                 Err(_) => env::set_var("PWD", "?"),
             };

--- a/src/lib/shell/binary/prompt.rs
+++ b/src/lib/shell/binary/prompt.rs
@@ -20,7 +20,7 @@ pub(crate) fn prompt_fn(shell: &mut Shell) -> Option<String> {
     let mut output = None;
 
     match shell.fork(Capture::StdoutThenIgnoreStderr, |child| unsafe {
-        let _ = function.read().execute(child, &mut ["ion"].iter());
+        let _ = function.read().execute(child, &["ion"]);
     }) {
         Ok(result) => {
             let mut string = String::with_capacity(1024);

--- a/src/lib/shell/flow_control.rs
+++ b/src/lib/shell/flow_control.rs
@@ -2,7 +2,6 @@ use super::{flow::FlowLogic, Shell};
 use fnv::*;
 use parser::{assignments::*, pipelines::Pipeline};
 use std::fmt::{self, Display, Formatter};
-use std::iter::ExactSizeIterator;
 use types::{Identifier, *};
 
 #[derive(Debug, PartialEq, Clone)]
@@ -168,11 +167,7 @@ impl Display for FunctionError {
 }
 
 impl Function {
-    pub(crate) fn execute<'a, I>(self, shell: &mut Shell, args: &mut I) -> Result<(), FunctionError>
-        where
-            I: ExactSizeIterator,
-            <I as Iterator>::Item: AsRef<str>,
-    {
+    pub(crate) fn execute<S: AsRef<str>>(self, shell: &mut Shell, args: &[S]) -> Result<(), FunctionError> {
         if args.len() - 1 != self.args.len() {
             return Err(FunctionError::InvalidArgumentCount);
         }
@@ -183,7 +178,7 @@ impl Function {
         let mut arrays_backup: FnvHashMap<&str, Option<Array>> =
             FnvHashMap::with_capacity_and_hasher(64, Default::default());
 
-        for (type_, value) in self.args.iter().zip(args.skip(1)) {
+        for (type_, value) in self.args.iter().zip(args.iter().skip(1)) {
             let value = match value_check(shell, value.as_ref(), type_.kind) {
                 Ok(value) => value,
                 Err(_) => {

--- a/src/lib/shell/fork_function.rs
+++ b/src/lib/shell/fork_function.rs
@@ -1,19 +1,14 @@
 use super::{Capture, Function, Shell};
-use std::iter::ExactSizeIterator;
 use std::process;
 use sys;
 
 pub(crate) fn command_not_found(shell: &mut Shell, command: &str) -> bool {
-    fork_function(shell, "COMMAND_NOT_FOUND", &mut ["ion", &command].iter())
+    fork_function(shell, "COMMAND_NOT_FOUND", &["ion", command])
 }
 
 /// High-level function for executing a function programmatically.
 /// NOTE: Always add "ion" as a first argument in `args`.
-pub fn fork_function<I>(shell: &mut Shell, fn_name: &str, args: &mut I) -> bool
-where
-    I: ExactSizeIterator,
-    <I as Iterator>::Item: AsRef<str>,
-{
+pub fn fork_function<S: AsRef<str>>(shell: &mut Shell, fn_name: &str, args: &[S]) -> bool {
     let function = match shell.functions.get(fn_name) {
         Some(func) => func as *const Function,
         None => return false,

--- a/src/lib/shell/job.rs
+++ b/src/lib/shell/job.rs
@@ -233,7 +233,7 @@ impl RefinedJob {
                 ref stdout,
                 ref stderr,
             } => {
-                shell.exec_external(&name, args[1..].iter().map(|s| s.as_ref()), stdin, stdout, stderr)
+                shell.exec_external(&name, &args[1..], stdin, stdout, stderr)
             }
             RefinedJob::Builtin {
                 main,
@@ -252,7 +252,7 @@ impl RefinedJob {
                 ref stdout,
                 ref stderr,
             } => {
-                shell.exec_function(name, &mut args.iter(), stdout, stderr, stdin)
+                shell.exec_function(name, args, stdout, stderr, stdin)
             }
             _ => panic!("exec job should not be able to be called on Cat or Tee jobs"),
         }

--- a/src/lib/shell/mod.rs
+++ b/src/lib/shell/mod.rs
@@ -172,11 +172,7 @@ impl<'a> Shell {
 
     /// A method for executing a function with the given `name`, using `args` as the input.
     /// If the function does not exist, an `IonError::DoesNotExist` is returned.
-    pub fn execute_function<I>(&mut self, name: &str, args: &mut I) -> Result<i32, IonError>
-        where
-            I: ExactSizeIterator,
-            <I as Iterator>::Item: AsRef<str>,
-    {
+    pub fn execute_function<S: AsRef<str>>(&mut self, name: &str, args: &[S]) -> Result<i32, IonError> {
         self.functions
             .get_mut(name.into())
             .ok_or(IonError::DoesNotExist)
@@ -295,8 +291,7 @@ impl<'a> Shell {
         } else if let Some(function) = self.functions.get(&pipeline.items[0].job.command).cloned() {
             if !pipeline.requires_piping() {
                 let args: &[String] = pipeline.items[0].job.args.deref();
-                let mut args = args.iter();
-                match function.execute(self, &mut args) {
+                match function.execute(self, args) {
                     Ok(()) => None,
                     Err(FunctionError::InvalidArgumentCount) => {
                         eprintln!("ion: invalid number of function arguments supplied");


### PR DESCRIPTION
This fixes a bug introduced in 9fe1eb26b72b567e71b406361133b75f8652cb97 and 23310ad61e8f26727c04863bfba126a293141ec5 while not having to allocate `Vec`s as done before those revisions by just passing `&[S]` slices everywhere, where `S: AsRef<str>`.