### PR TITLE
Improve StatementSplitter

### DIFF
--- a/src/lib/parser/statement/mod.rs
+++ b/src/lib/parser/statement/mod.rs
@@ -12,8 +12,8 @@ use shell::flow_control::Statement;
 /// `Statement`
 pub(crate) fn parse_and_validate<'a>(statement: Result<StatementVariant, StatementError>) -> Statement {
     match statement {
-        Ok(StatementVariant::And(statement)) => parse(statement),
-        Ok(StatementVariant::Or(statement)) => parse(statement),
+        Ok(StatementVariant::And(statement)) => Statement::And(Box::new(parse(statement))),
+        Ok(StatementVariant::Or(statement)) => Statement::Or(Box::new(parse(statement))),
         Ok(StatementVariant::Default(statement)) => parse(statement),
         Err(err) => {
             eprintln!("ion: {}", err);

--- a/src/lib/parser/statement/mod.rs
+++ b/src/lib/parser/statement/mod.rs
@@ -4,15 +4,17 @@ mod parse;
 mod splitter;
 
 pub(crate) use self::{
-    parse::parse, splitter::{StatementError, StatementSplitter},
+    parse::parse, splitter::{StatementVariant, StatementError, StatementSplitter},
 };
 use shell::flow_control::Statement;
 
 /// Parses a given statement string and return's the corresponding mapped
 /// `Statement`
-pub(crate) fn parse_and_validate<'a>(statement: Result<String, StatementError>) -> Statement {
+pub(crate) fn parse_and_validate<'a>(statement: Result<StatementVariant, StatementError>) -> Statement {
     match statement {
-        Ok(statement) => parse(statement.as_str()),
+        Ok(StatementVariant::And(statement)) => parse(statement),
+        Ok(StatementVariant::Or(statement)) => parse(statement),
+        Ok(StatementVariant::Default(statement)) => parse(statement),
         Err(err) => {
             eprintln!("ion: {}", err);
             Statement::Error(-1)

--- a/src/lib/shell/assignments.rs
+++ b/src/lib/shell/assignments.rs
@@ -20,7 +20,7 @@ fn list_vars(shell: &Shell) {
             let mut vars = array.iter();
             if let Some(ref var) = vars.next() {
                 let _ = buffer.write(["'", var, "', "].concat().as_bytes());
-                vars.for_each(|ref var| {
+                vars.for_each(|var| {
                     let _ = buffer.write(["'", var, "' "].concat().as_bytes());
                 });
             }

--- a/src/lib/shell/binary/mod.rs
+++ b/src/lib/shell/binary/mod.rs
@@ -19,8 +19,8 @@ SYNOPSIS
     ion [ -h | --help ] [-c] [-n] [-v]
 
 DESCRIPTION
-    ion is a commandline shell created to be a faster and easier to use alternative to the 
-    currently available shells. It is not POSIX compliant. 
+    ion is a commandline shell created to be a faster and easier to use alternative to the
+    currently available shells. It is not POSIX compliant.
 
 OPTIONS
     -c
@@ -70,7 +70,7 @@ impl Binary for Shell {
                 && self
                     .variables
                     .tilde_expansion(cmd, &self.directory_stack)
-                    .map_or(false, |ref path| Path::new(path).is_dir())
+                    .map_or(false, |path| Path::new(&path).is_dir())
             {
                 self.save_command_in_history(&[cmd, "/"].concat());
             } else {

--- a/src/lib/shell/flow.rs
+++ b/src/lib/shell/flow.rs
@@ -533,13 +533,10 @@ impl FlowLogic for Shell {
                 }
             }
             Statement::And(box_statement) => {
-                let condition;
-                match self.previous_status {
-                    SUCCESS => {
-                        condition = self.execute_statement(iterator, *box_statement);
-                    }
-                    _ => condition = Condition::NoOp,
-                }
+                let condition = match self.previous_status {
+                    SUCCESS => self.execute_statement(iterator, *box_statement),
+                    _ => Condition::NoOp,
+                };
 
                 match condition {
                     Condition::Break => return Condition::Break,
@@ -549,13 +546,10 @@ impl FlowLogic for Shell {
                 }
             }
             Statement::Or(box_statement) => {
-                let condition;
-                match self.previous_status {
-                    FAILURE => {
-                        condition = self.execute_statement(iterator, *box_statement);
-                    }
-                    _ => condition = Condition::NoOp,
-                }
+                let condition = match self.previous_status {
+                    FAILURE => self.execute_statement(iterator, *box_statement),
+                    _ => Condition::NoOp,
+                };
 
                 match condition {
                     Condition::Break => return Condition::Break,
@@ -565,7 +559,8 @@ impl FlowLogic for Shell {
                 }
             }
             Statement::Not(box_statement) => {
-                let condition = self.execute_statement(iterator, *box_statement);
+                // NOTE: Should the condition be used?
+                let _condition = self.execute_statement(iterator, *box_statement);
                 match self.previous_status {
                     FAILURE => self.previous_status = SUCCESS,
                     SUCCESS => self.previous_status = FAILURE,

--- a/src/lib/shell/flow.rs
+++ b/src/lib/shell/flow.rs
@@ -729,7 +729,7 @@ impl FlowLogic for Shell {
     fn on_command(&mut self, command_string: &str) {
         self.break_flow = false;
         let mut iterator =
-            StatementSplitter::new(String::from(command_string)).map(parse_and_validate);
+            StatementSplitter::new(command_string).map(parse_and_validate);
 
         // If the value is set to `0`, this means that we don't need to append to an
         // existing partial statement block in memory, but can read and execute

--- a/src/lib/shell/job.rs
+++ b/src/lib/shell/job.rs
@@ -3,7 +3,6 @@ use builtins::{BuiltinFunction, BUILTINS};
 use parser::{expand_string, pipelines::RedirectFrom};
 use shell::pipe_exec::PipelineExecution;
 use smallstring::SmallString;
-use smallvec::SmallVec;
 use std::{fmt, fs::File, str};
 use types::*;
 

--- a/src/lib/shell/mod.rs
+++ b/src/lib/shell/mod.rs
@@ -36,7 +36,7 @@ use liner::Context;
 use parser::{pipelines::Pipeline, ArgumentSplitter, Expander, Select, Terminator};
 use smallvec::SmallVec;
 use std::{
-    fs::File, io::{self, Read, Write}, iter::{ExactSizeIterator, FromIterator}, ops::Deref, path::Path, process,
+    fs::File, io::{self, Read, Write}, iter::FromIterator, ops::Deref, path::Path, process,
     sync::{atomic::Ordering, Arc, Mutex}, time::SystemTime,
 };
 use sys;


### PR DESCRIPTION
This is an attempt to have `StatementSplitter` migrate back to returning `&str`s but this needs to be reviewed because this change may make ion either make you breakfast or eat your cat :stuck_out_tongue_winking_eye: 