### PR TITLE
Fine-tune the atomic::ordering for all the atomics

### DIFF
--- a/src/lib/shell/mod.rs
+++ b/src/lib/shell/mod.rs
@@ -180,7 +180,7 @@ impl<'a> Shell<'a> {
                 _ => unreachable!(),
             };
 
-            signals::PENDING.store(signal as usize, Ordering::SeqCst);
+            signals::PENDING.store(signal as usize, Ordering::Relaxed);
         }
 
         unsafe {

--- a/src/lib/shell/signals.rs
+++ b/src/lib/shell/signals.rs
@@ -35,7 +35,7 @@ impl Iterator for SignalHandler {
     type Item = signal::Signal;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match PENDING.swap(0, Ordering::SeqCst) as u8 {
+        match PENDING.swap(0, Ordering::Relaxed) as u8 {
             0 => None,
             SIGINT => Some(signal::Signal::SIGINT),
             SIGHUP => Some(signal::Signal::SIGHUP),


### PR DESCRIPTION
https://github.com/redox-os/ion/blob/0fe51451ddda3797444df06d39519a39e3a31e36/src/lib/shell/pipe_exec/foreground.rs#L30
https://github.com/redox-os/ion/blob/0fe51451ddda3797444df06d39519a39e3a31e36/src/lib/shell/pipe_exec/foreground.rs#L46
https://github.com/redox-os/ion/blob/0fe51451ddda3797444df06d39519a39e3a31e36/src/lib/shell/pipe_exec/foreground.rs#L51
https://github.com/redox-os/ion/blob/0fe51451ddda3797444df06d39519a39e3a31e36/src/lib/shell/pipe_exec/foreground.rs#L57
Here grab is just a signal and doesn't synchronize with other variables. Therefore, Relaxed can be used in both single-threaded and multi-threaded environments.

https://github.com/redox-os/ion/blob/0fe51451ddda3797444df06d39519a39e3a31e36/src/lib/shell/pipe_exec/foreground.rs#L39
https://github.com/redox-os/ion/blob/0fe51451ddda3797444df06d39519a39e3a31e36/src/lib/shell/pipe_exec/foreground.rs#L52
Here status is just a signal and doesn't synchronize with other variables. Therefore, Relaxed can be used in both single-threaded and multi-threaded environments.
https://github.com/redox-os/ion/blob/0fe51451ddda3797444df06d39519a39e3a31e36/src/lib/shell/pipe_exec/foreground.rs#L34
https://github.com/redox-os/ion/blob/0fe51451ddda3797444df06d39519a39e3a31e36/src/lib/shell/pipe_exec/foreground.rs#L47
https://github.com/redox-os/ion/blob/0fe51451ddda3797444df06d39519a39e3a31e36/src/lib/shell/pipe_exec/foreground.rs#L53
Here reply is used to synchronize the status variable. Therefore, the read operation of reply needs to see the changes of the status variable. Using Ordering::SeqCst is unnecessary and may impact program performance, I think just Acquire/Release needs to be used here to ensure the correctness of the program.
https://github.com/redox-os/ion/blob/0fe51451ddda3797444df06d39519a39e3a31e36/src/lib/shell/pipe_exec/foreground.rs#L35
Here reply is just a signal and doesn't synchronize with other variables. Therefore, Relaxed can be used in both single-threaded and multi-threaded environments.