### PR TITLE
WIP: Tab completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,8 +171,11 @@ dependencies = [
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.61 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallstring 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "users 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -232,9 +235,25 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "proc-macro2"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "quote"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "quote"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rand"
@@ -295,6 +314,16 @@ version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "serde_derive"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "smallstring"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +354,16 @@ dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -372,6 +411,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.61 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ucd-util"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +436,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-xid"
 version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -479,7 +531,9 @@ source = "git+https://github.com/whitequark/rust-xdg#090afef2509d746e48d6bfa9b2e
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum ord_subset 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc65e6e24476e1a5baed530f60b918ff7925539aaae1d59ab51113c991321c40"
 "checksum permutate 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53b7d5b19a715ffab38693a9dd44b067fdfa2b18eef65bd93562dfe507022fae"
+"checksum proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "effdb53b25cdad54f8f48843d67398f7ef2e14f12c1b4cb4effc549a6462a4d6"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+"checksum quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e44651a0dc4cdd99f71c83b561e221f714912d11af1a4dff0631f923d53af035"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "0a12d51a5b5fd700e6c757f15877685bfa04fd7eb60c108f01d045cafa0073c2"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
@@ -488,20 +542,24 @@ source = "git+https://github.com/whitequark/rust-xdg#090afef2509d746e48d6bfa9b2e
 "checksum rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "76d7ba1feafada44f2d38eed812bd2489a03c0f5abb975799251518b68848649"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum serde 1.0.61 (registry+https://github.com/rust-lang/crates.io-index)" = "d7134c98234af4b842287fa3e40860ccf4e838f8f3c6909bd9da5fe4cbe41ea6"
+"checksum serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)" = "0a90213fa7e0f5eac3f7afe2d5ff6b088af515052cc7303bd68c7e3b91a3fb79"
 "checksum smallstring 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "30950abdb5b38f56a0e181ae56ed64a539b64fa77ea6325147203dc7faeb087f"
 "checksum smallvec 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4f8266519bc1d17d0b5b16f6c21295625d562841c708f6376f49028a43e9c11e"
 "checksum smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03dab98ab5ded3a8b43b2c80751194608d0b2aa0f1d46cf95d1c35e192844aa7"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+"checksum syn 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c67da57e61ebc7b7b6fff56bb34440ca3a83db037320b0507af4c10368deda7d"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
+"checksum toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a0263c6c02c4db6c8f7681f9fd35e90de799ebd4cfdeab77a38f4ff6b3d8c0d9"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum users 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a098d836637f965bbe0df8f744088318c43b685ffd46b676ed21036b7c94bae6"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,11 @@ liner = "0.4"
 permutate = "0.3"
 rand = "0.4"
 regex = "1.0"
+serde = "1.0"
+serde_derive = "1.0"
 smallstring = "0.1"
 smallvec = "0.6"
+toml = "0.4"
 unicode-segmentation = "1.2"
 xdg = { git = "https://github.com/whitequark/rust-xdg" }
 

--- a/completions/_placeholder.toml
+++ b/completions/_placeholder.toml
@@ -1,0 +1,41 @@
+name = "_placeholder"
+
+[params.short]
+flag = [ "" ]
+file = [ [ "" ] ]
+keyvalue = [ [ "" ] ]
+path = [ "" ]
+path_optional = [ "" ]
+string = [ "" ]
+
+[params.long]
+flag = [ "" ]
+file = [ [ "" ] ]
+keyvalue = [ [ "" ] ]
+path = [ "" ]
+path_optional = [ "" ]
+string = [ "" ]
+
+[[commands]]
+name = "add"
+
+[[commands]]
+name = "XXX"
+end_of_params = "--"
+after_params = [ "array", "path" ]
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]

--- a/completions/_placeholder.toml
+++ b/completions/_placeholder.toml
@@ -1,41 +1,62 @@
+# name of the command to complete
 name = "_placeholder"
 
+# short params are prefixed with one dash ("-")
 [params.short]
-flag = [ "" ]
+# file: parameters that take a file name as a patameter
+# the first element of each array is the parameter-name, the remaining elements
+# define a list of file extensions to match
+# e.g. to define a parameter "--file" which matches only files ending with ".rs"
+# and ".ion", do the following:
+# file = [ [ "file", ".ion", ".rs" ] ]
 file = [ [ "" ] ]
+# flags are toggles; they don't take a value
+flag = [ "" ]
+# For parameters that take a number. Currently only integers are supported.
+number = [ "" ]
+# A list of parameters that take key=value pairs as values
+# Format is the same as with "file". Do NOT write the '='
 keyvalue = [ [ "" ] ]
+# For parameters taking a path. If you want to match files with specific file
+# extensions, use "file".
 path = [ "" ]
+# Same as above, however the parameter value is optional. NOT YET IMPLEMENTED.
 path_optional = [ "" ]
-string = [ "" ]
+# Parameters that take a string as a value. Can be used for parameters that take
+# custom types. Same format as for "file" and "keyvalue", where additional
+# elements are a list of options
+string = [ [ "", ""] ]
 
+# short params are prefixed with two dashes ("--")
 [params.long]
-flag = [ "" ]
 file = [ [ "" ] ]
+flag = [ "" ]
+int = [ "" ]
 keyvalue = [ [ "" ] ]
 path = [ "" ]
 path_optional = [ "" ]
-string = [ "" ]
+string = [ [ "", ""] ]
 
+# Many applications have subcommands (e.g. for cargo: "build", "run", "clean")
+# You can define their parameters here. You can have as many commands as you want.
+# IMPORTANT: use double-brackets ("tables" in TOML)
 [[commands]]
-name = "add"
-
-[[commands]]
-name = "XXX"
-end_of_params = "--"
-after_params = [ "array", "path" ]
+name = ""
 
     [commands.params.short]
-    flag = [ "" ]
     file = [ [ "" ] ]
+    flag = [ "" ]
+    int = [ "" ]
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
     [commands.params.long]
-    flag = [ "" ]
     file = [ [ "" ] ]
+    flag = [ "" ]
+    int = [ "" ]
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]

--- a/completions/cargo.toml
+++ b/completions/cargo.toml
@@ -1,0 +1,72 @@
+name = "cargo"
+
+[params.short]
+flag = [ "V", "v", "vv", "q", "h" ]
+string = [ ["Z"] ]
+
+[params.long]
+flag = [
+    "frozen",
+    "help",
+    "list",
+    "locked",
+    "verbose",
+    "version",
+    "quiet",
+]
+string = [
+    [ "explain" ],
+    [ "color", "auto", "always", "never" ],
+]
+
+[[commands]]
+name = "build"
+
+    [commands.params.short]
+    flag = [ "h", "q", "v" ]
+    int = [ "j" ]
+    string = [
+        [ "p" ],
+        [ "Z" ],
+    ]
+
+    [commands.params.long]
+    flag = [
+        "all",
+        "all-features",
+        "all-targets",
+        "benches",
+        "bins",
+        "build-plan",
+        "examples",
+        "frozen",
+        "help",
+        "lib",
+        "locked",
+        "no-default-features",
+        "release",
+        "tests",
+        "quiet",
+        "verbose",
+    ]
+    int = [ "jobs" ]
+    path = [
+        "manifest-path",
+        "out-dir",
+        "target-dir",
+    ]
+    string = [
+        # no support for custom items yet
+        [ "bench" ],
+        [ "bin" ],
+        [ "color", "auto", "always", "never" ],
+        [ "example" ],
+        [ "exclude" ],
+        [ "message-format", "human", "json" ],
+        [ "package" ],
+        [ "target" ],
+        [ "test" ],
+    ]
+    array_string = [
+        "features",
+    ]

--- a/completions/git.toml
+++ b/completions/git.toml
@@ -1,0 +1,68 @@
+[main]
+name = git
+aliases = [ ]
+
+# TODO: positionals
+# TODO "trailing parameters"
+
+[params.short]
+p = flag
+C = path
+c = keyvalue
+
+[params.long]
+version = flag
+help = flag
+html-path = flag
+man-path = flag
+info-path = flag
+paginate = flag
+no-pager = flag
+no-replace-objects = flag
+bare = flag
+exec-path = optional path
+git-dir = path
+work-tree = path
+namespace = string
+
+
+[[command]]
+name = add
+end-of-params = '--'
+after-params = array path
+
+[params.short]
+v = flag
+n = flag
+f = flag
+i = flag
+p = flag
+e = flag
+u = flag
+N = flag
+
+[params.long]
+verbose = flag
+dry-run = flag
+force = flag
+interactive = flag
+patch = flag
+edit = flag
+all = flag
+no-all = flag
+ignore-removal = flag
+no-ignore-removal = flag
+update = flag
+intent-to-add = flag
+refresh = flag
+ignore-errors = flag
+ignore-missing = flag
+renormalize = flag
+chmod = 'special (+|-)x'
+
+
+[[command]]
+name = clone
+
+[[command]]
+name = commit

--- a/completions/git.toml
+++ b/completions/git.toml
@@ -6,6 +6,10 @@ path = [ "C" ]
 keyvalue = [ "c" ]
 
 [params.long]
+path = [
+    "git-dir",
+    "work-tree",
+]
 flag = [
     "version",
     "help",
@@ -17,15 +21,14 @@ flag = [
     "no-replace-object",
     "bare",
 ]
-path = [
-    "git-dir",
-    "work-tree",
-]
 path_optional = [
     "exec-path",
 ]
 string = [
     "namespace",
+]
+file = [
+    [ "test", ".txt", ".md" ],
 ]
 
 [[commands]]
@@ -58,3 +61,6 @@ after_params = [ "array", "path" ]
 
 [[commands]]
 name = "commit"
+
+[[commands]]
+name = "checkout"

--- a/completions/git.toml
+++ b/completions/git.toml
@@ -1,68 +1,60 @@
-[main]
-name = git
-aliases = [ ]
-
-# TODO: positionals
-# TODO "trailing parameters"
+name = "git"
 
 [params.short]
-p = flag
-C = path
-c = keyvalue
+flag = [ "p" ]
+path = [ "C" ]
+keyvalue = [ "c" ]
 
 [params.long]
-version = flag
-help = flag
-html-path = flag
-man-path = flag
-info-path = flag
-paginate = flag
-no-pager = flag
-no-replace-objects = flag
-bare = flag
-exec-path = optional path
-git-dir = path
-work-tree = path
-namespace = string
+flag = [
+    "version",
+    "help",
+    "html-path",
+    "man-path",
+    "info-path",
+    "paginate",
+    "no-pager",
+    "no-replace-object",
+    "bare",
+]
+path = [
+    "git-dir",
+    "work-tree",
+]
+path_optional = [
+    "exec-path",
+]
+string = [
+    "namespace",
+]
 
+[[commands]]
+name = "add"
+end_of_params = "--"
+after_params = [ "array", "path" ]
 
-[[command]]
-name = add
-end-of-params = '--'
-after-params = array path
+    [commands.params.short]
+    flag = [ "v", "n", "f", "i", "p", "e", "u", "N", ]
 
-[params.short]
-v = flag
-n = flag
-f = flag
-i = flag
-p = flag
-e = flag
-u = flag
-N = flag
+    [commands.params.long]
+    flag = [
+        "verbose",
+        "dry-run",
+        "force",
+        "interactive",
+        "patch",
+        "edit",
+        "all",
+        "no-all",
+        "ignore-removal",
+        "no-ignore-removal",
+        "update",
+        "intent-to-add",
+        "refresh",
+        "ignore-errors",
+        "ignore-missing",
+        "renormalize",
+    ]
 
-[params.long]
-verbose = flag
-dry-run = flag
-force = flag
-interactive = flag
-patch = flag
-edit = flag
-all = flag
-no-all = flag
-ignore-removal = flag
-no-ignore-removal = flag
-update = flag
-intent-to-add = flag
-refresh = flag
-ignore-errors = flag
-ignore-missing = flag
-renormalize = flag
-chmod = 'special (+|-)x'
-
-
-[[command]]
-name = clone
-
-[[command]]
-name = commit
+[[commands]]
+name = "commit"

--- a/completions/git.toml
+++ b/completions/git.toml
@@ -69,65 +69,6 @@ after_params = [ "array", "path" ]
         "renormalize",
     ]
 
-[[commands]]
-name = "am"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "archive"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "bisect"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
 
 [[commands]]
 name = "branch"
@@ -138,7 +79,7 @@ name = "branch"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
     [commands.params.long]
     flag = [ "" ]
@@ -146,27 +87,7 @@ name = "branch"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "bundle"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
 
 [[commands]]
@@ -178,7 +99,7 @@ name = "checkout"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
     [commands.params.long]
     flag = [ "" ]
@@ -186,67 +107,7 @@ name = "checkout"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "cherry-pick"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "citool"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "clean"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
 
 [[commands]]
@@ -258,7 +119,7 @@ name = "clone"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
     [commands.params.long]
     flag = [ "" ]
@@ -266,7 +127,7 @@ name = "clone"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
 
 [[commands]]
@@ -278,7 +139,7 @@ name = "commit"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
     [commands.params.long]
     flag = [ "" ]
@@ -286,47 +147,7 @@ name = "commit"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "describe"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "diff"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
 
 [[commands]]
@@ -338,7 +159,7 @@ name = "fetch"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
     [commands.params.long]
     flag = [ "" ]
@@ -346,87 +167,7 @@ name = "fetch"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "format-patch"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "gc"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "grep"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "gui"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
 
 [[commands]]
@@ -438,7 +179,7 @@ name = "init"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
     [commands.params.long]
     flag = [ "" ]
@@ -446,27 +187,7 @@ name = "init"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "log"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
 
 [[commands]]
@@ -478,7 +199,7 @@ name = "merge"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
     [commands.params.long]
     flag = [ "" ]
@@ -486,47 +207,7 @@ name = "merge"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "mv"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "notes"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
 
 [[commands]]
@@ -538,7 +219,7 @@ name = "pull"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
     [commands.params.long]
     flag = [ "" ]
@@ -546,7 +227,7 @@ name = "pull"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
 
 [[commands]]
@@ -558,7 +239,7 @@ name = "push"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
     [commands.params.long]
     flag = [ "" ]
@@ -566,7 +247,7 @@ name = "push"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
 
 [[commands]]
@@ -578,7 +259,7 @@ name = "rebase"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
     [commands.params.long]
     flag = [ "" ]
@@ -586,7 +267,7 @@ name = "rebase"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
 
 [[commands]]
@@ -598,7 +279,7 @@ name = "reset"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
     [commands.params.long]
     flag = [ "" ]
@@ -606,67 +287,7 @@ name = "reset"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "revert"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "rm"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "shortlog"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
 
 [[commands]]
@@ -678,7 +299,7 @@ name = "show"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
     [commands.params.long]
     flag = [ "" ]
@@ -686,7 +307,7 @@ name = "show"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
 
 [[commands]]
@@ -698,7 +319,7 @@ name = "stash"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
     [commands.params.long]
     flag = [ "" ]
@@ -706,7 +327,7 @@ name = "stash"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
 
 [[commands]]
@@ -718,7 +339,7 @@ name = "status"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
     [commands.params.long]
     flag = [ "" ]
@@ -726,7 +347,7 @@ name = "status"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
 
 [[commands]]
@@ -738,7 +359,7 @@ name = "submodule"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
     [commands.params.long]
     flag = [ "" ]
@@ -746,47 +367,7 @@ name = "submodule"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "tag"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "worktree"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
 
 [[commands]]
@@ -798,7 +379,7 @@ name = "config"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
     [commands.params.long]
     flag = [ "" ]
@@ -806,147 +387,7 @@ name = "config"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "fast-export"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "fast-import"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "filter-branch"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "mergetool"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "pack-refs"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "prune"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "reflog"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
 
 [[commands]]
@@ -958,7 +399,7 @@ name = "remote"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
     [commands.params.long]
     flag = [ "" ]
@@ -966,187 +407,7 @@ name = "remote"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "repack"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "replace"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "annotate"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "blame"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "cherry"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "count-objects"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "difftool"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "fsck"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "get-tar-commit-id"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
 
 [[commands]]
@@ -1158,7 +419,7 @@ name = "help"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]
 
     [commands.params.long]
     flag = [ "" ]
@@ -1166,244 +427,4 @@ name = "help"
     keyvalue = [ [ "" ] ]
     path = [ "" ]
     path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "instaweb"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "merge-tree"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "rerere"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "rev-parse"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "show-branch"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "verify-commit"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "verify-tag"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "what-changed"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "archimport"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "cvsexportcommit"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "XXX"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-
-[[commands]]
-name = "cvsimport"
-
-    [commands.params.short]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
-
-    [commands.params.long]
-    flag = [ "" ]
-    file = [ [ "" ] ]
-    keyvalue = [ [ "" ] ]
-    path = [ "" ]
-    path_optional = [ "" ]
-    string = [ "" ]
+    string = [ [ "", ""] ]

--- a/completions/git.toml
+++ b/completions/git.toml
@@ -3,13 +3,15 @@ name = "git"
 [params.short]
 flag = [ "p" ]
 path = [ "C" ]
-keyvalue = [ "c" ]
+keyvalue = [
+    [   "c",
+        "advice.pushUpdateRejected",
+        "advice.pushNonFFCurrent",
+        "core.editor",
+    ],
+]
 
 [params.long]
-path = [
-    "git-dir",
-    "work-tree",
-]
 flag = [
     "version",
     "help",
@@ -20,12 +22,20 @@ flag = [
     "no-pager",
     "no-replace-object",
     "bare",
+    "literal-pathspecs",
+    "glob-pathspecs",
+    "noglob-pathspecs",
+    "icase-pathspecs",
+    "no-optional-locks",
+]
+path = [
+    "git-dir",
+    "work-tree",
+    "namespace",
+    "super-prefix",
 ]
 path_optional = [
     "exec-path",
-]
-string = [
-    "namespace",
 ]
 file = [
     [ "test", ".txt", ".md" ],
@@ -60,7 +70,1340 @@ after_params = [ "array", "path" ]
     ]
 
 [[commands]]
-name = "commit"
+name = "am"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "archive"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "bisect"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "branch"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "bundle"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
 
 [[commands]]
 name = "checkout"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "cherry-pick"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "citool"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "clean"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "clone"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "commit"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "describe"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "diff"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "fetch"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "format-patch"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "gc"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "grep"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "gui"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "init"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "log"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "merge"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "mv"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "notes"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "pull"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "push"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "rebase"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "reset"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "revert"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "rm"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "shortlog"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "show"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "stash"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "status"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "submodule"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "tag"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "worktree"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "config"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "fast-export"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "fast-import"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "filter-branch"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "mergetool"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "pack-refs"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "prune"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "reflog"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "remote"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "repack"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "replace"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "annotate"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "blame"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "cherry"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "count-objects"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "difftool"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "fsck"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "get-tar-commit-id"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "help"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "instaweb"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "merge-tree"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "rerere"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "rev-parse"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "show-branch"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "verify-commit"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "verify-tag"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "what-changed"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "archimport"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "cvsexportcommit"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "XXX"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+
+[[commands]]
+name = "cvsimport"
+
+    [commands.params.short]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]
+
+    [commands.params.long]
+    flag = [ "" ]
+    file = [ [ "" ] ]
+    keyvalue = [ [ "" ] ]
+    path = [ "" ]
+    path_optional = [ "" ]
+    string = [ "" ]

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -22,10 +22,13 @@ extern crate libc;
 extern crate libloading;
 extern crate liner;
 extern crate regex;
+#[macro_use]
+extern crate serde_derive;
 extern crate smallstring;
 extern crate smallvec;
 #[cfg(target_os = "redox")]
 extern crate syscall;
+extern crate toml;
 extern crate unicode_segmentation;
 #[cfg(all(unix, not(target_os = "redox")))]
 extern crate users as users_unix;

--- a/src/lib/shell/binary/mod.rs
+++ b/src/lib/shell/binary/mod.rs
@@ -190,10 +190,14 @@ impl Binary for Shell {
     fn prompt(&mut self) -> String { prompt(self) }
 
     fn load_cmd_completion(&mut self, config: String) -> bool {
-        let completion = completer::CmdCompletion::from_config(config);
-        //let name = completion.get_name();
+        if let Some(completion) = completer::CmdCompletion::from_config(config) {
+            let name = completion.get_name();
+            self.completions.insert(name, completion);
 
-        false
+            true
+        } else {
+            false
+        }
     }
 }
 

--- a/src/lib/shell/binary/mod.rs
+++ b/src/lib/shell/binary/mod.rs
@@ -131,7 +131,9 @@ impl Binary for Shell {
         self.variables
             .set_array("args", iter::once(env::args().next().unwrap()).collect());
 
+        // TODO: load all files from specific directory
         self.load_cmd_completion("./completions/git.toml".to_owned());
+        self.load_cmd_completion("./completions/cargo.toml".to_owned());
 
         loop {
             if let Some(command) = self.readln() {

--- a/src/lib/shell/binary/readln.rs
+++ b/src/lib/shell/binary/readln.rs
@@ -55,7 +55,7 @@ pub(crate) fn readln(shell: &mut Shell) -> Option<String> {
                                     // in the middle of the command
                                     let buffer = editor.current_buffer();
                                     let cmd_so_far = buffer.range(0, buffer.num_chars());
-                                    eprintln!("cmd so far={:?}|pos={:?}", cmd_so_far, pos);
+                                    //eprintln!("cmd so far={:?}|pos={:?}", cmd_so_far, pos);
                                     let completer =
                                         IonCmdCompleter::new(completions, cmd_so_far, pos, dirs_ptr, vars_ptr);
                                     mem::replace(

--- a/src/lib/shell/binary/readln.rs
+++ b/src/lib/shell/binary/readln.rs
@@ -1,9 +1,8 @@
 use super::super::{completer::*, Binary, DirectoryStack, Shell, Variables};
-use fnv::FnvHashMap;
 use liner::{BasicCompleter, CursorPosition, Event, EventKind};
 use smallstring::SmallString;
 use std::{
-    env, io::{self, ErrorKind, Write}, mem, path::PathBuf,
+    collections::HashMap, env, io::{self, ErrorKind, Write}, mem, path::PathBuf,
 };
 use sys;
 use types::*;
@@ -12,7 +11,7 @@ pub(crate) fn readln(shell: &mut Shell) -> Option<String> {
     {
         let vars_ptr = &shell.variables as *const Variables;
         let dirs_ptr = &shell.directory_stack as *const DirectoryStack;
-        let completions = &shell.completions as *const FnvHashMap<String, CmdCompletion>;
+        let completions = &shell.completions as *const HashMap<String, CmdCompletion>;
 
         // Collects the current list of values from history for completion.
         let history = &shell.context.as_ref().unwrap().history.buffers.iter()

--- a/src/lib/shell/mod.rs
+++ b/src/lib/shell/mod.rs
@@ -20,7 +20,7 @@ pub use self::{
     binary::Binary, fork::{Capture, Fork, IonResult},
 };
 pub(crate) use self::{
-    flow::FlowLogic, history::{IgnoreSetting, ShellHistory}, job::{Job, JobKind},
+    completer::CmdCompletion, flow::FlowLogic, history::{IgnoreSetting, ShellHistory}, job::{Job, JobKind},
     pipe_exec::{foreground, job_control},
 };
 
@@ -97,6 +97,10 @@ pub struct Shell {
     /// Stores the patterns used to determine whether a command should be saved in the history
     /// or not
     ignore_setting: IgnoreSetting,
+    /// TODO
+    /// provides no protection against collision attacks, where a malicious user can craft specific
+    /// keys designed to slow a hasher down.
+    completions: FnvHashMap<String, CmdCompletion>,
 }
 
 pub struct ShellBuilder;
@@ -410,6 +414,7 @@ impl<'a> Shell {
             break_flow: false,
             foreground_signals: Arc::new(ForegroundSignals::new()),
             ignore_setting: IgnoreSetting::default(),
+            completions: FnvHashMap::default(),
         }
     }
 }

--- a/src/lib/shell/mod.rs
+++ b/src/lib/shell/mod.rs
@@ -36,7 +36,7 @@ use liner::Context;
 use parser::{pipelines::Pipeline, ArgumentSplitter, Expander, Select, Terminator};
 use smallvec::SmallVec;
 use std::{
-    fs::File, io::{self, Read, Write}, iter::FromIterator, ops::Deref, path::Path, process,
+    collections::HashMap, fs::File, io::{self, Read, Write}, iter::FromIterator, ops::Deref, path::Path, process,
     sync::{atomic::Ordering, Arc, Mutex}, time::SystemTime,
 };
 use sys;
@@ -100,7 +100,7 @@ pub struct Shell {
     /// TODO
     /// provides no protection against collision attacks, where a malicious user can craft specific
     /// keys designed to slow a hasher down.
-    completions: FnvHashMap<String, CmdCompletion>,
+    completions: HashMap<String, CmdCompletion>,
 }
 
 pub struct ShellBuilder;
@@ -414,7 +414,7 @@ impl<'a> Shell {
             break_flow: false,
             foreground_signals: Arc::new(ForegroundSignals::new()),
             ignore_setting: IgnoreSetting::default(),
-            completions: FnvHashMap::default(),
+            completions: HashMap::new(),
         }
     }
 }


### PR DESCRIPTION
**IMPORTANT**
This is sorta, kinda WIP and NOT intended to be merged as it is!
The code still needs a few tweaks, and the commits are not meaningful on their own (I just committed all wip-stuff at once when I made breaks). This is more like a proposal and a basis for discussion.

**Problem**:
This PR adds support for tab completions. See  #397

**Solution**:
The general idea: For each application, there is a user-friendly config file (TOML-format) which defines different types of command line parameters, etc. Currently supported features:
- boolean flags (e.g. `--version`)
- paths
- files with specific file extensions
- numbers
- key=value
- string (aka "everything else that takes custom values") with support for options (predefined list of possible values)

If an application has no completion-config, the default file file completer is used.

**Changes introduced by this pull request**:

- New dependencies: toml, serde
- On startup (in `execute_interactive`), available completion-configs are parsed and saved. **For now, this is hardcoded**, as I'm unsure where we should save such files.
- A new completer (`IonCmdCompleter`) was created, similar to the existing `IonFileCompleter`
- When the user hits tab twice and the application (first word on the command line) has a completion defined, it is examined for possible matches.
- I've added a base ("empty") config file as well as two (unfinished) configs for `cargo` and `git`.

**Drawbacks**:
- I don't know if my code structure/architecture is fine, as I figured out how liner works as I worked on this, so the code may be restructured more cleanly?
- Also, I had to add an unsafe (https://github.com/BafDyce/ion/blob/adb13743757078f021614e89a8820958ea15203e/src/lib/shell/completer.rs#L71) to satisfy the borrow checker. Don't know if this can be avoided by restructuring.
- Aliases (different names for the same application) are not handled/implemented yet.

**TODOs**:
- Discuss whether such a config-file based solution is wanted
- Add support for "dynamic" parameters (list of completions generated at runtime by executing an `ion` script?)
- Add support for "scheme" parameters
- Decide where to save the config files
    - Add hook for installation script
    - Adapt initialization code accordingly
- Fix issue: auto-complete does not work if the cursor is on the right edge of a completed parameter (no space is inserted afterwards)
- Cleanup the code, Add comments
- Rebase onto current master and fix merge conflicts
- We might also want to add a new builtin for (re)loading completions at runtime
- In a next step, we also should implement parsers to import completions of other shells/from man-pages.
- Test on Redox (currently only on Linux tested)
- Add a bunch of completion configs.

**Fixes**: #397

**State**: WIP

**Blocking/related**: None that I know of.

**Other**:
- Is the direction of this PR/proposal good? Or would you rather do it completely script-based (like other shells do)? I think the major advantage of a config-based approach is, that it's easier to set up a new completion ruleset.
- This is WIP and not ready to merge, however I wanted to have you have a look at it before I invest more time in it. Doesn't make sense to continue my efforts if you don't even want such a solution.

I'm open for feedback, however I'll also be busy in the next days.