### PR TITLE
Dependency updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "ion"
 path = "src/main.rs"
 
 [build-dependencies]
-ansi_term = "0.10"
+ansi_term = "0.11"
 version_check = "0.1.3"
 
 [dependencies]
@@ -35,7 +35,7 @@ itoa = "0.4"
 lazy_static = "1.0"
 liner = { git = "https://github.com/redox-os/liner" }
 permutate = "0.3"
-rand = "0.4"
+rand = "0.5"
 regex = "1.0"
 smallstring = "0.1"
 smallvec = "0.6"
@@ -52,7 +52,7 @@ panic = "abort"
 [target."cfg(all(unix, not(target_os = \"redox\")))".dependencies]
 libc = "0.2"
 libloading = "0.5"
-users = "0.6"
+users = "0.7"
 
 [target."cfg(target_os = \"redox\")".dependencies]
 redox_syscall = "0.1"

--- a/src/lib/shell/binary/readln.rs
+++ b/src/lib/shell/binary/readln.rs
@@ -27,6 +27,7 @@ pub(crate) fn readln(shell: &mut Shell) -> Option<String> {
 
             let line = shell.context.as_mut().unwrap().read_line(
                 prompt,
+                None,
                 &mut move |Event { editor, kind }| {
                     if let EventKind::BeforeComplete = kind {
                         let (words, pos) = editor.get_words_and_cursor_position();

--- a/src/lib/shell/variables/mod.rs
+++ b/src/lib/shell/variables/mod.rs
@@ -356,7 +356,7 @@ impl Variables {
         if sys::isatty(sys::STDIN_FILENO) {
             let mut con = Context::new();
             for arg in args.into_iter().skip(1) {
-                match con.read_line(format!("{}=", arg.as_ref().trim()), &mut |_| {}) {
+                match con.read_line(format!("{}=", arg.as_ref().trim()), None, &mut |_| {}) {
                     Ok(buffer) => self.set_var(arg.as_ref(), buffer.trim()),
                     Err(_) => return FAILURE,
                 }


### PR DESCRIPTION
* ansi_term 0.10.2 -> 0.11.0
* rand 0.4.2 -> 0.5.0
* users 0.6.1 -> 0.7.0

Fix building after addind in liner syntax highlight in https://github.com/redox-os/liner/pull/3

