### PR TITLE
Parsing bug

### DIFF
--- a/examples/pipelines.ion
+++ b/examples/pipelines.ion
@@ -4,3 +4,4 @@ echo foo | grep foo && echo found foo
 echo foo | grep bar || echo did not find bar
 echo test | grep test && echo found test | cat
 
+echo $(im_not_a_command | echo 1)

--- a/examples/pipelines.out
+++ b/examples/pipelines.out
@@ -6,3 +6,4 @@ found foo
 did not find bar
 test
 found test
+1

--- a/src/lib/parser/pipelines/collector.rs
+++ b/src/lib/parser/pipelines/collector.rs
@@ -259,11 +259,11 @@ impl<'a> Collector<'a> {
                                 break;
                             }
                         }
-                        // Reaching this block means that either there is no next byte, or the next
-                        // byte is none of '>' or '|', indicating that this is not the beginning of
-                        // a redirection for stderr
-                        bytes.next();
                     }
+                    // Reaching this block means that either there is no next byte, or the next
+                    // byte is none of '>' or '|', indicating that this is not the beginning of
+                    // a redirection for stderr
+                    bytes.next();
                 }
                 // Evaluate a quoted string but do not return it
                 // We pass in i, the index of a quote, but start a character later. This ensures
@@ -733,6 +733,18 @@ mod tests {
             assert_eq!(Input::File("stuff".into()), pipeline.items[2].inputs[0]);
             assert_eq!("other", pipeline.items[2].outputs[0].file);
             assert!(pipeline.items[2].outputs[0].append);
+        } else {
+            assert!(false);
+        }
+    }
+
+    #[test]
+    // Ensures no regression for infinite loop when args() hits
+    // '^' while not in the top level
+    fn args_loop_terminates() {
+        if let Statement::Pipeline(pipeline) = parse("$(^) '$(^)'") {
+            assert_eq!("$(^)", pipeline.items[0].job.args[0]);
+            assert_eq!("\'$(^)\'", pipeline.items[0].job.args[1]);
         } else {
             assert!(false);
         }

--- a/src/lib/shell/pipe_exec/mod.rs
+++ b/src/lib/shell/pipe_exec/mod.rs
@@ -889,6 +889,8 @@ pub(crate) fn pipe(
                         }
                     }
 
+                    set_process_group(&mut pgid, current_pid);
+
                     previous_status = shell.wait(pgid, remember);
                     let _ = io::stdout().flush();
                     let _ = io::stderr().flush();


### PR DESCRIPTION
fixes #761 

This stops the shell hanging when given ```$(^)```, though it still seems to hang occasionally when given ```$(a | grep ^)``` which I'll look into now