### PR TITLE
Have `WordIterator` not split escape characters (Fixes #437)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,11 +8,6 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -96,6 +91,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "decimal"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,7 +158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "ion-shell"
 version = "1.0.0-alpha"
 dependencies = [
- "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "calculate 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -168,13 +171,13 @@ dependencies = [
  "libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "liner 0.4.5 (git+https://github.com/redox-os/liner)",
  "permutate 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallstring 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "users 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "users 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "xdg 2.1.0 (git+https://github.com/whitequark/rust-xdg)",
 ]
@@ -206,7 +209,7 @@ dependencies = [
 [[package]]
 name = "liner"
 version = "0.4.5"
-source = "git+https://github.com/redox-os/liner#37ac2459955d644da9969abe5c3bc3375894c447"
+source = "git+https://github.com/redox-os/liner#4441c4dc37ddf02df43b9f1fe440047db0102119"
 dependencies = [
  "bytecount 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -238,13 +241,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rand"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "redox_syscall"
@@ -401,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "users"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -453,7 +463,6 @@ source = "git+https://github.com/whitequark/rust-xdg#090afef2509d746e48d6bfa9b2e
 
 [metadata]
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
-"checksum ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6b3568b48b7cefa6b8ce125f9bb4989e52fbcc29ebea88df04cc7c5f12f70455"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2fc4a1aa4c24c0718a250f0681885c1af91419d242f29eb8f2ab28502d80dbd1"
 "checksum backtrace 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dbdd17cd962b570302f5297aea8648d5923e22e555c2ed2d8b2e34eca646bf6d"
@@ -464,6 +473,7 @@ source = "git+https://github.com/whitequark/rust-xdg#090afef2509d746e48d6bfa9b2e
 "checksum cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "49ec142f5768efb5b7622aebc3fdbdbb8950a4b9ba996393cb76ef7466e8747d"
 "checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
 "checksum clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0f16b89cbb9ee36d87483dc939fe9f1e13c05898d56d7b230a0d4dff033a536"
+"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum decimal 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e6458723bc760383275fbc02f4c769b2e5f3de782abaf5e7e0b9b7f0368a63ed"
 "checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
 "checksum failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b"
@@ -480,7 +490,8 @@ source = "git+https://github.com/whitequark/rust-xdg#090afef2509d746e48d6bfa9b2e
 "checksum ord_subset 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc65e6e24476e1a5baed530f60b918ff7925539aaae1d59ab51113c991321c40"
 "checksum permutate 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53b7d5b19a715ffab38693a9dd44b067fdfa2b18eef65bd93562dfe507022fae"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
-"checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
+"checksum rand 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "482c45f965103f2433002a0c4d908599f38d1b8c1375e66e801a24c1c6cadc03"
+"checksum rand_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "edecf0f94da5551fc9b492093e30b041a891657db7940ee221f9d2f66e82eef2"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75ecf88252dce580404a22444fc7d626c01815debba56a7f4f536772a5ff19d3"
@@ -503,7 +514,7 @@ source = "git+https://github.com/whitequark/rust-xdg#090afef2509d746e48d6bfa9b2e
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-"checksum users 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a098d836637f965bbe0df8f744088318c43b685ffd46b676ed21036b7c94bae6"
+"checksum users 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "caa2760fcc10a6ae2c2a35d41c5d69827e4663f0d3889ecfb4d60b343f4139df"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"

--- a/src/lib/parser/shell_expand/mod.rs
+++ b/src/lib/parser/shell_expand/mod.rs
@@ -203,23 +203,12 @@ pub(crate) fn expand_string<E: Expander>(
     loop {
         match word_iterator.next() {
             Some(word) => {
-                let word = match word {
-                    WordToken::Brace(value) => {
+                match word {
+                    WordToken::Brace(_) => {
                         contains_brace = true;
-                        WordToken::Brace(value)
                     }
-                    WordToken::Normal(mut output, glob, tilde) => {
-                        if let Some(found) = output.find("\\") {
-                            if output.len() > found {
-                                let mut string = output.to_owned();
-                                string.to_mut().remove(found);
-                                output = string;
-                            }
-                        }
-                        WordToken::Normal(output, glob, tilde)
-                    }
-                    word_token => word_token,
-                };
+                    _ => (),
+                }
                 token_buffer.push(word);
             }
             None if original.is_empty() => {

--- a/src/lib/parser/shell_expand/mod.rs
+++ b/src/lib/parser/shell_expand/mod.rs
@@ -203,13 +203,27 @@ pub(crate) fn expand_string<E: Expander>(
     loop {
         match word_iterator.next() {
             Some(word) => {
-                if let WordToken::Brace(_) = word {
-                    contains_brace = true;
-                }
+                let word = match word {
+                    WordToken::Brace(value) => {
+                        contains_brace = true;
+                        WordToken::Brace(value)
+                    }
+                    WordToken::Normal(mut output, glob, tilde) => {
+                        if let Some(found) = output.find("\\") {
+                            if output.len() > found {
+                                let mut string = output.to_owned();
+                                string.to_mut().remove(found);
+                                output = string;
+                            }
+                        }
+                        WordToken::Normal(output, glob, tilde)
+                    }
+                    word_token => word_token,
+                };
                 token_buffer.push(word);
             }
             None if original.is_empty() => {
-                token_buffer.push(WordToken::Normal("", true, false));
+                token_buffer.push(WordToken::Normal("".into(), true, false));
                 break;
             }
             None => break,
@@ -300,12 +314,12 @@ fn expand_braces<E: Expander>(
 
                 slice(&mut output, expanded, index.clone());
             }
-            WordToken::Normal(text, do_glob, tilde) => {
+            WordToken::Normal(ref text, do_glob, tilde) => {
                 expand(
                     &mut output,
                     &mut expanded_words,
                     expand_func,
-                    text,
+                    text.as_ref(),
                     do_glob,
                     tilde,
                 );
@@ -407,12 +421,12 @@ fn expand_single_string_token<E: Expander>(
 
     match *token {
         WordToken::StringMethod(ref method) => method.handle(&mut output, expand_func),
-        WordToken::Normal(text, do_glob, tilde) => {
+        WordToken::Normal(ref text, do_glob, tilde) => {
             expand(
                 &mut output,
                 &mut expanded_words,
                 expand_func,
-                text,
+                text.as_ref(),
                 do_glob,
                 tilde,
             );
@@ -552,12 +566,12 @@ pub(crate) fn expand_tokens<E: Expander>(
                     method.handle(&mut output, expand_func);
                 }
                 WordToken::Brace(_) => unreachable!(),
-                WordToken::Normal(text, do_glob, tilde) => {
+                WordToken::Normal(ref text, do_glob, tilde) => {
                     expand(
                         &mut output,
                         &mut expanded_words,
                         expand_func,
-                        text,
+                        text.as_ref(),
                         do_glob,
                         tilde,
                     );

--- a/src/lib/parser/shell_expand/words/tests.rs
+++ b/src/lib/parser/shell_expand/words/tests.rs
@@ -47,12 +47,11 @@ fn string_method() {
 
 #[test]
 fn escape_with_backslash() {
-    let input = "\\$FOO\\$BAR \\$FOO";
+    let input = r#"\$FOO\$BAR \$FOO"#;
     let expected = vec![
-        WordToken::Normal("$FOO", false, false),
-        WordToken::Normal("$BAR", false, false),
+        WordToken::Normal("$FOO$BAR".into(), false, false),
         WordToken::Whitespace(" "),
-        WordToken::Normal("$FOO", false, false),
+        WordToken::Normal("$FOO".into(), false, false),
     ];
     compare(input, expected);
 }
@@ -99,7 +98,7 @@ fn array_process_within_string_process() {
     compare(
         "echo $(let free=[@(free -h)]; echo @free[6]@free[8]/@free[7])",
         vec![
-            WordToken::Normal("echo", false, false),
+            WordToken::Normal("echo".into(), false, false),
             WordToken::Whitespace(" "),
             WordToken::Process(
                 "let free=[@(free -h)]; echo @free[6]@free[8]/@free[7]",
@@ -152,7 +151,7 @@ fn string_keys() {
 fn nested_processes() {
     let input = "echo $(echo $(echo one)) $(echo one $(echo two) three)";
     let expected = vec![
-        WordToken::Normal("echo", false, false),
+        WordToken::Normal("echo".into(), false, false),
         WordToken::Whitespace(" "),
         WordToken::Process("echo $(echo one)", false, Select::All),
         WordToken::Whitespace(" "),
@@ -165,7 +164,7 @@ fn nested_processes() {
 fn words_process_with_quotes() {
     let input = "echo $(git branch | rg '[*]' | awk '{print $2}')";
     let expected = vec![
-        WordToken::Normal("echo", false, false),
+        WordToken::Normal("echo".into(), false, false),
         WordToken::Whitespace(" "),
         WordToken::Process(
             "git branch | rg '[*]' | awk '{print $2}'",
@@ -177,7 +176,7 @@ fn words_process_with_quotes() {
 
     let input = "echo $(git branch | rg \"[*]\" | awk '{print $2}')";
     let expected = vec![
-        WordToken::Normal("echo", false, false),
+        WordToken::Normal("echo".into(), false, false),
         WordToken::Whitespace(" "),
         WordToken::Process(
             "git branch | rg \"[*]\" | awk '{print $2}'",
@@ -192,16 +191,16 @@ fn words_process_with_quotes() {
 fn test_words() {
     let input = "echo $ABC \"${ABC}\" one{$ABC,$ABC} ~ $(echo foo) \"$(seq 1 100)\"";
     let expected = vec![
-        WordToken::Normal("echo", false, false),
+        WordToken::Normal("echo".into(), false, false),
         WordToken::Whitespace(" "),
         WordToken::Variable("ABC", false, Select::All),
         WordToken::Whitespace(" "),
         WordToken::Variable("ABC", true, Select::All),
         WordToken::Whitespace(" "),
-        WordToken::Normal("one", false, false),
+        WordToken::Normal("one".into(), false, false),
         WordToken::Brace(vec!["$ABC", "$ABC"]),
         WordToken::Whitespace(" "),
-        WordToken::Normal("~", false, true),
+        WordToken::Normal("~".into(), false, true),
         WordToken::Whitespace(" "),
         WordToken::Process("echo foo", false, Select::All),
         WordToken::Whitespace(" "),
@@ -210,26 +209,22 @@ fn test_words() {
     compare(input, expected);
 }
 
-//#[test]
-//fn test_multiple_escapes() {
-//    let input = "foo\\(\\) bar\\(\\)";
-//    let expected = vec![
-//        WordToken::Normal("foo", false, false),
-//        WordToken::Normal("(", false, false),
-//        WordToken::Normal(")", false, false),
-//        WordToken::Whitespace(" "),
-//        WordToken::Normal("bar", false, false),
-//        WordToken::Normal("(", false, false),
-//        WordToken::Normal(")", false, false),
-//    ];
-//    compare(input, expected);
-//}
+#[test]
+fn test_multiple_escapes() {
+    let input = "foo\\(\\) bar\\(\\)";
+    let expected = vec![
+        WordToken::Normal("foo()".into(), false, false),
+        WordToken::Whitespace(" "),
+        WordToken::Normal("bar()".into(), false, false),
+    ];
+    compare(input, expected);
+}
 
 #[test]
 fn test_arithmetic() {
     let input = "echo $((foo bar baz bing 3 * 2))";
     let expected = vec![
-        WordToken::Normal("echo", false, false),
+        WordToken::Normal("echo".into(), false, false),
         WordToken::Whitespace(" "),
         WordToken::Arithmetic("foo bar baz bing 3 * 2"),
     ];
@@ -240,9 +235,9 @@ fn test_arithmetic() {
 fn test_globbing() {
     let input = "barbaz* bingcrosb*";
     let expected = vec![
-        WordToken::Normal("barbaz*", true, false),
+        WordToken::Normal("barbaz*".into(), true, false),
         WordToken::Whitespace(" "),
-        WordToken::Normal("bingcrosb*", true, false),
+        WordToken::Normal("bingcrosb*".into(), true, false),
     ];
     compare(input, expected);
 }
@@ -251,15 +246,15 @@ fn test_globbing() {
 fn test_empty_strings() {
     let input = "rename '' 0 a \"\"";
     let expected = vec![
-        WordToken::Normal("rename", false, false),
+        WordToken::Normal("rename".into(), false, false),
         WordToken::Whitespace(" "),
-        WordToken::Normal("", false, false),
+        WordToken::Normal("".into(), false, false),
         WordToken::Whitespace(" "),
-        WordToken::Normal("0", false, false),
+        WordToken::Normal("0".into(), false, false),
         WordToken::Whitespace(" "),
-        WordToken::Normal("a", false, false),
+        WordToken::Normal("a".into(), false, false),
         WordToken::Whitespace(" "),
-        WordToken::Normal("", false, false),
+        WordToken::Normal("".into(), false, false),
     ];
     compare(input, expected);
 }

--- a/src/lib/parser/shell_expand/words/tests.rs
+++ b/src/lib/parser/shell_expand/words/tests.rs
@@ -210,20 +210,20 @@ fn test_words() {
     compare(input, expected);
 }
 
-#[test]
-fn test_multiple_escapes() {
-    let input = "foo\\(\\) bar\\(\\)";
-    let expected = vec![
-        WordToken::Normal("foo", false, false),
-        WordToken::Normal("(", false, false),
-        WordToken::Normal(")", false, false),
-        WordToken::Whitespace(" "),
-        WordToken::Normal("bar", false, false),
-        WordToken::Normal("(", false, false),
-        WordToken::Normal(")", false, false),
-    ];
-    compare(input, expected);
-}
+//#[test]
+//fn test_multiple_escapes() {
+//    let input = "foo\\(\\) bar\\(\\)";
+//    let expected = vec![
+//        WordToken::Normal("foo", false, false),
+//        WordToken::Normal("(", false, false),
+//        WordToken::Normal(")", false, false),
+//        WordToken::Whitespace(" "),
+//        WordToken::Normal("bar", false, false),
+//        WordToken::Normal("(", false, false),
+//        WordToken::Normal(")", false, false),
+//    ];
+//    compare(input, expected);
+//}
 
 #[test]
 fn test_arithmetic() {

--- a/src/lib/shell/completer.rs
+++ b/src/lib/shell/completer.rs
@@ -1,4 +1,4 @@
-use super::{directory_stack::DirectoryStack, variables::Variables};
+use super::{directory_stack::DirectoryStack, escape::{escape, unescape}, variables::Variables};
 use glob::glob;
 use liner::{Completer, FilenameCompleter};
 use smallvec::SmallVec;
@@ -147,40 +147,6 @@ where
             .into_iter()
             .map(|x| escape(x.as_str()))
     })
-}
-
-/// Escapes filenames from the completer so that special characters will be properly escaped.
-///
-/// NOTE: Perhaps we should submit a PR to Liner to add a &'static [u8] field to
-/// `FilenameCompleter` so that we don't have to perform the escaping ourselves?
-fn escape(input: &str) -> String {
-    let mut output = Vec::with_capacity(input.len());
-    for character in input.bytes() {
-        match character {
-            b'(' | b')' | b'[' | b']' | b'&' | b'$' | b'@' | b'{' | b'}' | b'<' | b'>' | b';'
-            | b'"' | b'\'' | b'#' | b'^' | b'*' => output.push(b'\\'),
-            _ => (),
-        }
-        output.push(character);
-    }
-    unsafe { String::from_utf8_unchecked(output) }
-}
-
-/// Unescapes filenames to be passed into the completer
-fn unescape(input: &str) -> String {
-    let mut output = Vec::with_capacity(input.len());
-    let mut bytes = input.bytes();
-    while let Some(b) = bytes.next() {
-        match b {
-            b'\\' => if let Some(next) = bytes.next() {
-                output.push(next);
-            } else {
-                output.push(b'\\')
-            },
-            _ => output.push(b),
-        }
-    }
-    unsafe { String::from_utf8_unchecked(output) }
 }
 
 /// A completer that combines suggestions from multiple completers.

--- a/src/lib/shell/escape.rs
+++ b/src/lib/shell/escape.rs
@@ -1,0 +1,33 @@
+/// Escapes filenames from the completer so that special characters will be properly escaped.
+///
+/// NOTE: Perhaps we should submit a PR to Liner to add a &'static [u8] field to
+/// `FilenameCompleter` so that we don't have to perform the escaping ourselves?
+pub(crate) fn escape(input: &str) -> String {
+    let mut output = Vec::with_capacity(input.len());
+    for character in input.bytes() {
+        match character {
+            b'(' | b')' | b'[' | b']' | b'&' | b'$' | b'@' | b'{' | b'}' | b'<' | b'>' | b';'
+            | b'"' | b'\'' | b'#' | b'^' | b'*' => output.push(b'\\'),
+            _ => (),
+        }
+        output.push(character);
+    }
+    unsafe { String::from_utf8_unchecked(output) }
+}
+
+/// Unescapes filenames to be passed into the completer
+pub(crate) fn unescape(input: &str) -> String {
+    let mut output = Vec::with_capacity(input.len());
+    let mut bytes = input.bytes();
+    while let Some(b) = bytes.next() {
+        match b {
+            b'\\' => if let Some(next) = bytes.next() {
+                output.push(next);
+            } else {
+                output.push(b'\\')
+            },
+            _ => output.push(b),
+        }
+    }
+    unsafe { String::from_utf8_unchecked(output) }
+}

--- a/src/lib/shell/mod.rs
+++ b/src/lib/shell/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod binary;
 pub(crate) mod colors;
 mod completer;
 pub(crate) mod directory_stack;
+pub(crate) mod escape;
 pub mod flags;
 mod flow;
 pub(crate) mod flow_control;


### PR DESCRIPTION
Although this solves the problem, it fails a variety amount of integration tests, which probably need to be updated for this different logic. I would like some guidance on how to fix them first.

Closes #437 